### PR TITLE
Release pipeline: package RC prereleases + ship the compiled native host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,23 +49,30 @@ jobs:
           path: e2e/playwright-report/
 
   package-dry-run:
-    # Proves scripts/package-extension.sh (and everything it depends on --
-    # generate-icons.py, extension/manifest.json) still produces a valid Chrome Web
-    # Store zip. This is the same script release-candidate.yml and release-extension.yml
-    # invoke for real releases/builds, but neither of those trigger on a PR, so
-    # without this job a change to the packaging pipeline itself (or a regression
-    # in it) would only surface at actual release time. Runs on every push and PR.
+    # Proves the packaging pipeline (scripts/package-extension.sh and
+    # scripts/package-host.sh, plus what they depend on -- generate-icons.py,
+    # extension/manifest.json, the native host's self-contained publish) still produces
+    # valid artifacts. These are the same scripts release-candidate.yml and
+    # release-extension.yml invoke for real releases, but neither triggers on a PR, so
+    # without this job a regression in packaging would only surface at release time.
+    # The host is published for just one platform here to keep PR runs fast; the release
+    # workflows build the full desktop matrix. Runs on every push and PR.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
       - name: Package extension
         run: ./scripts/package-extension.sh dist
+      - name: Package native host (linux-x64 only, smoke check for the release matrix)
+        run: ./scripts/package-host.sh linux-x64 dist
       - uses: actions/upload-artifact@v4
         with:
           name: pdf-editor-extension-dry-run
