### PR TITLE
Release automation: publish on Release-published, continuous build on main

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,0 +1,81 @@
+name: Build Main
+
+# Builds a Chrome Web Store-ready zip every time a commit lands on main (typically a
+# PR merge), so there's always an up-to-date, downloadable build without needing to
+# cut an official release for every change. This intentionally does NOT create a git
+# tag, a GitHub Release, or publish anywhere -- it's just a CI build artifact. Actual
+# releases (tag/GitHub Release triggered, optionally published to the Chrome Web
+# Store) are handled by release-extension.yml.
+#
+# The version is computed by bumping the patch number of the latest "v*.*.*" tag
+# (falling back to extension/manifest.json's current version if no tag exists yet),
+# so the artifact is labelled with what the *next* release would be. Because several
+# merges can land before the next real tag, the same base version can repeat across
+# builds -- the artifact name also carries the run number and commit SHA so each
+# build stays uniquely identifiable in the Actions artifact list.
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history/tags, needed to find the previous release
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        run: dotnet build --configuration Release
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+      - name: Compute next version from the previous tag
+        id: version
+        run: |
+          previous_tag=$(git tag -l 'v*.*.*' | sort -V | tail -1)
+          if [[ -n "$previous_tag" ]]; then
+            base_version="${previous_tag#v}"
+          else
+            base_version=$(python3 -c "import json; print(json.load(open('extension/manifest.json'))['version'])")
+          fi
+          IFS='.' read -r major minor patch <<< "$base_version"
+          next_version="${major}.${minor}.$((patch + 1))"
+
+          echo "Previous tag: ${previous_tag:-(none found; used manifest.json's version as the base)}"
+          echo "Base version: $base_version"
+          echo "Next build version: $next_version"
+
+          echo "version=$next_version" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp manifest.json with the computed version
+        run: |
+          python3 - "${{ steps.version.outputs.version }}" <<'EOF'
+          import json
+          import sys
+
+          path = "extension/manifest.json"
+          with open(path) as f:
+              manifest = json.load(f)
+          manifest["version"] = sys.argv[1]
+          with open(path, "w") as f:
+              json.dump(manifest, f, indent=2)
+              f.write("\n")
+          EOF
+
+      - name: Package extension
+        run: ./scripts/package-extension.sh dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pdf-editor-extension-v${{ steps.version.outputs.version }}-main.${{ github.run_number }}.${{ steps.version.outputs.short_sha }}
+          path: dist/*.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,25 @@ jobs:
         with:
           name: playwright-report
           path: e2e/playwright-report/
+
+  package-dry-run:
+    # Proves scripts/package-extension.sh (and everything it depends on --
+    # generate-icons.py, extension/manifest.json) still produces a valid Chrome Web
+    # Store zip. This is the same script release-extension.yml and build-main.yml
+    # invoke for real releases/builds, but neither of those trigger on a PR, so
+    # without this job a change to the packaging pipeline itself (or a regression
+    # in it) would only surface at actual release time. Runs on every push and PR.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Package extension
+        run: ./scripts/package-extension.sh dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pdf-editor-extension-dry-run
+          path: dist/*.zip
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,11 +1,22 @@
 name: Release Extension
 
 # Builds a Chrome Web Store-ready zip of extension/ and publishes it as a build
-# artifact and (on a version tag) a GitHub Release. Optionally uploads straight to
-# the Chrome Web Store when the CHROME_* secrets below are configured.
+# artifact and (on a version tag or a published Release) a GitHub Release asset.
+# Optionally uploads straight to the Chrome Web Store when the CHROME_* secrets
+# below are configured.
+#
+# Two triggers cover the two ways a release gets cut:
+#   - push tags "v*.*.*"   -- `git tag v1.2.3 && git push origin v1.2.3` with no
+#                             GitHub Release object involved.
+#   - release: published   -- creating/publishing a Release in the GitHub UI or API
+#                             (this also creates the tag if it didn't already exist).
+# Both set github.ref to the same refs/tags/<version> ref, so the rest of this
+# workflow doesn't need to distinguish between them.
 on:
   push:
     tags: ["v*.*.*"]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       publish_to_store:

--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ at the zip's root (the format the store requires) rather than nested in a folder
 ./scripts/package-extension.sh          # writes dist/pdf-editor-extension-v<version>.zip
 ```
 
-**CI/CD** (`.github/workflows/release-extension.yml`) automates this on every version tag
-(`git tag v1.2.3 && git push origin v1.2.3`), or on demand via the *Run workflow* button:
+**CI/CD** (`.github/workflows/release-extension.yml`) automates this every time a release
+is cut — whether that's pushing a version tag (`git tag v1.2.3 && git push origin
+v1.2.3`) or **publishing a GitHub Release** in the UI/API (which creates the tag for you
+if it doesn't already exist) — or on demand via the *Run workflow* button:
 
-1. **`verify`** — builds and runs the full .NET test suite, and (for tag pushes) checks
-   the tag matches `manifest.json`'s `version` so a release can't accidentally ship the
-   wrong build.
+1. **`verify`** — builds and runs the full .NET test suite, and (for a tag/release)
+   checks the tag matches `manifest.json`'s `version` so a release can't accidentally
+   ship the wrong build.
 2. **`package`** — runs the script above and uploads the zip as a build artifact.
-3. **`github-release`** (tag pushes only) — attaches the zip to a GitHub Release.
+3. **`github-release`** (tag/release triggers only) — attaches the zip to the GitHub
+   Release (creating it first if you only pushed a tag).
 4. **`publish-to-chrome-web-store`** — uploads (and publishes) straight to the Chrome Web
    Store via its API, **only if** the required secrets are configured on the repository
    (see below); otherwise this step is skipped and the zip from step 2 is still there for

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ npx playwright install chromium   # once
 npx playwright test               # 10 scenarios
 ```
 
+## Continuous builds on `main`
+
+**`.github/workflows/build-main.yml`** builds and packages the extension every time a
+commit lands on `main` (typically a PR merge) — so a current, downloadable build always
+exists without cutting an official release for every change. It doesn't create a tag,
+a GitHub Release, or publish anywhere; it's purely a CI artifact.
+
+The version is computed by bumping the patch number of the latest `v*.*.*` tag (falling
+back to `extension/manifest.json`'s committed version if no tag exists yet), so the
+artifact is labelled with what the *next* release would be. Since several merges can
+land before the next real tag, the artifact name also carries the run number and commit
+SHA (`pdf-editor-extension-v<version>-main.<run>.<sha>`) so each build stays uniquely
+identifiable.
+
 ## Releasing the extension
 
 `scripts/package-extension.sh` builds a Chrome Web Store-ready zip: it (re)generates the

--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ npx playwright install chromium   # once
 npx playwright test               # 10 scenarios
 ```
 
+### CI on pull requests
+
+Every push and PR runs `.github/workflows/ci.yml`'s three jobs: `test` (build + full
+.NET suite with the 90% coverage gate), `e2e` (the Playwright suite above, headless),
+and `package-dry-run` (actually runs `scripts/package-extension.sh` and uploads the
+resulting zip). That last job exists because the release/build pipelines below
+(`release-extension.yml`, `build-main.yml`) only trigger on tags, published Releases, or
+merges to `main` — without a PR-time dry run, a regression in the packaging script
+itself would only surface once someone actually tried to cut a release.
+
 ## Continuous builds on `main`
 
 **`.github/workflows/build-main.yml`** builds and packages the extension every time a

--- a/scripts/package-extension.sh
+++ b/scripts/package-extension.sh
@@ -29,6 +29,10 @@ EOF
 VERSION=$(python3 -c "import json; print(json.load(open('$EXTENSION_DIR/manifest.json'))['version'])")
 
 mkdir -p "$OUTPUT_DIR"
+# Resolve to an absolute path: the zip is written from inside a subshell that cds
+# into $EXTENSION_DIR below, so a relative $OUTPUT_DIR (e.g. the plain "dist" that
+# CI passes in) would otherwise be looked up relative to the wrong directory.
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 ZIP_PATH="$OUTPUT_DIR/pdf-editor-extension-v${VERSION}.zip"
 rm -f "$ZIP_PATH"
 


### PR DESCRIPTION
## Summary

Release/build automation, plus PR-time coverage for the packaging pipeline itself and a real bug fix uncovered along the way.

### 1. Trigger the release pipeline on GitHub Release published

`.github/workflows/release-extension.yml` now also triggers on `release: types:
[published]`, alongside the existing `push: tags: ["v*.*.*"]`. Publishing a Release in
the GitHub UI/API creates the tag for you if it doesn't already exist, and both trigger
types set `github.ref` to the same `refs/tags/<version>` ref — so no other job logic
needed to change; `verify`'s version check, `package`, `github-release`, and the Chrome
Web Store publish gate all already key off that ref.

### 2. Continuous build on every merge to `main`

New `.github/workflows/build-main.yml`: runs on every push to `main` (i.e. a PR merge).
Builds and tests the .NET solution, computes the next version by bumping the patch
number of the latest `v*.*.*` tag (falling back to `manifest.json`'s committed version
if no tag exists yet), stamps that computed version into the checked-out
`manifest.json`, and packages the extension via `scripts/package-extension.sh`. The zip
is uploaded as a build artifact named with the computed version plus the run number and
commit SHA (`pdf-editor-extension-v<version>-main.<run>.<sha>`), so repeated merges
before the next real tag stay distinct.

This is deliberately **just a CI artifact** — no tag, no GitHub Release, no Chrome Web
Store publish. It complements `release-extension.yml`, which still owns actual releases.

### 3. Packaging dry-run on every PR

`ci.yml`'s existing `test` and `e2e` jobs already run on every PR (verified against both
open PRs' check runs). But `release-extension.yml` and `build-main.yml` — the actual
packaging/release pipeline — only trigger on tags, published Releases, or merges to
`main`, so a regression in `scripts/package-extension.sh` itself had **zero** PR-time
coverage. New `package-dry-run` job in `ci.yml` actually runs the packaging script on
every push/PR and uploads the resulting zip (7-day retention) so reviewers can sanity
check it too.

### 4. Bug fix: `scripts/package-extension.sh` resolved its output path relative to the wrong directory

Building #3 immediately proved its worth: the script's zip step `cd`s into `extension/`
before invoking `zip`, but the output directory was never resolved to an absolute path
first. Passed a *relative* path (exactly how `release-extension.yml` and the new
`package-dry-run` job both invoke it — `./scripts/package-extension.sh dist`), the zip
would be looked up relative to `extension/` instead of the repo root and fail outright
(`zip I/O error: No such file or directory`). `release-extension.yml`'s `package` job
would have failed the first time it actually ran a release.

Fixed by resolving the output directory to an absolute path immediately after creating
it. Verified locally against: the default argument, a relative argument invoked from the
repo root, and a relative argument invoked from an unrelated working directory.

### Testing

- Version-bump logic tested locally: no tags → falls back to `manifest.json`'s version
  (`1.0.0` → `1.0.1`); tags `v1.0.0, v1.2.5, v1.9.0, v1.10.0, v2.0.0` present → `sort -V`
  correctly picks `v2.0.0` (not fooled by lexical ordering) → `2.0.1`.
- Full pipeline (compute version → stamp `manifest.json` → package) produces a valid,
  correctly-versioned zip.
- `dotnet test`: all 98 tests still pass.
- `package-dry-run`'s exact steps reproduced locally against the fixed script.

## Why this PR (base branch)

Continues on `claude/release-published-trigger` (base: `claude/chromium-pdf-editor-ext-3odc5d`,
same reasoning as before — `main` doesn't have the workflow files or source tree until
#1 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GVx5dyceVpopJG4hs1tMP