### PR TITLE
Hotfix: package-extension.sh fails with a relative output directory

### DIFF
--- a/scripts/package-extension.sh
+++ b/scripts/package-extension.sh
@@ -29,6 +29,10 @@ EOF
 VERSION=$(python3 -c "import json; print(json.load(open('$EXTENSION_DIR/manifest.json'))['version'])")
 
 mkdir -p "$OUTPUT_DIR"
+# Resolve to an absolute path: the zip is written from inside a subshell that cds
+# into $EXTENSION_DIR below, so a relative $OUTPUT_DIR (e.g. the plain "dist" that
+# CI passes in) would otherwise be looked up relative to the wrong directory.
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 ZIP_PATH="$OUTPUT_DIR/pdf-editor-extension-v${VERSION}.zip"
 rm -f "$ZIP_PATH"
 


### PR DESCRIPTION
## The bug

Running the **Release Extension** workflow manually on `main` fails:

```
Packaging extension v1.0.0...
zip I/O error: No such file or directory
zip error: Could not create output file (dist/pdf-editor-extension-v1.0.0.zip)
```

`scripts/package-extension.sh`'s zip step `cd`s into `extension/` before invoking `zip`,
but the output directory was never resolved to an absolute path first. Passed a
*relative* path — exactly how `release-extension.yml`'s `package` step invokes it
(`./scripts/package-extension.sh dist`) — the zip gets looked up relative to
`extension/` instead of the repo root, and fails outright.

## The fix

Resolve the output directory to an absolute path immediately after creating it:

```diff
 mkdir -p "$OUTPUT_DIR"
+# Resolve to an absolute path: the zip is written from inside a subshell that cds
+# into $EXTENSION_DIR below, so a relative $OUTPUT_DIR (e.g. the plain "dist" that
+# CI passes in) would otherwise be looked up relative to the wrong directory.
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 ZIP_PATH="$OUTPUT_DIR/pdf-editor-extension-v${VERSION}.zip"
```

## Testing

- Reproduced the exact reported error on `main`'s current script before applying the fix.
- Confirmed it's resolved after: `./scripts/package-extension.sh dist` now succeeds and
  produces a valid zip.
- `dotnet test`: all 98 tests still pass.

## Why a separate, minimal PR straight to `main`

This exact fix already exists on two other branches (a general release-pipeline
hardening PR and a release-candidate/promotion redesign), but neither has reached `main`
yet, and both carry a lot of unrelated changes still under review. Since this is an
active blocker on manual releases right now, this PR isolates just the one-line fix so
it can merge immediately. The larger PRs will pick up cleanly once this lands (identical
diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GVx5dyceVpopJG4hs1tMP

---
_Generated by [Claude Code](https://claude.ai/code/session_019GVx5dyceVpopJG4hs1tMP)_