-          path: dist/*.zip
+          path: dist/pdf-editor-extension-*.zip
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -2,7 +2,8 @@ name: Release Candidate
 
 # Every merge to main creates a release candidate: a tag "vX.Y.Z-<build>" (patch-bumped
 # from the latest *final* release tag, ignoring other RC tags), a packaged extension zip,
-# and a GitHub prerelease with that zip attached as an asset.
+# self-contained native-host builds for each desktop platform (Windows, Linux, macOS
+# Intel + Apple Silicon), and a GitHub prerelease with all of those attached as assets.
 #
 # This workflow builds, tests, packages, and publishes the prerelease itself rather than
 # handing the packaging off to release-extension.yml -- and it has to. GitHub deliberately
@@ -91,22 +92,32 @@ jobs:
         id: package
         run: ./scripts/package-extension.sh dist
 
+      - name: Package native host (all desktop platforms)
+        run: |
+          for rid in win-x64 linux-x64 osx-x64 osx-arm64; do
+            ./scripts/package-host.sh "$rid" dist
+          done
+
       - name: Create and push the release candidate tag
         run: |
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      - name: Create the release candidate (prerelease) and attach the package
+      - name: Create the release candidate (prerelease) and attach the packages
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           prerelease: true
           generate_release_notes: true
-          files: ${{ steps.package.outputs.zip_path }}
+          files: |
+            dist/pdf-editor-extension-*.zip
+            dist/pdf-editor-host-*.zip
           body: |
             Release candidate built from ${{ github.sha }}.
 
-            The packaged extension zip is attached to this release as a build artifact. This is
-            **not** published to the Chrome Web Store. To promote it, create a new Release
-            targeting this commit with the clean tag `${{ steps.version.outputs.final_tag }}`
-            and leave "Set as a pre-release" unchecked.
+            Attached as build artifacts: the packaged extension zip, and a self-contained
+            native-host build for each desktop platform (`pdf-editor-host-<platform>.zip` —
+            the .NET runtime and native libraries are bundled, so no SDK is needed to run it).
+            This is **not** published to the Chrome Web Store. To promote it, create a new
+            Release targeting this commit with the clean tag
+            `${{ steps.version.outputs.final_tag }}` and leave "Set as a pre-release" unchecked.

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,20 +1,26 @@
 name: Release Candidate
 
 # Every merge to main creates a release candidate: a tag "vX.Y.Z-<build>" (patch-bumped
-# from the latest *final* release tag, ignoring other RC tags) and a GitHub prerelease
-# for it. Creating that prerelease fires release: published, which hands off to
-# release-extension.yml to actually build, test, package, and attach the zip -- this
-# workflow's only job is deciding the version and creating the pointer, so build/package
-# logic lives in exactly one place.
+# from the latest *final* release tag, ignoring other RC tags), a packaged extension zip,
+# and a GitHub prerelease with that zip attached as an asset.
 #
-# Promoting an RC to a real release is a manual step: create a new GitHub Release
-# targeting the RC's commit, but type a clean tag ("vX.Y.Z", no "-<build>" suffix) and
-# leave "Set as a pre-release" unchecked. release-extension.yml treats that the same
-# way -- except a non-prerelease publish also deploys to the Chrome Web Store.
+# This workflow builds, tests, packages, and publishes the prerelease itself rather than
+# handing the packaging off to release-extension.yml -- and it has to. GitHub deliberately
+# does NOT deliver the "release: published" event to other workflows when the release was
+# created by the built-in GITHUB_TOKEN (its anti-recursion rule), so a "create the prerelease
+# here, let release-extension.yml react and attach the zip" design silently never packages
+# anything. The shared packaging logic still lives in one place -- scripts/package-extension.sh
+# -- which both this workflow and release-extension.yml invoke.
 #
-# Tests must pass here before an RC is even created, and must pass again in
-# release-extension.yml before anything is packaged or deployed -- a failing suite
-# blocks the pipeline at every stage.
+# Promoting an RC to a real release is a manual step: create a new GitHub Release targeting
+# the RC's commit, but type a clean tag ("vX.Y.Z", no "-<build>" suffix) and leave "Set as a
+# pre-release" unchecked. That release IS created by a human, so it does fire
+# "release: published" -> release-extension.yml, which packages again and also deploys to the
+# Chrome Web Store.
+#
+# Tests must pass here before an RC is created or packaged, and again in release-extension.yml
+# before a promotion is packaged or deployed -- a failing suite blocks the pipeline at every
+# stage.
 on:
   push:
     branches: ["main"]
@@ -33,6 +39,10 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Build
         run: dotnet build --configuration Release
       - name: Test
@@ -52,27 +62,51 @@ jobs:
           IFS='.' read -r major minor patch <<< "$base_version"
           next_version="${major}.${minor}.$((patch + 1))"
           rc_tag="v${next_version}-${{ github.run_number }}"
+          # Chrome manifest versions allow up to four integer parts, so the build number
+          # becomes a fourth part (tag v1.0.1-57 -> manifest/package version 1.0.1.57).
+          manifest_version="${next_version}.${{ github.run_number }}"
 
           echo "Previous final release tag: ${previous_tag:-(none found; used the version in manifest.json as the base)}"
           echo "Next release candidate: $rc_tag (would promote to v${next_version})"
           echo "tag=$rc_tag" >> "$GITHUB_OUTPUT"
           echo "final_tag=v${next_version}" >> "$GITHUB_OUTPUT"
+          echo "manifest_version=$manifest_version" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp manifest.json with the release-candidate version
+        run: |
+          python3 - "${{ steps.version.outputs.manifest_version }}" <<'EOF'
+          import json
+          import sys
+
+          path = "extension/manifest.json"
+          with open(path) as f:
+              manifest = json.load(f)
+          manifest["version"] = sys.argv[1]
+          with open(path, "w") as f:
+              json.dump(manifest, f, indent=2)
+              f.write("\n")
+          EOF
+
+      - name: Package extension
+        id: package
+        run: ./scripts/package-extension.sh dist
 
       - name: Create and push the release candidate tag
         run: |
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      - name: Create the release candidate (prerelease)
+      - name: Create the release candidate (prerelease) and attach the package
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           prerelease: true
           generate_release_notes: true
+          files: ${{ steps.package.outputs.zip_path }}
           body: |
             Release candidate built from ${{ github.sha }}.
 
-            This is **not** published to the Chrome Web Store. To promote it, create a
-            new Release targeting this commit with the clean tag
-            `${{ steps.version.outputs.final_tag }}` and leave "Set as a pre-release"
-            unchecked.
+            The packaged extension zip is attached to this release as a build artifact. This is
+            **not** published to the Chrome Web Store. To promote it, create a new Release
+            targeting this commit with the clean tag `${{ steps.version.outputs.final_tag }}`
+            and leave "Set as a pre-release" unchecked.

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
 
       - name: Determine the version to package
         id: version
@@ -112,12 +115,20 @@ jobs:
           path: ${{ steps.package.outputs.zip_path }}
           if-no-files-found: error
 
+      - name: Package native host (all desktop platforms)
+        run: |
+          for rid in win-x64 linux-x64 osx-x64 osx-arm64; do
+            ./scripts/package-host.sh "$rid" dist
+          done
+
       - name: Attach to the GitHub Release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
-          files: ${{ steps.package.outputs.zip_path }}
+          files: |
+            dist/pdf-editor-extension-*.zip
+            dist/pdf-editor-host-*.zip
 
   publish-to-chrome-web-store:
     needs: package

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,20 +1,21 @@
 name: Release Extension
 
-# Handles both stages of the release cycle, both triggered by "release: published"
-# (GitHub fires this same event whether the release is a prerelease or not):
+# Handles releases created by a human (a "release: published" event). Automated release
+# candidates do NOT reach this workflow: release-candidate.yml creates them with the
+# built-in GITHUB_TOKEN, and GitHub's anti-recursion rule means a GITHUB_TOKEN-created
+# release never fires "release: published" for another workflow -- so release-candidate.yml
+# builds, tests, packages, and attaches the RC zip itself.
 #
-#   - Release candidates: release-candidate.yml creates a "vX.Y.Z-<build>" tag and an
-#     empty prerelease on every merge to main. That prerelease's creation is what fires
-#     this workflow. Builds, tests, packages, and attaches the zip to the RC release --
-#     but does NOT deploy anywhere else.
-#   - Promoting to a real release: manually create a new GitHub Release targeting an
-#     RC's commit, with a clean tag ("vX.Y.Z", no "-<build>" suffix) and "Set as a
-#     pre-release" unchecked. Same build/test/package/attach steps, but this time also
-#     deploys to the Chrome Web Store.
+#   - Promoting to a real release: manually create a new GitHub Release targeting an RC's
+#     commit, with a clean tag ("vX.Y.Z", no "-<build>" suffix) and "Set as a pre-release"
+#     unchecked. Because a human created it, it fires this workflow: build, test, package,
+#     attach the zip, and -- because it is not a prerelease -- deploy to the Chrome Web Store.
+#   - A prerelease created manually in the GitHub UI (or a workflow_dispatch run) also fires
+#     this workflow but stops after packaging; only a non-prerelease publish deploys.
 #
-# The only difference between the two is the release's `prerelease` flag -- see the
-# "publish-to-chrome-web-store" job's `if:`. Tests must pass in `verify` before either
-# path packages or deploys anything.
+# Whether the store-deploy job runs is decided by the release's `prerelease` flag -- see the
+# "publish-to-chrome-web-store" job's `if:`. Tests must pass in `verify` before either path
+# packages or deploys anything.
 on:
   release:
     types: [published]

--- a/README.md
+++ b/README.md
@@ -211,13 +211,11 @@ built zip by hand the first time (which Chrome requires anyway, to create the li
    .\scripts\install-host.ps1 -ExtensionId <extension-id>
    ```
 
-   This publishes the .NET host and registers `com.pdfeditor.host` for Chrome,
-   Chromium, Edge, and Brave.
-
-   > Don't have the .NET SDK? Every [release](../../releases) attaches a self-contained
-   > host build per platform (`pdf-editor-host-<platform>.zip`) with the runtime and
-   > native libraries bundled — unzip it and point a native-messaging host manifest at
-   > the extracted executable instead of running the publish step above.
+   By default this **downloads a prebuilt, self-contained host** from the latest
+   [release](../../releases) (the .NET runtime and native libraries are bundled, so no
+   .NET SDK is needed) and registers `com.pdfeditor.host` for Chrome, Chromium, Edge, and
+   Brave. Contributors working from a source checkout can add `--from-source` (bash) or
+   `-FromSource` (PowerShell) to build the host locally with `dotnet publish` instead.
 4. Restart the browser. The extension's options page shows the host connection status.
 
 ## Usage notes

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ built zip by hand the first time (which Chrome requires anyway, to create the li
 
    This publishes the .NET host and registers `com.pdfeditor.host` for Chrome,
    Chromium, Edge, and Brave.
+
+   > Don't have the .NET SDK? Every [release](../../releases) attaches a self-contained
+   > host build per platform (`pdf-editor-host-<platform>.zip`) with the runtime and
+   > native libraries bundled — unzip it and point a native-messaging host manifest at
+   > the extracted executable instead of running the publish step above.
 4. Restart the browser. The extension's options page shows the host connection status.
 
 ## Usage notes

--- a/scripts/install-host.ps1
+++ b/scripts/install-host.ps1
@@ -1,24 +1,84 @@
-# Publishes the native host and registers it with Chromium-based browsers on Windows.
-# Usage: .\scripts\install-host.ps1 -ExtensionId <id> [-Configuration Release]
+# Installs the PDF Editor native messaging host and registers it with Chromium-based
+# browsers (Chrome, Chromium, Edge, Brave) on Windows.
+#
+# By default it downloads a prebuilt, self-contained host from the project's latest
+# GitHub release -- the .NET runtime and native libraries are bundled, so no .NET SDK
+# is required. Use -FromSource to build it locally with `dotnet publish` instead.
+#
+# Usage:
+#   .\scripts\install-host.ps1 -ExtensionId <id> [-FromSource] [-Configuration Release]
+#                              [-Repo owner/name] [-Tag vX.Y.Z]
 param(
     [Parameter(Mandatory = $true)][string]$ExtensionId,
-    [string]$Configuration = "Release"
+    [switch]$FromSource,
+    [string]$Configuration = "Release",
+    [string]$Repo = "",
+    [string]$Tag = ""
 )
 
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $publishDir = Join-Path $env:LOCALAPPDATA "PdfEditorHost"
 $hostName = "com.pdfeditor.host"
+$defaultRepo = "ZanattaMichael/Chromium-PDF-Editor"
 
-Write-Host "Publishing native host ($Configuration)..."
-dotnet publish (Join-Path $repoRoot "src/PdfEditor.NativeHost") -c $Configuration -o $publishDir --nologo -v q
+# owner/name to download from: explicit -Repo, else inferred from origin's URL, else default.
+function Resolve-Repo {
+    if ($Repo) { return $Repo }
+    try {
+        $url = git -C $repoRoot remote get-url origin 2>$null
+        if ($url -match 'github\.com[:/]+([^/]+)/([^/.]+)') { return "$($Matches[1])/$($Matches[2])" }
+    } catch { }
+    return $defaultRepo
+}
 
-# Chrome on Windows launches the host via a .bat shim.
-$launcher = Join-Path $publishDir "pdf-editor-host.bat"
-"@echo off`r`ndotnet `"$publishDir\PdfEditor.NativeHost.dll`" %*" | Set-Content -Path $launcher -Encoding ascii
+# The release tag to install: explicit -Tag, else latest final release, else newest of any kind.
+function Resolve-Tag($r) {
+    if ($Tag) { return $Tag }
+    try { return (Invoke-RestMethod "https://api.github.com/repos/$r/releases/latest").tag_name } catch { }
+    try {
+        $latest = Invoke-RestMethod "https://api.github.com/repos/$r/releases?per_page=1"
+        if ($latest -and $latest[0].tag_name) { return $latest[0].tag_name }
+    } catch { }
+    throw "Could not determine the latest release tag for $r. Pass -Tag <vX.Y.Z>."
+}
+
+if ($FromSource) {
+    Write-Host "Building native host from source ($Configuration)..."
+    if (Test-Path $publishDir) { Remove-Item -Recurse -Force $publishDir }
+    dotnet publish (Join-Path $repoRoot "src/PdfEditor.NativeHost") -c $Configuration -o $publishDir --nologo -v q
+    # A framework-dependent build runs via the installed `dotnet`, so launch it through a .bat shim.
+    $launcher = Join-Path $publishDir "pdf-editor-host.bat"
+    "@echo off`r`ndotnet `"$publishDir\PdfEditor.NativeHost.dll`" %*" | Set-Content -Path $launcher -Encoding ascii
+    $hostPath = $launcher
+} else {
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+        throw "No prebuilt win-arm64 host is published. Use -FromSource."
+    }
+    $rid = "win-x64"
+    $r = Resolve-Repo
+    $t = Resolve-Tag $r
+    $url = "https://github.com/$r/releases/download/$t/pdf-editor-host-$rid.zip"
+
+    Write-Host "Downloading prebuilt host $t ($rid) from $r..."
+    if (Test-Path $publishDir) { Remove-Item -Recurse -Force $publishDir }
+    New-Item -ItemType Directory -Force -Path $publishDir | Out-Null
+    $zip = Join-Path $env:TEMP "pdf-editor-host-$rid.zip"
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $zip
+    } catch {
+        throw "Could not download $url. That release may not have a $rid asset yet; try -FromSource, or -Tag/-Repo."
+    }
+    Expand-Archive -Path $zip -DestinationPath $publishDir -Force
+    Remove-Item $zip -Force
+    $hostPath = Join-Path $publishDir "PdfEditor.NativeHost.exe"
+    if (-not (Test-Path $hostPath)) {
+        throw "The downloaded package did not contain PdfEditor.NativeHost.exe."
+    }
+}
 
 $template = Get-Content (Join-Path $repoRoot "scripts/com.pdfeditor.host.json.template") -Raw
-$manifest = $template.Replace("__HOST_PATH__", $launcher.Replace("\", "\\")).Replace("__EXTENSION_ID__", $ExtensionId)
+$manifest = $template.Replace("__HOST_PATH__", $hostPath.Replace("\", "\\")).Replace("__EXTENSION_ID__", $ExtensionId)
 $manifestPath = Join-Path $publishDir "$hostName.json"
 $manifest | Set-Content -Path $manifestPath -Encoding utf8
 

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -1,13 +1,49 @@
 #!/usr/bin/env bash
-# Publishes the native host and registers it with Chromium-based browsers.
-# Usage: ./scripts/install-host.sh <extension-id> [--configuration Release]
+# Installs the PDF Editor native messaging host and registers it with Chromium-based
+# browsers (Chrome, Chromium, Edge, Brave).
+#
+# By default it downloads a prebuilt, self-contained host from the project's latest
+# GitHub release -- the .NET runtime and native libraries are bundled, so no .NET SDK
+# is required. Pass --from-source to build it locally with `dotnet publish` instead
+# (for contributors, or platforms without a prebuilt asset).
+#
+# Usage:
+#   ./scripts/install-host.sh <extension-id> [options]
+#     --from-source              build locally with dotnet instead of downloading
+#     --configuration <cfg>      build configuration for --from-source (default: Release)
+#     --repo <owner/name>        GitHub repo to download from (default: inferred from git remote)
+#     --tag <vX.Y.Z>             release tag to download (default: latest release)
 set -euo pipefail
 
-EXTENSION_ID="${1:-}"
-CONFIGURATION="${3:-Release}"
+DEFAULT_REPO="ZanattaMichael/Chromium-PDF-Editor"
+
+EXTENSION_ID=""
+FROM_SOURCE=false
+CONFIGURATION="Release"
+REPO_OVERRIDE=""
+TAG_OVERRIDE=""
+
+usage() {
+  echo "Usage: $0 <extension-id> [--from-source] [--configuration Release] [--repo owner/name] [--tag vX.Y.Z]" >&2
+  echo "Find the extension ID at chrome://extensions with Developer mode enabled." >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from-source) FROM_SOURCE=true; shift ;;
+    --configuration) CONFIGURATION="${2:?--configuration needs a value}"; shift 2 ;;
+    --repo) REPO_OVERRIDE="${2:?--repo needs a value}"; shift 2 ;;
+    --tag) TAG_OVERRIDE="${2:?--tag needs a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    *)
+      if [[ -z "$EXTENSION_ID" ]]; then EXTENSION_ID="$1"; else echo "Unexpected argument: $1" >&2; usage; exit 1; fi
+      shift ;;
+  esac
+done
+
 if [[ -z "$EXTENSION_ID" ]]; then
-  echo "Usage: $0 <extension-id> [--configuration Release]" >&2
-  echo "Find the ID at chrome://extensions with Developer mode enabled." >&2
+  usage
   exit 1
 fi
 
@@ -15,17 +51,101 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PUBLISH_DIR="$HOME/.local/share/pdf-editor-host"
 HOST_NAME="com.pdfeditor.host"
 
-echo "Publishing native host ($CONFIGURATION)..."
-dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" -c "$CONFIGURATION" -o "$PUBLISH_DIR" --nologo -v q
+# The runtime identifier for this machine, in the naming the release assets use.
+detect_rid() {
+  local os arch
+  case "$(uname -s)" in
+    Linux) os="linux" ;;
+    Darwin) os="osx" ;;
+    *) echo "error: unsupported OS '$(uname -s)' for a prebuilt host — use --from-source" >&2; exit 1 ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) echo "error: unsupported architecture '$(uname -m)' for a prebuilt host — use --from-source" >&2; exit 1 ;;
+  esac
+  # Only osx ships both x64 and arm64; linux is published as x64 only.
+  if [[ "$os" == "linux" && "$arch" != "x64" ]]; then
+    echo "error: no prebuilt linux-$arch host is published — use --from-source" >&2
+    exit 1
+  fi
+  echo "$os-$arch"
+}
 
-LAUNCHER="$PUBLISH_DIR/pdf-editor-host.sh"
-cat > "$LAUNCHER" <<LAUNCH
+# owner/name to download from: explicit override, else inferred from origin's URL, else default.
+resolve_repo() {
+  if [[ -n "$REPO_OVERRIDE" ]]; then echo "$REPO_OVERRIDE"; return; fi
+  local url
+  url="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)"
+  if [[ "$url" =~ github\.com[:/]+([^/]+)/([^/.]+) ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  else
+    echo "$DEFAULT_REPO"
+  fi
+}
+
+extract_tag() {
+  grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+}
+
+# The release tag to install: explicit override, else the latest final release, else the
+# newest release of any kind (so a repo with only prereleases still resolves).
+resolve_tag() {
+  local repo="$1" tag
+  if [[ -n "$TAG_OVERRIDE" ]]; then echo "$TAG_OVERRIDE"; return; fi
+  tag="$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null | extract_tag || true)"
+  if [[ -z "$tag" ]]; then
+    tag="$(curl -fsSL "https://api.github.com/repos/$repo/releases?per_page=1" 2>/dev/null | extract_tag || true)"
+  fi
+  if [[ -z "$tag" ]]; then
+    echo "error: could not determine the latest release tag for $repo — pass --tag <vX.Y.Z>" >&2
+    exit 1
+  fi
+  echo "$tag"
+}
+
+if [[ "$FROM_SOURCE" == true ]]; then
+  echo "Building native host from source ($CONFIGURATION)..."
+  rm -rf "$PUBLISH_DIR"
+  mkdir -p "$PUBLISH_DIR"
+  dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" -c "$CONFIGURATION" -o "$PUBLISH_DIR" --nologo -v q
+  # A framework-dependent build runs via the installed `dotnet`, so launch it through a shim.
+  LAUNCHER="$PUBLISH_DIR/pdf-editor-host.sh"
+  cat > "$LAUNCHER" <<LAUNCH
 #!/usr/bin/env bash
 exec dotnet "$PUBLISH_DIR/PdfEditor.NativeHost.dll" "\$@"
 LAUNCH
-chmod +x "$LAUNCHER"
+  chmod +x "$LAUNCHER"
+  HOST_PATH="$LAUNCHER"
+else
+  for tool in curl unzip; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "error: '$tool' is required to download the prebuilt host — install it or use --from-source" >&2; exit 1; }
+  done
+  RID="$(detect_rid)"
+  REPO="$(resolve_repo)"
+  TAG="$(resolve_tag "$REPO")"
+  URL="https://github.com/$REPO/releases/download/$TAG/pdf-editor-host-$RID.zip"
 
-MANIFEST_JSON=$(sed -e "s|__HOST_PATH__|$LAUNCHER|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+  echo "Downloading prebuilt host $TAG ($RID) from $REPO..."
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  if ! curl -fSL -o "$TMP/host.zip" "$URL"; then
+    echo "error: could not download $URL" >&2
+    echo "       That release may not have a $RID asset yet. Try --from-source, or --tag/--repo." >&2
+    exit 1
+  fi
+  rm -rf "$PUBLISH_DIR"
+  mkdir -p "$PUBLISH_DIR"
+  unzip -q -o "$TMP/host.zip" -d "$PUBLISH_DIR"
+  HOST_PATH="$PUBLISH_DIR/PdfEditor.NativeHost"
+  if [[ ! -f "$HOST_PATH" ]]; then
+    echo "error: the downloaded package did not contain the host executable" >&2
+    exit 1
+  fi
+  chmod +x "$HOST_PATH"
+fi
+
+MANIFEST_JSON=$(sed -e "s|__HOST_PATH__|$HOST_PATH|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
   "$REPO_ROOT/scripts/com.pdfeditor.host.json.template")
 
 case "$(uname -s)" in

--- a/scripts/package-host.sh
+++ b/scripts/package-host.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Publishes the native messaging host as a self-contained build for one runtime identifier
+# and zips it for release. "Self-contained" means the .NET runtime and every native
+# dependency (SkiaSharp, PDFium) are bundled, so the target machine needs no .NET SDK or
+# runtime installed — unlike scripts/install-host.sh, which builds from source locally.
+#
+# Usage: ./scripts/package-host.sh <runtime-id> [output-dir]
+#   e.g. ./scripts/package-host.sh linux-x64 dist
+set -euo pipefail
+
+RID="${1:?usage: package-host.sh <runtime-id> [output-dir]  (e.g. win-x64, linux-x64, osx-x64, osx-arm64)}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${2:-$REPO_ROOT/dist}"
+
+mkdir -p "$OUTPUT_DIR"
+# Resolve to absolute so the zip path is stable regardless of the caller's directory.
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+PUBLISH_DIR="$OUTPUT_DIR/host-$RID"
+rm -rf "$PUBLISH_DIR"
+
+echo "Publishing native host ($RID, self-contained)..."
+dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
+  --configuration Release \
+  --runtime "$RID" \
+  --self-contained true \
+  -p:PublishSingleFile=false \
+  --output "$PUBLISH_DIR" \
+  --nologo -v q
+
+ZIP_PATH="$OUTPUT_DIR/pdf-editor-host-$RID.zip"
+rm -f "$ZIP_PATH"
+(
+  cd "$PUBLISH_DIR"
+  zip -X -r -q "$ZIP_PATH" .
+)
+
+echo "Packaged: $ZIP_PATH ($(du -h "$ZIP_PATH" | cut -f1))"
+
+# When run as a GitHub Actions step, expose the zip path to later steps.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "zip_path=${ZIP_PATH}" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
Splits the release-pipeline work out of the (now-merged, security-only) PR #8 into its own PR. Three related changes, all about what a release actually ships:

## 1. Release candidates now get a packaged asset

RC prereleases were getting a tag and notes but **no zip**. Cause: GitHub's anti-recursion rule — `release-candidate.yml` creates the prerelease with the built-in `GITHUB_TOKEN`, and a `GITHUB_TOKEN`-created release never fires `release: published` for another workflow, so the intended hand-off to `release-extension.yml` silently never ran. Confirmed live: prereleases `v1.0.1-2`/`v1.0.1-3` were authored by `github-actions[bot]` with no assets.

Fix: `release-candidate.yml` now builds, tests, stamps the manifest with the RC's four-part version, packages, and attaches the zip itself.

## 2. The compiled C# native host is now in the build

Releases carried only the browser extension; the native host was only ever built on the user's machine (needs the .NET SDK). New `scripts/package-host.sh` publishes the host **self-contained** (the .NET runtime + native libs — SkiaSharp, PDFium — bundled) per platform. Both release workflows build the desktop matrix (`win-x64`, `linux-x64`, `osx-x64`, `osx-arm64`) and attach every `pdf-editor-host-<platform>.zip`. `ci.yml`'s dry-run also publishes the host for one platform on every PR so regressions surface early.

## 3. Install scripts download the prebuilt host by default

`install-host.sh`/`.ps1` no longer require the .NET SDK: they detect the platform RID, resolve the repo (git remote, with override) and latest release tag, download `pdf-editor-host-<rid>.zip`, and point the native-messaging manifest directly at the bundled executable. Build-from-source is preserved behind `--from-source`/`-FromSource`.

## Verification

- Cross-published all four RIDs from Linux; each bundles its own native libs. Smoke-tested the linux-x64 build over the real framed protocol: `ping`→pong, `info`→page count, `render`→valid PNG (PDFium + Skia work in the self-contained bundle).
- All workflow YAML parses; every `run:` block passes `bash -n`; `install-host.ps1` passes a PowerShell AST parse; RID detection, git-remote repo inference, and `tag_name` extraction were unit-checked.
- No .NET source changes — this is entirely workflow/script/README, on top of the security work already merged to `main` via #8.

**Not exercisable in CI-less local testing:** the live download path (`install-host.sh` fetching a real asset) can only run once a release actually carries `pdf-editor-host-<rid>.zip` — which is exactly what change #2 produces on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GVx5dyceVpopJG4hs1tMP)_