### PR TITLE
Hotfix: bash syntax error in release-candidate.yml's version step

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -53,7 +53,7 @@ jobs:
           next_version="${major}.${minor}.$((patch + 1))"
           rc_tag="v${next_version}-${{ github.run_number }}"
 
-          echo "Previous final release tag: ${previous_tag:-(none found; used manifest.json's version as the base)}"
+          echo "Previous final release tag: ${previous_tag:-(none found; used the version in manifest.json as the base)}"
           echo "Next release candidate: $rc_tag (would promote to v${next_version})"
           echo "tag=$rc_tag" >> "$GITHUB_OUTPUT"
           echo "final_tag=v${next_version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## The bug

The first real run of `release-candidate.yml` on `main` failed immediately:

```
Run # Only a clean "vX.Y.Z" counts as a previous *final* release -- RC tags
/home/runner/work/_temp/....sh: line 13: unexpected EOF while looking for matching `''
Error: Process completed with exit code 2.
```

## Root cause

Line 13 of the generated script is:

```bash
echo "Previous final release tag: ${previous_tag:-(none found; used manifest.json's version as the base)}"
```

The apostrophe in `manifest.json's` sits inside a `${var:-default text}` parameter
expansion. Bash re-enters its own quote/brace scanning for the default-value word to
find the matching `}`, and an unmatched single quote there confuses that scan — even
though the whole thing is nested inside an outer double-quoted string, where a bare `'`
would normally be harmless. Reproduced locally:

```bash
$ bash -n <(echo 'echo "${foo:-manifest.json'"'"'s version}"')
line 1: unexpected EOF while looking for matching `''
```

## Fix

Reworded to avoid the apostrophe: `used the version in manifest.json as the base`.

## Testing

- Reproduced the exact error locally by extracting the step's script and running
  `bash -n` on it before the fix; confirmed clean after.
- Grepped every other `${var:-...}` default across all workflow files and `scripts/*.sh`
  for the same pattern — this was the only occurrence.
- `dotnet test`: all 98 tests still pass (unrelated to this change, but re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GVx5dyceVpopJG4hs1tMP

---
_Generated by [Claude Code](https://claude.ai/code/session_019GVx5dyceVpopJG4hs1tMP)_