### PR TITLE
Viewer: fix redaction on offset-origin pages, cache/prefetch, loading wheel, continuous scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,12 @@ script — everything in one download. Unzip it and follow the included `INSTALL
 
 - **Redaction preview**: draw boxes with the ⬛ tool, then *Preview* renders the result
   in a window before anything is committed. *Apply* performs the destructive removal.
-- **Text editing**: with the ✏ tool, drag around the text you want to change; the
-  editor pre-fills what it found there. Replacement text is stamped in Helvetica at a
-  matched size (font-exact reproduction of arbitrary embedded fonts is not attempted).
+- **Text editing**: with the ✏ tool, drag around the text you want to change; the editor
+  pre-fills what it found there, including the detected font. You can set the replacement
+  font family (Helvetica / Times / Courier), size, **bold**/*italic*, and colour before
+  applying. The controls default to the region's detected style, so leaving them alone keeps
+  the look; font-exact reproduction of arbitrary embedded fonts is not attempted (the
+  replacement uses the closest standard font).
 - **Sign then don't rewrite**: a digital signature is invalidated by any subsequent
   full rewrite — encrypt **before** signing (the UI warns about this ordering).
 - Files opened from `file://` URLs need *Allow access to file URLs* enabled for the

--- a/e2e/helpers/pdf.js
+++ b/e2e/helpers/pdf.js
@@ -46,4 +46,45 @@ function buildPdf(pages, { mediaBox = [0, 0, 595, 842], cropBox = null, rotate =
   return Buffer.from(body, 'latin1');
 }
 
-module.exports = { buildPdf };
+/**
+ * Builds a page that mimics how Chrome / Skia print-to-PDF (Google Docs "Download as PDF")
+ * structures content: a top-level scale + Y-flip matrix applied *outside* any q/Q, so it is never
+ * restored and is still active at the end of the content stream. The text is drawn under that
+ * matrix (via a text matrix) so it renders upright at a normal absolute position — but anything
+ * naively appended to the page inherits the leftover matrix. Regression fixture for redaction/edit
+ * landing in the wrong place on such documents. MediaBox is [0 0 400 600]; the word renders around
+ * absolute (50, 300).
+ */
+function buildLeftoverCtmPdf(word = 'SECRET') {
+  const content =
+    '0.5 0 0 -0.5 0 600 cm\n' +   // unbalanced top-level transform (never restored)
+    'q\n' +
+    '0 0 800 1200 re W n\n' +     // clip to the page in the scaled space
+    `BT\n/F1 48 Tf\n1 0 0 -1 100 600 Tm\n(${word.replace(/([\\()])/g, '\\$1')}) Tj\nET\n` +
+    'Q\n';
+
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] ' +
+      '/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>',
+    `<< /Length ${content.length} >>\nstream\n${content}endstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+
+  let body = '%PDF-1.4\n';
+  const offsets = [0];
+  objects.forEach((obj, i) => {
+    offsets.push(body.length);
+    body += `${i + 1} 0 obj\n${obj}\nendobj\n`;
+  });
+  const xrefStart = body.length;
+  body += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (let i = 1; i <= objects.length; i++) {
+    body += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+  }
+  body += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`;
+  return Buffer.from(body, 'latin1');
+}
+
+module.exports = { buildPdf, buildLeftoverCtmPdf };

--- a/e2e/helpers/pdf.js
+++ b/e2e/helpers/pdf.js
@@ -9,11 +9,12 @@
  * `{ rotate: 90|180|270 }` to rotate them — both regression-test the coordinate mapping
  * used for redaction.
  */
-function buildPdf(pages, { mediaBox = [0, 0, 595, 842], rotate = 0 } = {}) {
+function buildPdf(pages, { mediaBox = [0, 0, 595, 842], cropBox = null, rotate = 0 } = {}) {
   const objects = [];
   const pageObjectNumbers = pages.map((_, i) => 4 + i * 2);
   const box = mediaBox.join(' ');
   const rotateEntry = rotate ? ` /Rotate ${rotate}` : '';
+  const cropEntry = cropBox ? ` /CropBox [${cropBox.join(' ')}]` : '';
 
   objects.push('<< /Type /Catalog /Pages 2 0 R >>'); // 1
   objects.push(`<< /Type /Pages /Kids [${pageObjectNumbers.map((n) => `${n} 0 R`).join(' ')}] /Count ${pages.length} >>`); // 2
@@ -25,7 +26,7 @@ function buildPdf(pages, { mediaBox = [0, 0, 595, 842], rotate = 0 } = {}) {
         `BT /F1 ${size} Tf ${x} ${y} Td (${text.replace(/([\\()])/g, '\\$1')}) Tj ET`)
       .join('\n');
     objects.push(
-      `<< /Type /Page /Parent 2 0 R /MediaBox [${box}]${rotateEntry} ` +
+      `<< /Type /Page /Parent 2 0 R /MediaBox [${box}]${cropEntry}${rotateEntry} ` +
       `/Resources << /Font << /F1 3 0 R >> >> /Contents ${4 + objects.length - 2} 0 R >>`);
     objects.push(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`);
   }

--- a/e2e/helpers/pdf.js
+++ b/e2e/helpers/pdf.js
@@ -3,11 +3,15 @@
 /**
  * Builds a minimal, uncompressed, single- or multi-page PDF fixture with
  * absolutely positioned Helvetica text. Deterministic and dependency-free —
- * page size is A4 (595 x 842 pt), matching the .NET test fixtures.
+ * default page size is A4 (595 x 842 pt), matching the .NET test fixtures.
+ *
+ * Pass `{ mediaBox: [llx, lly, urx, ury] }` to give the pages a non-(0,0) origin,
+ * which is what regression-tests the coordinate mapping used for redaction.
  */
-function buildPdf(pages) {
+function buildPdf(pages, { mediaBox = [0, 0, 595, 842] } = {}) {
   const objects = [];
   const pageObjectNumbers = pages.map((_, i) => 4 + i * 2);
+  const box = mediaBox.join(' ');
 
   objects.push('<< /Type /Catalog /Pages 2 0 R >>'); // 1
   objects.push(`<< /Type /Pages /Kids [${pageObjectNumbers.map((n) => `${n} 0 R`).join(' ')}] /Count ${pages.length} >>`); // 2
@@ -19,7 +23,7 @@ function buildPdf(pages) {
         `BT /F1 ${size} Tf ${x} ${y} Td (${text.replace(/([\\()])/g, '\\$1')}) Tj ET`)
       .join('\n');
     objects.push(
-      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] ` +
+      `<< /Type /Page /Parent 2 0 R /MediaBox [${box}] ` +
       `/Resources << /Font << /F1 3 0 R >> >> /Contents ${4 + objects.length - 2} 0 R >>`);
     objects.push(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`);
   }

--- a/e2e/helpers/pdf.js
+++ b/e2e/helpers/pdf.js
@@ -5,13 +5,15 @@
  * absolutely positioned Helvetica text. Deterministic and dependency-free —
  * default page size is A4 (595 x 842 pt), matching the .NET test fixtures.
  *
- * Pass `{ mediaBox: [llx, lly, urx, ury] }` to give the pages a non-(0,0) origin,
- * which is what regression-tests the coordinate mapping used for redaction.
+ * Pass `{ mediaBox: [llx, lly, urx, ury] }` to give the pages a non-(0,0) origin, and/or
+ * `{ rotate: 90|180|270 }` to rotate them — both regression-test the coordinate mapping
+ * used for redaction.
  */
-function buildPdf(pages, { mediaBox = [0, 0, 595, 842] } = {}) {
+function buildPdf(pages, { mediaBox = [0, 0, 595, 842], rotate = 0 } = {}) {
   const objects = [];
   const pageObjectNumbers = pages.map((_, i) => 4 + i * 2);
   const box = mediaBox.join(' ');
+  const rotateEntry = rotate ? ` /Rotate ${rotate}` : '';
 
   objects.push('<< /Type /Catalog /Pages 2 0 R >>'); // 1
   objects.push(`<< /Type /Pages /Kids [${pageObjectNumbers.map((n) => `${n} 0 R`).join(' ')}] /Count ${pages.length} >>`); // 2
@@ -23,7 +25,7 @@ function buildPdf(pages, { mediaBox = [0, 0, 595, 842] } = {}) {
         `BT /F1 ${size} Tf ${x} ${y} Td (${text.replace(/([\\()])/g, '\\$1')}) Tj ET`)
       .join('\n');
     objects.push(
-      `<< /Type /Page /Parent 2 0 R /MediaBox [${box}] ` +
+      `<< /Type /Page /Parent 2 0 R /MediaBox [${box}]${rotateEntry} ` +
       `/Resources << /Font << /F1 3 0 R >> >> /Contents ${4 + objects.length - 2} 0 R >>`);
     objects.push(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`);
   }

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -291,6 +291,36 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('text edit: change the font family, size, and style', async () => {
+    const file = fixture('font-edit.pdf', [[{ text: 'Plain Heading', x: 72, y: 700 }]]);
+    const page = await openViewerWith(file);
+
+    await page.click('#tool-edit');
+    await dragPdfRect(page, { x: 60, y: 690, width: 260, height: 34 });
+    await expect(page.locator('#panel-edit')).toBeVisible();
+    await expect(page.locator('#edit-text')).toHaveValue('Plain Heading');
+    // Plain Helvetica text pre-fills the controls with the sans-serif default.
+    await expect(page.locator('#edit-font')).toHaveValue('helvetica');
+    await expect(page.locator('#edit-bold')).not.toHaveClass(/active/);
+
+    // Change the text, switch to Times, bump the size, and turn on bold.
+    await page.fill('#edit-text', 'Styled Heading');
+    await page.selectOption('#edit-font', 'times');
+    await page.fill('#edit-size', '20');
+    await page.click('#edit-bold');
+    await expect(page.locator('#edit-bold')).toHaveClass(/active/);
+    await page.click('#edit-apply');
+    await expect(page.locator('#status')).toContainText('Text replaced');
+
+    // Re-selecting the region shows the new text, and the detected font/style round-trips.
+    await page.click('#tool-edit');
+    await dragPdfRect(page, { x: 55, y: 685, width: 300, height: 45 });
+    await expect(page.locator('#edit-text')).toHaveValue(/Styled Heading/);
+    await expect(page.locator('#edit-font')).toHaveValue('times');
+    await expect(page.locator('#edit-bold')).toHaveClass(/active/);
+    await page.close();
+  });
+
   test('find & replace across the document', async () => {
     const file = fixture('replace.pdf', [[
       { text: 'Contract with OldCorp', x: 72, y: 700 },

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -133,6 +133,50 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('search & mark: finds every occurrence of a phrase, marks boxes, redacts them', async () => {
+    // Two copies of the secret word plus an unrelated line. Searching marks both copies as
+    // redaction boxes; applying blacks out both spots and leaves the other line untouched.
+    const file = fixture('search-redact.pdf', [[
+      { text: 'CONFIDENTIAL summary', x: 72, y: 700 },
+      { text: 'again CONFIDENTIAL here', x: 72, y: 600 },
+      { text: 'ordinary public line', x: 72, y: 500 },
+    ]]);
+    const page = await openViewerWith(file);
+
+    // The Redact panel is shown by the redact tool; the search box lives inside it.
+    await page.click('#tool-redact');
+    await page.fill('#redact-search-text', 'CONFIDENTIAL');
+    await page.click('#redact-search-btn');
+
+    // Both occurrences are marked as boxes (and the input is cleared for the next search).
+    await expect(page.locator('#redact-list li')).toHaveCount(2);
+    await expect(page.locator('#redact-search-text')).toHaveValue('');
+
+    await page.click('#redact-apply');
+    await expect(page.locator('#status')).toContainText('content removed');
+
+    // Both words are blacked out; the ordinary line survives (its glyphs are not a black box)
+    // and blank paper stays white.
+    expect(await pixelAt(page, 90, 704)).toEqual([0, 0, 0, 255]);
+    expect(await pixelAt(page, 120, 604)).toEqual([0, 0, 0, 255]);
+    expect(await pixelAt(page, 90, 504)).not.toEqual([0, 0, 0, 255]);
+    expect(await pixelAt(page, 400, 504)).toEqual([255, 255, 255, 255]);
+    await page.close();
+  });
+
+  test('search & mark: reports when a phrase is not found and marks nothing', async () => {
+    const file = fixture('search-none.pdf', [[{ text: 'nothing to hide here', x: 72, y: 700 }]]);
+    const page = await openViewerWith(file);
+
+    await page.click('#tool-redact');
+    await page.fill('#redact-search-text', 'MISSING');
+    await page.click('#redact-search-btn');
+
+    await expect(page.locator('#status')).toContainText('No matches');
+    await expect(page.locator('#redact-list li')).toHaveCount(0);
+    await page.close();
+  });
+
   test('continuous scroll: all pages stack and the counter tracks the visible page', async () => {
     const file = fixture('scroll.pdf', [
       [{ text: 'Page one', x: 72, y: 700 }],

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -27,6 +27,9 @@ function fixture(name, pages, opts) {
   return file;
 }
 
+// In the continuous-scroll layout each page is `.page[data-page="N"]` with its own image.
+const pageImageSel = (n = 1) => `.page[data-page="${n}"] .page-image`;
+
 /** Opens a fresh viewer page and loads the given fixture through the Open button. */
 async function openViewerWith(file) {
   const page = await ext.context.newPage();
@@ -34,8 +37,7 @@ async function openViewerWith(file) {
   const chooser = page.waitForEvent('filechooser');
   await page.click('#btn-open-empty');
   await (await chooser).setFiles(file);
-  await expect(page.locator('#page-wrap')).toHaveClass(/loaded/);
-  await expect(page.locator('#page-image')).toHaveAttribute('src', /data:image\/png/);
+  await expect(page.locator(pageImageSel(1))).toHaveAttribute('src', /data:image\/png/);
   return page;
 }
 
@@ -47,7 +49,7 @@ const A4 = [0, 0, 595, 842];
 /** Drags a rectangle on the overlay, in PDF user-space coordinates. */
 async function dragPdfRect(page, { x, y, width, height }, mediaBox = A4) {
   const [llx, lly, urx, ury] = mediaBox;
-  const box = await page.locator('#page-image').boundingBox();
+  const box = await page.locator(pageImageSel(1)).boundingBox();
   const scale = box.width / (urx - llx);
   const cssX = (pdfX) => box.x + (pdfX - llx) * scale;
   const cssY = (pdfY) => box.y + (ury - pdfY) * scale;
@@ -60,7 +62,7 @@ async function dragPdfRect(page, { x, y, width, height }, mediaBox = A4) {
 /** Samples a rendered-page pixel at a PDF user-space point (returns [r,g,b,a]). */
 async function pixelAt(page, pdfX, pdfY, mediaBox = A4) {
   return page.evaluate(async ([px, py, [llx, lly, urx, ury]]) => {
-    const img = document.getElementById('page-image');
+    const img = document.querySelector('.page[data-page="1"] .page-image');
     await img.decode();
     const canvas = document.createElement('canvas');
     canvas.width = img.naturalWidth;
@@ -128,6 +130,77 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // The region renders as opaque black; untouched text area stays white.
     expect(await pixelAt(page, 180, 707)).toEqual([0, 0, 0, 255]);
     expect(await pixelAt(page, 400, 400)).toEqual([255, 255, 255, 255]);
+    await page.close();
+  });
+
+  test('continuous scroll: all pages stack and the counter tracks the visible page', async () => {
+    const file = fixture('scroll.pdf', [
+      [{ text: 'Page one', x: 72, y: 700 }],
+      [{ text: 'Page two', x: 72, y: 700 }],
+      [{ text: 'Page three', x: 72, y: 700 }],
+    ]);
+    const page = await openViewerWith(file);
+
+    await expect(page.locator('.page')).toHaveCount(3); // every page laid out in the column
+    await expect(page.locator('#page-label')).toHaveText('1 / 3');
+    await expect(page.locator('#btn-prev')).toBeDisabled();
+
+    // Paging forward scrolls the next page into view; the counter follows what's visible,
+    // and that page renders lazily once it's near the viewport.
+    await page.click('#btn-next');
+    await expect(page.locator('#page-label')).toHaveText('2 / 3');
+    await expect(page.locator(pageImageSel(2))).toHaveAttribute('src', /data:image\/png/);
+
+    await page.click('#btn-next');
+    await expect(page.locator('#page-label')).toHaveText('3 / 3');
+    await expect(page.locator('#btn-next')).toBeDisabled();
+
+    await page.click('#btn-prev');
+    await expect(page.locator('#page-label')).toHaveText('2 / 3');
+    await page.close();
+  });
+
+  test('redaction works on a page other than the first (per-page overlays)', async () => {
+    // Text near the top of page 2 so it stays on-screen once page 2 is scrolled to the top.
+    const file = fixture('multi-redact.pdf', [
+      [{ text: 'first page', x: 72, y: 700 }],
+      [{ text: 'SECOND SECRET', x: 72, y: 800 }],
+    ]);
+    const page = await openViewerWith(file);
+
+    await page.click('#tool-redact');
+    // Page forward: goToPage top-aligns page 2 in the viewport (deterministic).
+    await page.click('#btn-next');
+    await expect(page.locator('#page-label')).toHaveText('2 / 2');
+    await expect(page.locator(pageImageSel(2))).toHaveAttribute('src', /data:image\/png/);
+
+    // Draw on page 2's own overlay, in that page's A4 user-space (near its top).
+    const box = await page.locator(pageImageSel(2)).boundingBox();
+    const scale = box.width / 595;
+    const cx = (px) => box.x + px * scale;
+    const cy = (py) => box.y + (842 - py) * scale;
+    await page.mouse.move(cx(60), cy(790));
+    await page.mouse.down();
+    await page.mouse.move(cx(320), cy(825), { steps: 5 });
+    await page.mouse.up();
+
+    await expect(page.locator('#redact-list li')).toHaveText(/page 2/);
+    await page.click('#redact-apply');
+    await expect(page.locator('#status')).toContainText('content removed');
+
+    // Page 2's region renders black — proving the drag mapped to page 2, not page 1.
+    const pixel = await page.evaluate(async () => {
+      const img = document.querySelector('.page[data-page="2"] .page-image');
+      await img.decode();
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const s = img.naturalWidth / 595;
+      return [...ctx.getImageData(Math.round(180 * s), Math.round((842 - 807) * s), 1, 1).data];
+    });
+    expect(pixel).toEqual([0, 0, 0, 255]);
     await page.close();
   });
 
@@ -220,7 +293,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // The document stays editable with the retained password (re-render works).
     await page.click('#btn-zoom-in');
     await expect(page.locator('#zoom-label')).toHaveText('125%');
-    await expect(page.locator('#page-wrap')).toHaveClass(/loaded/);
+    await expect(page.locator(pageImageSel(1))).toHaveAttribute('src', /data:image\/png/);
     await page.close();
   });
 
@@ -273,7 +346,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     const chooser = page.waitForEvent('filechooser');
     await page.click('#btn-open-empty');
     await (await chooser).setFiles(file);
-    await expect(page.locator('#page-wrap')).toHaveClass(/loaded/);
+    await expect(page.locator(pageImageSel(1))).toHaveAttribute('src', /data:image\/png/);
 
     // Make one change so there is something to save/undo.
     await page.click('#btn-find');

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -169,10 +169,12 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     const page = await openViewerWith(file);
 
     await page.click('#tool-redact');
-    // Page forward: goToPage top-aligns page 2 in the viewport (deterministic).
-    await page.click('#btn-next');
-    await expect(page.locator('#page-label')).toHaveText('2 / 2');
+    // Top-align page 2 *instantly* (no smooth-scroll animation, so boundingBox() below is
+    // settled and the drag can't land on stale coordinates), then let it render.
+    await page.evaluate(() =>
+      document.querySelector('.page[data-page="2"]').scrollIntoView({ block: 'start', behavior: 'instant' }));
     await expect(page.locator(pageImageSel(2))).toHaveAttribute('src', /data:image\/png/);
+    await expect(page.locator('#page-label')).toHaveText('2 / 2');
 
     // Draw on page 2's own overlay, in that page's A4 user-space (near its top).
     const box = await page.locator(pageImageSel(2)).boundingBox();
@@ -228,6 +230,43 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // outside it stays white.
     expect(await pixelAt(page, 200, 905, box)).toEqual([0, 0, 0, 255]);
     expect(await pixelAt(page, 600, 400, box)).toEqual([255, 255, 255, 255]);
+    await page.close();
+  });
+
+  test('redaction on a rotated (/Rotate 90) page lands where it is drawn', async () => {
+    // On a rotated page PDFium renders a width/height-swapped image; if the viewer ignores
+    // the rotation the box is drawn in one place and redacted in another. Draw a box at a
+    // known spot on the *displayed* image and prove that exact spot goes black — a full
+    // display -> PDF -> redact -> render round-trip that only closes if rotation is handled.
+    const file = fixture('rotated.pdf', [[{ text: 'rotated secret', x: 120, y: 400 }]], { rotate: 90 });
+    const page = await openViewerWith(file);
+
+    await page.click('#tool-redact');
+    const box = await page.locator(pageImageSel(1)).boundingBox();
+    // Landscape image (rotated): draw a rectangle across the middle in display coordinates.
+    await page.mouse.move(box.x + box.width * 0.30, box.y + box.height * 0.40);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.62, box.y + box.height * 0.62, { steps: 5 });
+    await page.mouse.up();
+
+    await expect(page.locator('#redact-list li')).toHaveCount(1);
+    await page.click('#redact-apply');
+    await expect(page.locator('#status')).toContainText('content removed');
+
+    // The centre of the drawn rectangle (display fractions ~0.46, 0.51) is now opaque black.
+    const pixel = await page.evaluate(async (sel) => {
+      const img = document.querySelector(sel);
+      await img.decode();
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const px = Math.round(0.46 * img.naturalWidth);
+      const py = Math.round(0.51 * img.naturalHeight);
+      return [...ctx.getImageData(px, py, 1, 1).data];
+    }, pageImageSel(1));
+    expect(pixel).toEqual([0, 0, 0, 255]);
     await page.close();
   });
 

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -233,6 +233,28 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('redaction lands correctly when the CropBox exceeds the MediaBox', async () => {
+    // Real-world regression: some PDFs set a CropBox larger than the MediaBox. The renderer
+    // clamps to the media box, so if the viewer trusted the oversized crop box the whole page
+    // was scaled and the redaction landed above where it was drawn. The page here is a normal
+    // A4 media box with a crop box 160pt taller; text sits inside the real (media) area.
+    const file = fixture('oversized-crop.pdf',
+      [[{ text: 'CLAMP ME', x: 72, y: 500 }]],
+      { mediaBox: [0, 0, 595, 842], cropBox: [0, 0, 595, 1002] });
+    const page = await openViewerWith(file);
+
+    await page.click('#tool-redact');
+    await dragPdfRect(page, { x: 60, y: 492, width: 220, height: 30 });
+    await expect(page.locator('#redact-list li')).toHaveCount(1);
+    await page.click('#redact-apply');
+    await expect(page.locator('#status')).toContainText('content removed');
+
+    // The drawn spot (not a shifted one) is what turns black.
+    expect(await pixelAt(page, 150, 507)).toEqual([0, 0, 0, 255]);
+    expect(await pixelAt(page, 450, 300)).toEqual([255, 255, 255, 255]);
+    await page.close();
+  });
+
   test('redaction on a rotated (/Rotate 90) page lands where it is drawn', async () => {
     // On a rotated page PDFium renders a width/height-swapped image; if the viewer ignores
     // the rotation the box is drawn in one place and redacted in another. Draw a box at a

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -5,7 +5,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { launchExtension } = require('../helpers/harness');
-const { buildPdf } = require('../helpers/pdf');
+const { buildPdf, buildLeftoverCtmPdf } = require('../helpers/pdf');
 
 /** @type {Awaited<ReturnType<typeof launchExtension>>} */
 let ext;
@@ -161,6 +161,64 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     expect(await pixelAt(page, 120, 604)).toEqual([0, 0, 0, 255]);
     expect(await pixelAt(page, 90, 504)).not.toEqual([0, 0, 0, 255]);
     expect(await pixelAt(page, 400, 504)).toEqual([255, 255, 255, 255]);
+    await page.close();
+  });
+
+  test('redaction lands on the text on a Chrome/Google-Docs PDF (leftover transform)', async () => {
+    // Regression for the reported bug: Chrome / Google-Docs-exported PDFs leave a scale+flip
+    // matrix active at the end of the page content. The black box used to inherit it and land
+    // scaled/flipped away, while the text under it was correctly removed. Here we search for the
+    // word (absolute coordinates, no screen mapping), redact it, and prove the black box covers
+    // exactly the pixels the word occupied — end-to-end through the extension and native host.
+    const file = path.join(fixtureDir, 'leftover-ctm.pdf');
+    fs.writeFileSync(file, buildLeftoverCtmPdf('SECRET'));
+    const page = await openViewerWith(file);
+
+    // Find the centroid of the word's dark pixels on the rendered page (natural-image pixels).
+    const darkCentroid = async () => page.evaluate(async () => {
+      const img = document.querySelector('.page[data-page="1"] .page-image');
+      await img.decode();
+      const c = document.createElement('canvas');
+      c.width = img.naturalWidth; c.height = img.naturalHeight;
+      const ctx = c.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const { data, width, height } = ctx.getImageData(0, 0, c.width, c.height);
+      let sx = 0, sy = 0, n = 0;
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          if (data[i] < 100 && data[i + 1] < 100 && data[i + 2] < 100) { sx += x; sy += y; n++; }
+        }
+      }
+      return n ? { x: Math.round(sx / n), y: Math.round(sy / n), n, width, height } : null;
+    });
+
+    const before = await darkCentroid();
+    expect(before).not.toBeNull();       // the word actually renders
+    expect(before.n).toBeGreaterThan(50);
+
+    // Search + mark + apply through the real UI / native host.
+    await page.click('#tool-redact');
+    await page.fill('#redact-search-text', 'SECRET');
+    await page.click('#redact-search-btn');
+    await expect(page.locator('#redact-list li')).toHaveCount(1);
+    await page.click('#redact-apply');
+    await expect(page.locator('#status')).toContainText('content removed');
+
+    // The pixel at the word's former centroid is now opaque black — the box landed on the word.
+    const pixel = await page.evaluate(async (pt) => {
+      const img = document.querySelector('.page[data-page="1"] .page-image');
+      await img.decode();
+      const c = document.createElement('canvas');
+      c.width = img.naturalWidth; c.height = img.naturalHeight;
+      const ctx = c.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      // Sample relative to the (possibly re-rendered at a different scale) image.
+      const x = Math.round(pt.x / pt.width * c.width);
+      const y = Math.round(pt.y / pt.height * c.height);
+      return [...ctx.getImageData(x, y, 1, 1).data];
+    }, before);
+    expect(pixel).toEqual([0, 0, 0, 255]);
     await page.close();
   });
 

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -21,9 +21,9 @@ test.afterAll(async () => {
   if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
 });
 
-function fixture(name, pages) {
+function fixture(name, pages, opts) {
   const file = path.join(fixtureDir, name);
-  fs.writeFileSync(file, buildPdf(pages));
+  fs.writeFileSync(file, buildPdf(pages, opts));
   return file;
 }
 
@@ -39,12 +39,18 @@ async function openViewerWith(file) {
   return page;
 }
 
+// PDF user-space coordinate helpers. The page box defaults to A4 at the origin; pass a
+// [llx, lly, urx, ury] box to work with pages whose MediaBox does not start at (0,0) — the
+// rendered image's bottom-left is (llx, lly), so mappings must subtract that origin.
+const A4 = [0, 0, 595, 842];
+
 /** Drags a rectangle on the overlay, in PDF user-space coordinates. */
-async function dragPdfRect(page, { x, y, width, height }) {
+async function dragPdfRect(page, { x, y, width, height }, mediaBox = A4) {
+  const [llx, lly, urx, ury] = mediaBox;
   const box = await page.locator('#page-image').boundingBox();
-  const scale = box.width / 595; // A4 width in points
-  const cssX = (pdfX) => box.x + pdfX * scale;
-  const cssY = (pdfY) => box.y + (842 - pdfY) * scale;
+  const scale = box.width / (urx - llx);
+  const cssX = (pdfX) => box.x + (pdfX - llx) * scale;
+  const cssY = (pdfY) => box.y + (ury - pdfY) * scale;
   await page.mouse.move(cssX(x), cssY(y + height));
   await page.mouse.down();
   await page.mouse.move(cssX(x + width), cssY(y), { steps: 5 });
@@ -52,8 +58,8 @@ async function dragPdfRect(page, { x, y, width, height }) {
 }
 
 /** Samples a rendered-page pixel at a PDF user-space point (returns [r,g,b,a]). */
-async function pixelAt(page, pdfX, pdfY) {
-  return page.evaluate(async ([px, py]) => {
+async function pixelAt(page, pdfX, pdfY, mediaBox = A4) {
+  return page.evaluate(async ([px, py, [llx, lly, urx, ury]]) => {
     const img = document.getElementById('page-image');
     await img.decode();
     const canvas = document.createElement('canvas');
@@ -61,10 +67,11 @@ async function pixelAt(page, pdfX, pdfY) {
     canvas.height = img.naturalHeight;
     const ctx = canvas.getContext('2d');
     ctx.drawImage(img, 0, 0);
-    const scale = img.naturalWidth / 595;
-    const data = ctx.getImageData(Math.round(px * scale), Math.round((842 - py) * scale), 1, 1).data;
+    const scale = img.naturalWidth / (urx - llx);
+    const data = ctx.getImageData(
+      Math.round((px - llx) * scale), Math.round((ury - py) * scale), 1, 1).data;
     return [...data];
-  }, [pdfX, pdfY]);
+  }, [pdfX, pdfY, mediaBox]);
 }
 
 /** Fills the promptDialog() form (inputs in creation order) and confirms. */
@@ -121,6 +128,33 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // The region renders as opaque black; untouched text area stays white.
     expect(await pixelAt(page, 180, 707)).toEqual([0, 0, 0, 255]);
     expect(await pixelAt(page, 400, 400)).toEqual([255, 255, 255, 255]);
+    await page.close();
+  });
+
+  test('redaction lands correctly on a page whose box origin is not (0,0)', async () => {
+    // Regression: the viewer used to assume the page's lower-left is (0,0). PDFium renders
+    // the MediaBox at its true origin, so on a box like [100 200 695 1042] every redaction
+    // landed offset by (100,200). Draw a box over the text and prove the *text's* location
+    // (not the shifted one) is what gets blacked out.
+    const box = [100, 200, 695, 1042];
+    const file = fixture('offset-redact.pdf',
+      [[{ text: 'OFFSET SECRET', x: 150, y: 900 }]], { mediaBox: box });
+    const page = await openViewerWith(file);
+
+    await page.click('#tool-redact');
+    await dragPdfRect(page, { x: 140, y: 892, width: 240, height: 30 }, box);
+    await expect(page.locator('#redact-list li')).toHaveCount(1);
+
+    await page.click('#redact-preview');
+    const dialog = page.locator('dialog#modal');
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Apply redaction' }).click();
+    await expect(page.locator('#status')).toContainText('content removed');
+
+    // The redaction box is painted exactly over the text (origin honoured), and a point
+    // outside it stays white.
+    expect(await pixelAt(page, 200, 905, box)).toEqual([0, 0, 0, 255]);
+    expect(await pixelAt(page, 600, 400, box)).toEqual([255, 255, 255, 255]);
     await page.close();
   });
 

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -130,6 +130,49 @@ textarea, input[type="number"], input[type="text"], input[type="password"] {
 
 label { display: block; margin: 6px 0; color: var(--muted); font-size: 12px; }
 
+select {
+  width: 100%;
+  background: #26262b;
+  color: var(--text);
+  border: 1px solid #55555e;
+  border-radius: 4px;
+  padding: 6px;
+  font: inherit;
+  margin: 4px 0;
+}
+
+#edit-style {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+#edit-style label { margin: 0; flex: 1 1 70px; }
+#edit-style input[type="number"] { margin: 2px 0; }
+
+.style-toggle {
+  min-width: 34px;
+  padding: 6px 8px;
+  line-height: 1;
+}
+.style-toggle.active { background: var(--accent-2); border-color: var(--accent-2); color: #fff; }
+
+.color-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+.color-field input[type="color"] {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid #55555e;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
 .actions { display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }
 
 .tabs { display: flex; gap: 4px; margin-bottom: 8px; }

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -106,6 +106,10 @@ button.danger:hover:not(:disabled) { background: #ef5443; }
 
 .panel-section h2 { margin: 0 0 8px; font-size: 15px; }
 
+#redact-search { display: flex; gap: 6px; margin: 8px 0; }
+#redact-search input { flex: 1; margin: 0; }
+#redact-search button { white-space: nowrap; }
+
 #redact-list { list-style: none; padding: 0; margin: 8px 0; }
 #redact-list li {
   display: flex;

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -58,19 +58,29 @@ button.danger:hover:not(:disabled) { background: #ef5443; }
 
 #scroll-area { flex: 1; overflow: auto; display: flex; justify-content: center; padding: 16px; }
 
-#page-wrap { position: relative; align-self: flex-start; display: none; }
-#page-wrap.loaded { display: block; }
+/* Continuous vertical scroll of every page. */
+#pages {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  align-self: flex-start;
+  margin: 0 auto;
+}
+#pages:empty { display: none; }
 
-#page-image {
-  display: block;
+.page {
+  position: relative;
   background: #fff;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
   user-select: none;
+  flex: none;
 }
 
-#overlay { position: absolute; inset: 0; }
+.page-image { display: block; width: 100%; height: 100%; }
 
-#overlay.tool-active { cursor: crosshair; }
+.overlay { position: absolute; inset: 0; }
+.overlay.tool-active { cursor: crosshair; }
 
 .region {
   position: absolute;

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -185,3 +185,43 @@ dialog h2 { margin-top: 0; font-size: 16px; }
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* --------------------------------------------------------- busy indicator */
+/* Shown whenever the app is waiting on the native host for an operation, so a
+   button press never just sits there doing nothing. Purely visual — it never
+   blocks pointer input. */
+#busy-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(20, 20, 24, 0.28);
+  pointer-events: none;
+}
+#busy-overlay[hidden] { display: none; }
+
+.busy-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 22px 30px;
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.55);
+  color: var(--text);
+  font-size: 13px;
+  max-width: 70vw;
+  text-align: center;
+}
+
+.spinner-lg {
+  width: 40px;
+  height: 40px;
+  border: 4px solid rgba(255, 255, 255, 0.22);
+  border-top-color: var(--accent-2);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -61,7 +61,19 @@
         <h2>Edit text</h2>
         <p class="muted">Text found in the selected region:</p>
         <textarea id="edit-text" rows="5"></textarea>
-        <label>Font size <input id="edit-size" type="number" min="4" max="96" step="0.5" /></label>
+        <label>Font
+          <select id="edit-font">
+            <option value="helvetica">Helvetica (sans-serif)</option>
+            <option value="times">Times (serif)</option>
+            <option value="courier">Courier (monospace)</option>
+          </select>
+        </label>
+        <div id="edit-style">
+          <label>Size <input id="edit-size" type="number" min="4" max="96" step="0.5" /></label>
+          <button type="button" id="edit-bold" class="style-toggle" title="Bold"><b>B</b></button>
+          <button type="button" id="edit-italic" class="style-toggle" title="Italic"><i>I</i></button>
+          <label class="color-field" title="Text colour">Colour <input id="edit-color" type="color" value="#000000" /></label>
+        </div>
         <div class="actions">
           <button id="edit-apply">Apply</button>
           <button id="edit-cancel">Cancel</button>

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -48,7 +48,12 @@
     <aside id="panel" hidden>
       <div id="panel-redact" class="panel-section" hidden>
         <h2>Redact</h2>
-        <p class="muted">Drag boxes over content. Content behind each box is <strong>permanently removed</strong> when applied.</p>
+        <p class="muted">Drag boxes over content, or search for text to mark every match. Content
+          behind each box is <strong>permanently removed</strong> when applied.</p>
+        <div id="redact-search">
+          <input id="redact-search-text" type="text" placeholder="Find text to redact…" />
+          <button id="redact-search-btn">🔍 Find &amp; mark</button>
+        </div>
         <ul id="redact-list"></ul>
         <div class="actions">
           <button id="redact-preview" disabled>👁 Preview</button>

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -97,6 +97,13 @@
     <span id="badges"></span>
   </footer>
 
+  <div id="busy-overlay" hidden>
+    <div class="busy-card">
+      <span class="spinner-lg"></span>
+      <span id="busy-text"></span>
+    </div>
+  </div>
+
   <dialog id="modal"></dialog>
   <input id="file-input" type="file" accept="application/pdf" hidden />
   <input id="merge-input" type="file" accept="application/pdf" multiple hidden />

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -36,10 +36,7 @@
 
   <main id="workspace">
     <div id="scroll-area">
-      <div id="page-wrap">
-        <img id="page-image" alt="PDF page" draggable="false" />
-        <div id="overlay"></div>
-      </div>
+      <div id="pages"></div>
       <div id="empty-state">
         <h1>PDF Editor</h1>
         <p>Open a PDF to start editing, or navigate to any PDF and it will open here automatically.</p>

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -46,17 +46,24 @@ function pageSize() {
   return state.info.pages[state.page - 1];
 }
 
+// The rendered image spans the page box [x, x+width] × [y, y+height] in PDF user space.
+// x/y are the box's lower-left origin and are non-zero for PDFs whose MediaBox/CropBox
+// doesn't start at (0,0); the image's bottom-left corresponds to (x, y), not (0, 0), so
+// every screen↔document mapping must include that offset or redactions land shifted.
+
 /** CSS pixel (relative to the page image) → PDF user-space point. */
 function cssToPdf(cssX, cssY) {
-  const scale = pageImage.clientWidth / pageSize().width;
-  return { x: cssX / scale, y: pageSize().height - cssY / scale };
+  const p = pageSize();
+  const scale = pageImage.clientWidth / p.width;
+  return { x: p.x + cssX / scale, y: p.y + p.height - cssY / scale };
 }
 
 function pdfRectToCss(region) {
-  const scale = pageImage.clientWidth / pageSize().width;
+  const p = pageSize();
+  const scale = pageImage.clientWidth / p.width;
   return {
-    left: region.x * scale,
-    top: (pageSize().height - region.y - region.height) * scale,
+    left: (region.x - p.x) * scale,
+    top: (p.y + p.height - region.y - region.height) * scale,
     width: region.width * scale,
     height: region.height * scale,
   };

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -78,26 +78,52 @@ function pageSize(pageNum = state.page) {
   return state.info.pages[pageNum - 1];
 }
 
-// The rendered image spans the page box [x, x+width] × [y, y+height] in PDF user space.
-// x/y are the box's lower-left origin and are non-zero for PDFs whose MediaBox/CropBox
-// doesn't start at (0,0); the image's bottom-left corresponds to (x, y), not (0, 0), so
-// every screen↔document mapping must include that offset or redactions land shifted.
+// The rendered image is the page's crop box (origin x,y; size width×height in PDF user
+// space) with the page's clockwise rotation applied. So mapping between the image and the
+// document has to account for both the crop-box origin AND the rotation, or redactions land
+// shifted/rotated. (fx,fy) below are fractions across the *unrotated* crop box — fx from its
+// left, fy from its bottom — and (u,v) are fractions across the *displayed* image, u from
+// its left, v from its top.
+
+/** Fraction across the displayed image (u,v) → fraction across the unrotated crop box. */
+function displayToPage(rotation, u, v) {
+  switch (rotation) {
+    case 90: return [v, u];
+    case 180: return [1 - u, v];
+    case 270: return [1 - v, 1 - u];
+    default: return [u, 1 - v];
+  }
+}
+
+/** Fraction across the unrotated crop box (fx,fy) → fraction across the displayed image. */
+function pageToDisplay(rotation, fx, fy) {
+  switch (rotation) {
+    case 90: return [fy, fx];
+    case 180: return [1 - fx, fy];
+    case 270: return [1 - fy, 1 - fx];
+    default: return [fx, 1 - fy];
+  }
+}
 
 /** CSS pixel (relative to a page's image) → PDF user-space point on that page. */
 function cssToPdf(pageNum, img, cssX, cssY) {
   const p = pageSize(pageNum);
-  const scale = img.clientWidth / p.width;
-  return { x: p.x + cssX / scale, y: p.y + p.height - cssY / scale };
+  const [fx, fy] = displayToPage(p.rotation, cssX / img.clientWidth, cssY / img.clientHeight);
+  return { x: p.x + fx * p.width, y: p.y + fy * p.height };
 }
 
 function pdfRectToCss(pageNum, img, region) {
   const p = pageSize(pageNum);
-  const scale = img.clientWidth / p.width;
+  const [ua, va] = pageToDisplay(p.rotation, (region.x - p.x) / p.width, (region.y - p.y) / p.height);
+  const [ub, vb] = pageToDisplay(p.rotation,
+    (region.x + region.width - p.x) / p.width, (region.y + region.height - p.y) / p.height);
+  const w = img.clientWidth;
+  const h = img.clientHeight;
   return {
-    left: (region.x - p.x) * scale,
-    top: (p.y + p.height - region.y - region.height) * scale,
-    width: region.width * scale,
-    height: region.height * scale,
+    left: Math.min(ua, ub) * w,
+    top: Math.min(va, vb) * h,
+    width: Math.abs(ua - ub) * w,
+    height: Math.abs(va - vb) * h,
   };
 }
 
@@ -202,7 +228,11 @@ function prefetchAround(centerPage, dpi) {
 function displaySize(pageNum) {
   const p = pageSize(pageNum);
   const factor = state.zoom * (96 / 72);
-  return { width: p.width * factor, height: p.height * factor };
+  const swap = p.rotation === 90 || p.rotation === 270; // landscape when rotated a quarter-turn
+  return {
+    width: (swap ? p.height : p.width) * factor,
+    height: (swap ? p.width : p.height) * factor,
+  };
 }
 
 /** (Re)builds the scrollable column of page placeholders and starts lazy rendering. */

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -7,8 +7,10 @@ const host = new HostClient();
 
 const state = {
   pdf: null,            // Uint8Array — current working document
+  pdfB64: null,         // base64 of pdf, recomputed once per version (not per request)
+  version: 0,           // bumped whenever pdf changes; keys the render cache
   password: null,       // password for the working document, if encrypted
-  info: null,           // { pageCount, encrypted, pages: [{number,width,height}] }
+  info: null,           // { pageCount, encrypted, pages: [{number,x,y,width,height}] }
   page: 1,
   zoom: 1,
   dpi: 144,
@@ -20,6 +22,22 @@ const state = {
   pendingSignRegion: null,
   signatures: [],
 };
+
+// Rendered pages are cached in memory so navigating back and forth is instant instead of
+// re-rendering (and re-uploading the whole document) every time. Entries are keyed by the
+// document version, so any edit invalidates the whole cache automatically.
+const renderCache = new Map(); // `${version}|${page}|${dpi}` -> png base64
+const MAX_CACHED_PAGES = 24;
+let prefetchToken = 0;
+
+/** Installs new working bytes: encode once, bump the version, drop now-stale renders. */
+function setWorkingPdf(bytes, base64) {
+  state.pdf = bytes;
+  state.pdfB64 = base64 ?? bytesToBase64(bytes);
+  state.version++;
+  renderCache.clear();
+  prefetchToken++; // cancel any in-flight prefetch for the previous document
+}
 
 const $ = (id) => document.getElementById(id);
 const pageImage = $('page-image');
@@ -73,7 +91,7 @@ function pdfRectToCss(region) {
 
 async function loadDocument(bytes, fileName, { pushHistory = false, password } = {}) {
   if (pushHistory && state.pdf) {
-    state.history.push({ pdf: state.pdf, info: state.info, password: state.password });
+    state.history.push({ pdf: state.pdf, pdfB64: state.pdfB64, info: state.info, password: state.password });
     if (state.history.length > 10) state.history.shift();
   }
   const pdfB64 = bytesToBase64(bytes);
@@ -90,7 +108,7 @@ async function loadDocument(bytes, fileName, { pushHistory = false, password } =
     }
     throw e;
   }
-  state.pdf = bytes;
+  setWorkingPdf(bytes, pdfB64);
   state.password = password ?? state.password;
   state.info = info;
   if (fileName) state.fileName = fileName;
@@ -109,7 +127,7 @@ async function applyResult(base64Pdf, message) {
 async function refreshSignatures() {
   try {
     const result = await host.call('signatures', {
-      pdf: bytesToBase64(state.pdf), pdfPassword: state.password,
+      pdf: state.pdfB64, pdfPassword: state.password,
     });
     state.signatures = result.signatures ?? [];
   } catch {
@@ -117,19 +135,85 @@ async function refreshSignatures() {
   }
 }
 
-async function renderPage() {
-  const dpi = Math.min(300, Math.round(state.dpi * state.zoom));
-  setStatus(`Rendering page ${state.page}…`, true);
+function currentDpi() {
+  return Math.min(300, Math.round(state.dpi * state.zoom));
+}
+
+function cacheKey(page, dpi) {
+  return `${state.version}|${page}|${dpi}`;
+}
+
+/** Renders one page (or returns it from cache), memoising the result. */
+async function renderToCache(page, dpi) {
+  const key = cacheKey(page, dpi);
+  const cached = renderCache.get(key);
+  if (cached !== undefined) {
+    renderCache.delete(key); // move to most-recently-used
+    renderCache.set(key, cached);
+    return cached;
+  }
   const result = await host.call('render', {
-    pdf: bytesToBase64(state.pdf), page: state.page, dpi, pdfPassword: state.password,
+    pdf: state.pdfB64, page, dpi, pdfPassword: state.password,
   });
-  pageImage.src = `data:image/png;base64,${result.png}`;
-  await pageImage.decode().catch(() => {});
+  renderCache.set(key, result.png);
+  while (renderCache.size > MAX_CACHED_PAGES) {
+    renderCache.delete(renderCache.keys().next().value); // evict least-recently-used
+  }
+  return result.png;
+}
+
+/** Fills the cache for pages near `centerPage`, nearest first, in the background. */
+function prefetchAround(centerPage, dpi) {
+  const token = ++prefetchToken;
+  const total = state.info?.pageCount ?? 0;
+  const order = [];
+  for (let d = 1; d <= total && order.length < MAX_CACHED_PAGES - 1; d++) {
+    if (centerPage - d >= 1) order.push(centerPage - d);
+    if (centerPage + d <= total) order.push(centerPage + d);
+  }
+  (async () => {
+    for (const page of order) {
+      if (token !== prefetchToken) return; // navigation, zoom, or edit superseded us
+      if (renderCache.has(cacheKey(page, dpi))) continue;
+      try {
+        await renderToCache(page, dpi);
+      } catch {
+        /* a prefetch failure is never fatal — the page renders on demand instead */
+      }
+      await new Promise((r) => setTimeout(r, 0)); // yield so the UI stays responsive
+    }
+  })();
+}
+
+function showPage(png) {
+  pageImage.src = `data:image/png;base64,${png}`;
   pageImage.style.width = `${pageSize().width * state.zoom * (96 / 72)}px`;
   $('page-wrap').classList.add('loaded');
   $('empty-state').style.display = 'none';
-  setStatus('');
   drawRegions();
+}
+
+async function renderPage() {
+  const page = state.page;
+  const dpi = currentDpi();
+  const cached = renderCache.get(cacheKey(page, dpi));
+  if (cached !== undefined) {
+    showPage(cached); // instant — no host round-trip, no spinner
+  } else {
+    setStatus(`Rendering page ${page}…`, true);
+    let png;
+    try {
+      png = await renderToCache(page, dpi);
+    } catch (e) {
+      setStatus('');
+      throw e;
+    }
+    // If the user moved on while we awaited, let the newer render win.
+    if (state.page !== page || currentDpi() !== dpi) return;
+    showPage(png);
+    setStatus('');
+  }
+  prefetchAround(page, dpi);
 }
 
 function updateChrome() {
@@ -336,7 +420,7 @@ async function previewRedaction() {
   try {
     setStatus('Building redaction preview…', true);
     const result = await host.call('redact', {
-      pdf: bytesToBase64(state.pdf), regions: state.regions, pdfPassword: state.password,
+      pdf: state.pdfB64, regions: state.regions, pdfPassword: state.password,
     });
     const pages = [...new Set(state.regions.map((r) => r.page))].sort((a, b) => a - b);
     const images = [];
@@ -387,7 +471,7 @@ async function applyRedaction(precomputed) {
   try {
     setStatus('Applying redaction…', true);
     const result = precomputed ?? await host.call('redact', {
-      pdf: bytesToBase64(state.pdf), regions: state.regions, pdfPassword: state.password,
+      pdf: state.pdfB64, regions: state.regions, pdfPassword: state.password,
     });
     const count = state.regions.length;
     state.regions = [];
@@ -405,7 +489,7 @@ async function beginTextEdit(region) {
   try {
     setStatus('Reading text in region…', true);
     const found = await host.call('get-region-text', {
-      pdf: bytesToBase64(state.pdf), region, pdfPassword: state.password,
+      pdf: state.pdfB64, region, pdfPassword: state.password,
     });
     setStatus('');
     $('edit-text').value = found.text;
@@ -423,7 +507,7 @@ async function applyTextEdit() {
   try {
     setStatus('Replacing text…', true);
     const result = await host.call('replace-region-text', {
-      pdf: bytesToBase64(state.pdf),
+      pdf: state.pdfB64,
       region,
       text: $('edit-text').value,
       fontSize: parseFloat($('edit-size').value) || undefined,
@@ -490,7 +574,7 @@ async function applyImageSignature() {
     }
     setStatus('Placing signature…', true);
     const result = await host.call('sign-image', {
-      pdf: bytesToBase64(state.pdf), region, png: pngB64, pdfPassword: state.password,
+      pdf: state.pdfB64, region, png: pngB64, pdfPassword: state.password,
     });
     hidePanels();
     setTool('select');
@@ -528,7 +612,7 @@ async function digitallySign() {
     try {
       setStatus('Signing…', true);
       const result = await host.call('sign-digital', {
-        pdf: bytesToBase64(state.pdf),
+        pdf: state.pdfB64,
         pfx: pfxB64,
         pfxPassword,
         reason: choice.reason || undefined,
@@ -587,7 +671,7 @@ async function mergeFiles() {
     if (files.length === 0) return;
     try {
       setStatus(`Merging ${files.length} file${files.length === 1 ? '' : 's'}…`, true);
-      const pdfs = [bytesToBase64(state.pdf)];
+      const pdfs = [state.pdfB64];
       for (const file of files) {
         pdfs.push(bytesToBase64(new Uint8Array(await file.arrayBuffer())));
       }
@@ -617,7 +701,7 @@ async function protect() {
   try {
     setStatus('Encrypting…', true);
     const result = await host.call('encrypt', {
-      pdf: bytesToBase64(state.pdf),
+      pdf: state.pdfB64,
       userPassword: value.user,
       ownerPassword: value.owner || undefined,
       pdfPassword: state.password,
@@ -640,7 +724,7 @@ async function findReplace() {
   try {
     setStatus('Replacing…', true);
     const result = await host.call('replace-all', {
-      pdf: bytesToBase64(state.pdf),
+      pdf: state.pdfB64,
       phrase: value.find,
       replacement: value.replace,
       pdfPassword: state.password,
@@ -741,7 +825,7 @@ async function save() {
 function undo() {
   const previous = state.history.pop();
   if (!previous) return;
-  state.pdf = previous.pdf;
+  setWorkingPdf(previous.pdf, previous.pdfB64);
   state.info = previous.info;
   state.password = previous.password;
   state.page = Math.min(state.page, state.info.pageCount);

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -551,6 +551,36 @@ function promptDialog(title, fields, confirmLabel = 'OK') {
 
 // ------------------------------------------------------------- redaction
 
+/** Finds every occurrence of a phrase and marks each as a redaction box. */
+async function searchAndMarkRedactions() {
+  const phrase = $('redact-search-text').value.trim();
+  if (!phrase) { toast('Enter some text to search for.'); return; }
+  if (!state.pdf) return;
+  try {
+    setStatus(`Searching for “${phrase}”…`, true);
+    const result = await host.call('find-text', {
+      pdf: state.pdfB64, phrase, pdfPassword: state.password,
+    });
+    const matches = result.matches ?? [];
+    setStatus('');
+    if (matches.length === 0) { toast(`No matches for “${phrase}”.`); return; }
+    // Pad each match slightly so the box fully covers the glyphs' edges.
+    const pad = 1;
+    for (const m of matches) {
+      state.regions.push({
+        page: m.page,
+        x: m.x - pad, y: m.y - pad,
+        width: m.width + 2 * pad, height: m.height + 2 * pad,
+      });
+    }
+    $('redact-search-text').value = '';
+    drawRegions();
+    toast(`Marked ${matches.length} match${matches.length === 1 ? '' : 'es'} of “${phrase}” — review, then Preview or Apply.`);
+  } catch (e) {
+    fail(e);
+  }
+}
+
 async function previewRedaction() {
   try {
     setStatus('Building redaction preview…', true);
@@ -1011,6 +1041,10 @@ function wire() {
   $('redact-preview').addEventListener('click', previewRedaction);
   $('redact-apply').addEventListener('click', () => applyRedaction());
   $('redact-clear').addEventListener('click', () => { state.regions = []; drawRegions(); });
+  $('redact-search-btn').addEventListener('click', searchAndMarkRedactions);
+  $('redact-search-text').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); searchAndMarkRedactions(); }
+  });
 
   $('edit-apply').addEventListener('click', applyTextEdit);
   $('edit-cancel').addEventListener('click', () => { hidePanels(); setTool('select'); });

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -620,6 +620,10 @@ async function applyRedaction(precomputed) {
 
 // ------------------------------------------------------------- text edit
 
+function setStyleToggle(id, on) {
+  $(id).classList.toggle('active', !!on);
+}
+
 async function beginTextEdit(region) {
   try {
     setStatus('Reading text in region…', true);
@@ -629,6 +633,12 @@ async function beginTextEdit(region) {
     setStatus('');
     $('edit-text').value = found.text;
     $('edit-size').value = Number(found.fontSize).toFixed(1);
+    // Pre-fill the font controls with what was detected in the region.
+    $('edit-font').value = ['helvetica', 'times', 'courier'].includes(found.fontFamily)
+      ? found.fontFamily : 'helvetica';
+    setStyleToggle('edit-bold', found.bold);
+    setStyleToggle('edit-italic', found.italic);
+    $('edit-color').value = '#000000';
     showPanel('panel-edit');
     $('edit-text').focus();
   } catch (e) {
@@ -646,6 +656,10 @@ async function applyTextEdit() {
       region,
       text: $('edit-text').value,
       fontSize: parseFloat($('edit-size').value) || undefined,
+      fontFamily: $('edit-font').value,
+      bold: $('edit-bold').classList.contains('active'),
+      italic: $('edit-italic').classList.contains('active'),
+      color: $('edit-color').value,
       pdfPassword: state.password,
     });
     hidePanels();
@@ -1000,6 +1014,8 @@ function wire() {
 
   $('edit-apply').addEventListener('click', applyTextEdit);
   $('edit-cancel').addEventListener('click', () => { hidePanels(); setTool('select'); });
+  $('edit-bold').addEventListener('click', () => $('edit-bold').classList.toggle('active'));
+  $('edit-italic').addEventListener('click', () => $('edit-italic').classList.toggle('active'));
 
   $('sign-tab-draw').addEventListener('click', () => {
     $('sign-tab-draw').classList.add('active');

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -40,9 +40,14 @@ function setWorkingPdf(bytes, base64) {
 }
 
 const $ = (id) => document.getElementById(id);
-const pageImage = $('page-image');
-const overlay = $('overlay');
+const pagesEl = $('pages');
+const scrollArea = $('scroll-area');
 const modal = $('modal');
+
+// One entry per page: { wrap, img, overlay, ratio, renderedKey }. Rebuilt on every load.
+let pageEls = [];
+let nearObserver = null; // renders pages as they approach the viewport
+let visObserver = null;  // tracks which page is currently front-and-centre
 
 // ------------------------------------------------------------------ utils
 
@@ -69,8 +74,8 @@ function fail(err) {
   setStatus(`⚠ ${err.message ?? err}`);
 }
 
-function pageSize() {
-  return state.info.pages[state.page - 1];
+function pageSize(pageNum = state.page) {
+  return state.info.pages[pageNum - 1];
 }
 
 // The rendered image spans the page box [x, x+width] × [y, y+height] in PDF user space.
@@ -78,16 +83,16 @@ function pageSize() {
 // doesn't start at (0,0); the image's bottom-left corresponds to (x, y), not (0, 0), so
 // every screen↔document mapping must include that offset or redactions land shifted.
 
-/** CSS pixel (relative to the page image) → PDF user-space point. */
-function cssToPdf(cssX, cssY) {
-  const p = pageSize();
-  const scale = pageImage.clientWidth / p.width;
+/** CSS pixel (relative to a page's image) → PDF user-space point on that page. */
+function cssToPdf(pageNum, img, cssX, cssY) {
+  const p = pageSize(pageNum);
+  const scale = img.clientWidth / p.width;
   return { x: p.x + cssX / scale, y: p.y + p.height - cssY / scale };
 }
 
-function pdfRectToCss(region) {
-  const p = pageSize();
-  const scale = pageImage.clientWidth / p.width;
+function pdfRectToCss(pageNum, img, region) {
+  const p = pageSize(pageNum);
+  const scale = img.clientWidth / p.width;
   return {
     left: (region.x - p.x) * scale,
     top: (p.y + p.height - region.y - region.height) * scale,
@@ -124,7 +129,7 @@ async function loadDocument(bytes, fileName, { pushHistory = false, password } =
   state.page = Math.min(state.page, info.pageCount);
   state.regions = state.regions.filter((r) => r.page <= info.pageCount);
   await refreshSignatures();
-  await renderPage();
+  await showDocument();
   updateChrome();
 }
 
@@ -194,35 +199,124 @@ function prefetchAround(centerPage, dpi) {
   })();
 }
 
-function showPage(png) {
-  pageImage.src = `data:image/png;base64,${png}`;
-  pageImage.style.width = `${pageSize().width * state.zoom * (96 / 72)}px`;
-  $('page-wrap').classList.add('loaded');
+function displaySize(pageNum) {
+  const p = pageSize(pageNum);
+  const factor = state.zoom * (96 / 72);
+  return { width: p.width * factor, height: p.height * factor };
+}
+
+/** (Re)builds the scrollable column of page placeholders and starts lazy rendering. */
+function buildPages() {
+  nearObserver?.disconnect();
+  visObserver?.disconnect();
+  pageEls = [];
+  pagesEl.innerHTML = '';
   $('empty-state').style.display = 'none';
+
+  for (let n = 1; n <= state.info.pageCount; n++) {
+    const { width, height } = displaySize(n);
+    const wrap = document.createElement('div');
+    wrap.className = 'page';
+    wrap.dataset.page = String(n);
+    wrap.style.width = `${width}px`;
+    wrap.style.height = `${height}px`;
+
+    const img = document.createElement('img');
+    img.className = 'page-image';
+    img.alt = `Page ${n}`;
+    img.draggable = false;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'overlay';
+    if (state.tool !== 'select') overlay.classList.add('tool-active');
+
+    wrap.append(img, overlay);
+    pagesEl.appendChild(wrap);
+    pageEls.push({ wrap, img, overlay, ratio: 0, renderedKey: null });
+  }
+
+  // Render pages a little before they scroll into view; keep the cache warm around them.
+  nearObserver = new IntersectionObserver((entries) => {
+    for (const e of entries) if (e.isIntersecting) renderPageEl(Number(e.target.dataset.page));
+  }, { root: scrollArea, rootMargin: '500px 0px' });
+
+  // Track which page is most in view so the page counter and nav stay correct.
+  visObserver = new IntersectionObserver((entries) => {
+    for (const e of entries) {
+      const pe = pageEls[Number(e.target.dataset.page) - 1];
+      if (pe) pe.ratio = e.isIntersecting ? e.intersectionRatio : 0;
+    }
+    let best = state.page;
+    let bestRatio = -1;
+    pageEls.forEach((pe, i) => { if (pe.ratio > bestRatio) { bestRatio = pe.ratio; best = i + 1; } });
+    if (best !== state.page) {
+      state.page = best;
+      updateNav();
+      prefetchAround(best, currentDpi());
+    }
+  }, { root: scrollArea, threshold: [0, 0.25, 0.5, 0.75, 1] });
+
+  for (const pe of pageEls) { nearObserver.observe(pe.wrap); visObserver.observe(pe.wrap); }
   drawRegions();
 }
 
-async function renderPage() {
-  const page = state.page;
+/** Renders one page's image (from cache when possible) into its placeholder. */
+async function renderPageEl(pageNum) {
+  const pe = pageEls[pageNum - 1];
+  if (!pe) return;
   const dpi = currentDpi();
-  const cached = renderCache.get(cacheKey(page, dpi));
+  const key = cacheKey(pageNum, dpi);
+  if (pe.renderedKey === key) return;
+
+  const cached = renderCache.get(key);
   if (cached !== undefined) {
-    showPage(cached); // instant — no host round-trip, no spinner
-  } else {
-    setStatus(`Rendering page ${page}…`, true);
-    let png;
-    try {
-      png = await renderToCache(page, dpi);
-    } catch (e) {
-      setStatus('');
-      throw e;
-    }
-    // If the user moved on while we awaited, let the newer render win.
-    if (state.page !== page || currentDpi() !== dpi) return;
-    showPage(png);
-    setStatus('');
+    pe.img.src = `data:image/png;base64,${cached}`;
+    pe.renderedKey = key;
+    return;
   }
-  prefetchAround(page, dpi);
+  try {
+    const png = await renderToCache(pageNum, dpi);
+    if (cacheKey(pageNum, currentDpi()) !== key || !pe.wrap.isConnected) return;
+    pe.img.src = `data:image/png;base64,${png}`;
+    pe.renderedKey = key;
+  } catch {
+    /* leave the placeholder blank; it renders again when it next scrolls into view */
+  }
+}
+
+/** Rebuilds the page column for the current document and renders the visible page now. */
+async function showDocument() {
+  buildPages();
+  await renderPageEl(state.page); // render the landing page eagerly rather than waiting on the observer
+  prefetchAround(state.page, currentDpi());
+}
+
+/** Smoothly scrolls a page to the top of the viewport. */
+function goToPage(pageNum, behavior = 'smooth') {
+  const n = Math.max(1, Math.min(state.info?.pageCount ?? 1, pageNum));
+  pageEls[n - 1]?.wrap.scrollIntoView({ behavior, block: 'start' });
+}
+
+/** Re-lays-out every page at a new zoom, keeping the current page in view. */
+function setZoom(z) {
+  if (!state.pdf) return;
+  const clamped = Math.max(0.5, Math.min(3, Math.round(z * 100) / 100));
+  if (clamped === state.zoom) return;
+  state.zoom = clamped;
+  const anchor = state.page;
+  buildPages();
+  renderPageEl(anchor);
+  goToPage(anchor, 'auto'); // jump, not smooth, so the same page stays put
+  updateChrome();
+}
+
+/** Updates just the page counter / nav buttons — cheap enough to call while scrolling. */
+function updateNav() {
+  if (!state.pdf) return;
+  $('page-label').textContent = `${state.page} / ${state.info.pageCount}`;
+  $('btn-prev').disabled = state.page <= 1;
+  $('btn-next').disabled = state.page >= state.info.pageCount;
+  $('zoom-label').textContent = `${Math.round(state.zoom * 100)}%`;
 }
 
 function updateChrome() {
@@ -234,10 +328,7 @@ function updateChrome() {
   }
   $('btn-undo').disabled = state.history.length === 0;
   if (loaded) {
-    $('page-label').textContent = `${state.page} / ${state.info.pageCount}`;
-    $('btn-prev').disabled = state.page <= 1;
-    $('btn-next').disabled = state.page >= state.info.pageCount;
-    $('zoom-label').textContent = `${Math.round(state.zoom * 100)}%`;
+    updateNav();
     document.title = `${state.fileName} — PDF Editor`;
   }
   const badgesEl = $('badges');
@@ -262,24 +353,25 @@ function updateChrome() {
 // -------------------------------------------------------------- region UI
 
 function drawRegions() {
-  overlay.querySelectorAll('.region').forEach((el) => el.remove());
+  for (const pe of pageEls) pe.overlay.querySelectorAll('.region').forEach((el) => el.remove());
   for (const [index, region] of state.regions.entries()) {
-    if (region.page !== state.page) continue;
     addRegionDiv(region, 'redact', `#${index + 1}`);
   }
-  if (state.pendingEditRegion?.page === state.page) addRegionDiv(state.pendingEditRegion, 'edit');
-  if (state.pendingSignRegion?.page === state.page) addRegionDiv(state.pendingSignRegion, 'sign');
+  if (state.pendingEditRegion) addRegionDiv(state.pendingEditRegion, 'edit');
+  if (state.pendingSignRegion) addRegionDiv(state.pendingSignRegion, 'sign');
   renderRedactList();
 }
 
 function addRegionDiv(region, kind, label = '') {
-  const css = pdfRectToCss(region);
+  const pe = pageEls[region.page - 1];
+  if (!pe) return; // page not currently laid out
+  const css = pdfRectToCss(region.page, pe.img, region);
   const div = document.createElement('div');
   div.className = `region ${kind}`;
   div.style.cssText =
     `left:${css.left}px;top:${css.top}px;width:${css.width}px;height:${css.height}px;`;
   div.textContent = label;
-  overlay.appendChild(div);
+  pe.overlay.appendChild(div);
 }
 
 function renderRedactList() {
@@ -303,25 +395,30 @@ function renderRedactList() {
   $('redact-clear').disabled = !any;
 }
 
-// Drag-to-draw on the overlay for edit/redact/sign tools.
+// Drag-to-draw for edit/redact/sign tools. Delegated on the page column so a drag is
+// attributed to whichever page it started on.
 let drag = null;
 
-overlay.addEventListener('pointerdown', (e) => {
+pagesEl.addEventListener('pointerdown', (e) => {
   if (state.tool === 'select' || !state.pdf) return;
+  const overlay = e.target.closest('.overlay');
+  if (!overlay) return;
+  const pe = pageEls.find((p) => p.overlay === overlay);
+  if (!pe) return;
   const rect = overlay.getBoundingClientRect();
-  drag = { x0: e.clientX - rect.left, y0: e.clientY - rect.top, div: null };
+  drag = { pe, pageNum: Number(pe.wrap.dataset.page), x0: e.clientX - rect.left, y0: e.clientY - rect.top, div: null };
   overlay.setPointerCapture(e.pointerId);
 });
 
-overlay.addEventListener('pointermove', (e) => {
+pagesEl.addEventListener('pointermove', (e) => {
   if (!drag) return;
-  const rect = overlay.getBoundingClientRect();
+  const rect = drag.pe.overlay.getBoundingClientRect();
   const x1 = e.clientX - rect.left;
   const y1 = e.clientY - rect.top;
   if (!drag.div) {
     drag.div = document.createElement('div');
     drag.div.className = `region ${state.tool === 'redact' ? '' : state.tool === 'edit' ? 'edit' : 'sign'}`;
-    overlay.appendChild(drag.div);
+    drag.pe.overlay.appendChild(drag.div);
   }
   const left = Math.min(drag.x0, x1);
   const top = Math.min(drag.y0, y1);
@@ -329,21 +426,20 @@ overlay.addEventListener('pointermove', (e) => {
     `left:${left}px;top:${top}px;width:${Math.abs(x1 - drag.x0)}px;height:${Math.abs(y1 - drag.y0)}px;`;
 });
 
-overlay.addEventListener('pointerup', async (e) => {
+pagesEl.addEventListener('pointerup', async (e) => {
   if (!drag) return;
-  const div = drag.div;
-  const rect = overlay.getBoundingClientRect();
+  const { pe, pageNum, x0, y0, div } = drag;
+  const rect = pe.overlay.getBoundingClientRect();
   const x1 = e.clientX - rect.left;
   const y1 = e.clientY - rect.top;
-  const { x0, y0 } = drag;
   drag = null;
   if (div) div.remove();
   if (Math.abs(x1 - x0) < 4 || Math.abs(y1 - y0) < 4) return;
 
-  const a = cssToPdf(Math.min(x0, x1), Math.max(y0, y1)); // bottom-left
-  const b = cssToPdf(Math.max(x0, x1), Math.min(y0, y1)); // top-right
+  const a = cssToPdf(pageNum, pe.img, Math.min(x0, x1), Math.max(y0, y1)); // bottom-left
+  const b = cssToPdf(pageNum, pe.img, Math.max(x0, x1), Math.min(y0, y1)); // top-right
   const region = {
-    page: state.page,
+    page: pageNum,
     x: a.x, y: a.y, width: b.x - a.x, height: b.y - a.y,
   };
 
@@ -381,7 +477,7 @@ function setTool(tool) {
   state.tool = tool;
   for (const button of document.querySelectorAll('.tool')) button.classList.remove('active');
   $(`tool-${tool}`).classList.add('active');
-  overlay.classList.toggle('tool-active', tool !== 'select');
+  for (const pe of pageEls) pe.overlay.classList.toggle('tool-active', tool !== 'select');
   if (tool === 'redact') showPanel('panel-redact');
   else if (tool === 'select') hidePanels();
 }
@@ -838,8 +934,8 @@ function undo() {
   state.info = previous.info;
   state.password = previous.password;
   state.page = Math.min(state.page, state.info.pageCount);
-  refreshSignatures().then(() => {
-    renderPage();
+  refreshSignatures().then(async () => {
+    await showDocument();
     updateChrome();
     toast('Undid last change.');
   });
@@ -863,10 +959,10 @@ function wire() {
   $('btn-protect').addEventListener('click', protect);
   $('btn-digital').addEventListener('click', digitallySign);
 
-  $('btn-prev').addEventListener('click', () => { state.page--; renderPage(); updateChrome(); });
-  $('btn-next').addEventListener('click', () => { state.page++; renderPage(); updateChrome(); });
-  $('btn-zoom-in').addEventListener('click', () => { state.zoom = Math.min(3, state.zoom + 0.25); renderPage(); updateChrome(); });
-  $('btn-zoom-out').addEventListener('click', () => { state.zoom = Math.max(0.5, state.zoom - 0.25); renderPage(); updateChrome(); });
+  $('btn-prev').addEventListener('click', () => goToPage(state.page - 1));
+  $('btn-next').addEventListener('click', () => goToPage(state.page + 1));
+  $('btn-zoom-in').addEventListener('click', () => setZoom(state.zoom + 0.25));
+  $('btn-zoom-out').addEventListener('click', () => setZoom(state.zoom - 0.25));
 
   $('redact-preview').addEventListener('click', previewRedaction);
   $('redact-apply').addEventListener('click', () => applyRedaction());

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -48,6 +48,15 @@ const modal = $('modal');
 
 function setStatus(text, busy = false) {
   $('status').innerHTML = busy ? `<span class="spinner"></span>${text}` : text;
+  // The loading wheel rides along with the busy-status calls that already wrap every
+  // host round-trip, so any operation that makes a button "hang" shows a spinner.
+  const overlay = $('busy-overlay');
+  if (busy) {
+    $('busy-text').textContent = text;
+    overlay.hidden = false;
+  } else {
+    overlay.hidden = true;
+  }
 }
 
 function toast(text) {

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -115,9 +115,11 @@ resolve_tag() {
 # Copies an extracted self-contained host directory into PUBLISH_DIR and sets HOST_PATH.
 install_from_dir() {
   local src="$1"
+  echo "Installing host from $src..."
+  echo "  (will be copied to $PUBLISH_DIR and registered as $HOST_NAME.json)"
   src="$(cd "$src" && pwd)"
-  if [[ ! -f "$src/PdfEditor.NativeHost" ]]; then
-    echo "error: no PdfEditor.NativeHost found in $src" >&2
+  if [[ ! -d "$src/PdfEditor.NativeHost" ]]; then
+    echo "error: no PdfEditor.NativeHost found in $src ($src/PdfEditor.NativeHost)" >&2
     exit 1
   fi
   rm -rf "$PUBLISH_DIR"

--- a/src/PdfEditor.Core/Models.cs
+++ b/src/PdfEditor.Core/Models.cs
@@ -14,12 +14,15 @@ public sealed record RectRegion(int Page, float X, float Y, float Width, float H
 public sealed record TextMatch(int Page, string Text, float X, float Y, float Width, float Height);
 
 /// <summary>
-/// Basic geometry of a single page. <paramref name="X"/>/<paramref name="Y"/> are the
-/// lower-left corner of the page box in PDF user space — non-zero when the page's
-/// MediaBox/CropBox does not start at the origin, which the viewer must account for when
-/// mapping screen coordinates back to the document (otherwise redactions land offset).
+/// Geometry of a single page, describing exactly the box that gets rendered so the viewer
+/// can map screen coordinates back to the document. <paramref name="X"/>/<paramref name="Y"/>
+/// are the lower-left corner of the (crop) box in PDF user space — non-zero when it does not
+/// start at the origin. <paramref name="Width"/>/<paramref name="Height"/> are the box size
+/// in that space (before any rotation). <paramref name="Rotation"/> is the page's clockwise
+/// display rotation (0/90/180/270); at 90/270 the rendered image is width/height-swapped.
+/// Ignoring the crop box or the rotation makes redactions land in the wrong place.
 /// </summary>
-public sealed record PageInfo(int Number, float X, float Y, float Width, float Height);
+public sealed record PageInfo(int Number, float X, float Y, float Width, float Height, int Rotation);
 
 /// <summary>Summary of a loaded document.</summary>
 public sealed record DocumentInfo(int PageCount, IReadOnlyList<PageInfo> Pages, bool IsEncrypted);

--- a/src/PdfEditor.Core/Models.cs
+++ b/src/PdfEditor.Core/Models.cs
@@ -27,8 +27,12 @@ public sealed record PageInfo(int Number, float X, float Y, float Width, float H
 /// <summary>Summary of a loaded document.</summary>
 public sealed record DocumentInfo(int PageCount, IReadOnlyList<PageInfo> Pages, bool IsEncrypted);
 
-/// <summary>Text found inside a region, along with the dominant font size (user-space points).</summary>
-public sealed record RegionText(string Text, float FontSize);
+/// <summary>
+/// Text found inside a region, with the dominant font size (user-space points) and a
+/// best-effort read of the dominant font: family (<c>helvetica</c>/<c>times</c>/<c>courier</c>)
+/// and whether it is bold/italic — used to pre-fill the edit controls.
+/// </summary>
+public sealed record RegionText(string Text, float FontSize, string FontFamily, bool Bold, bool Italic);
 
 /// <summary>Result of an operation that rewrites the document.</summary>
 public sealed record EditResult(byte[] Pdf, IReadOnlyList<string> Warnings)

--- a/src/PdfEditor.Core/Models.cs
+++ b/src/PdfEditor.Core/Models.cs
@@ -13,8 +13,13 @@ public sealed record RectRegion(int Page, float X, float Y, float Width, float H
 /// <summary>A located occurrence of a text phrase.</summary>
 public sealed record TextMatch(int Page, string Text, float X, float Y, float Width, float Height);
 
-/// <summary>Basic geometry of a single page.</summary>
-public sealed record PageInfo(int Number, float Width, float Height);
+/// <summary>
+/// Basic geometry of a single page. <paramref name="X"/>/<paramref name="Y"/> are the
+/// lower-left corner of the page box in PDF user space — non-zero when the page's
+/// MediaBox/CropBox does not start at the origin, which the viewer must account for when
+/// mapping screen coordinates back to the document (otherwise redactions land offset).
+/// </summary>
+public sealed record PageInfo(int Number, float X, float Y, float Width, float Height);
 
 /// <summary>Summary of a loaded document.</summary>
 public sealed record DocumentInfo(int PageCount, IReadOnlyList<PageInfo> Pages, bool IsEncrypted);

--- a/src/PdfEditor.Core/PdfContentGuard.cs
+++ b/src/PdfEditor.Core/PdfContentGuard.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas;
+
+namespace PdfEditor.Core;
+
+/// <summary>
+/// Helpers for adding content to an existing page without inheriting whatever graphics state that
+/// page's content leaves behind.
+/// </summary>
+internal static class PdfContentGuard
+{
+    /// <summary>
+    /// Returns a <see cref="PdfCanvas"/> that draws in the page's <em>default</em> (identity) user
+    /// space, isolated from any leftover CTM or clip path the existing page content left in effect.
+    /// <para>
+    /// A plain <c>new PdfCanvas(page)</c> appends operators to the end of the page content, where
+    /// they run under whatever transform is still active. Real-world generators — notably Chrome /
+    /// Skia print-to-PDF, which is what "Download as PDF" from Google Docs produces — apply a
+    /// top-level scale + Y-flip matrix (e.g. <c>.24 0 0 -.24 0 792 cm</c>) that is never wrapped in
+    /// a <c>q</c>/<c>Q</c> pair, so it is still active at the stream's end. Anything drawn there is
+    /// scaled and flipped and lands in the wrong place.
+    /// </para>
+    /// <para>
+    /// This brackets the existing content with a balanced <c>q</c> … <c>Q</c> so the returned canvas
+    /// draws in the page's default user space. The operators are written as raw stream bytes because
+    /// <see cref="PdfCanvas"/> validates <c>q</c>/<c>Q</c> balance eagerly per canvas — a lone
+    /// <c>Q</c> would throw even though the page as a whole stays balanced.
+    /// </para>
+    /// </summary>
+    internal static PdfCanvas InDefaultUserSpace(PdfPage page, PdfDocument doc)
+    {
+        // 'q' before all existing content saves the clean default (identity) graphics state.
+        page.NewContentStreamBefore().SetData(Encoding.ASCII.GetBytes("q\n"));
+        // 'Q' after it pops back to that clean state, discarding the content's leftover CTM/clip.
+        page.NewContentStreamAfter().SetData(Encoding.ASCII.GetBytes("Q\n"));
+        // Draw into a further-appended stream so this canvas's own q/Q stay self-balanced.
+        return new PdfCanvas(page.NewContentStreamAfter(), page.GetResources(), doc);
+    }
+}

--- a/src/PdfEditor.Core/PdfInspector.cs
+++ b/src/PdfEditor.Core/PdfInspector.cs
@@ -10,8 +10,13 @@ public static class PdfInspector
         var pages = new List<PageInfo>();
         for (int p = 1; p <= doc.GetNumberOfPages(); p++)
         {
-            var size = doc.GetPage(p).GetPageSize();
-            pages.Add(new PageInfo(p, size.GetX(), size.GetY(), size.GetWidth(), size.GetHeight()));
+            var page = doc.GetPage(p);
+            // PDFium renders the *crop* box (which defaults to the media box), not the media
+            // box, and applies the page rotation — so both must be reported or the viewer's
+            // coordinate mapping is wrong.
+            var box = page.GetCropBox();
+            int rotation = ((page.GetRotation() % 360) + 360) % 360;
+            pages.Add(new PageInfo(p, box.GetX(), box.GetY(), box.GetWidth(), box.GetHeight(), rotation));
         }
         return new DocumentInfo(pages.Count, pages, encrypted);
     }

--- a/src/PdfEditor.Core/PdfInspector.cs
+++ b/src/PdfEditor.Core/PdfInspector.cs
@@ -11,7 +11,7 @@ public static class PdfInspector
         for (int p = 1; p <= doc.GetNumberOfPages(); p++)
         {
             var size = doc.GetPage(p).GetPageSize();
-            pages.Add(new PageInfo(p, size.GetWidth(), size.GetHeight()));
+            pages.Add(new PageInfo(p, size.GetX(), size.GetY(), size.GetWidth(), size.GetHeight()));
         }
         return new DocumentInfo(pages.Count, pages, encrypted);
     }

--- a/src/PdfEditor.Core/PdfInspector.cs
+++ b/src/PdfEditor.Core/PdfInspector.cs
@@ -1,3 +1,5 @@
+using iText.Kernel.Geom;
+
 namespace PdfEditor.Core;
 
 /// <summary>Reads basic document facts (page geometry, encryption state).</summary>
@@ -11,13 +13,26 @@ public static class PdfInspector
         for (int p = 1; p <= doc.GetNumberOfPages(); p++)
         {
             var page = doc.GetPage(p);
-            // PDFium renders the *crop* box (which defaults to the media box), not the media
-            // box, and applies the page rotation — so both must be reported or the viewer's
-            // coordinate mapping is wrong.
-            var box = page.GetCropBox();
+            // The renderer (PDFium) shows the *effective* crop box — the crop box intersected
+            // with the media box — and applies the page rotation. iText's GetCropBox() returns
+            // the crop box as authored, which can be larger than or offset beyond the media box;
+            // reporting that unclamped would scale/shift every coordinate the viewer maps, so
+            // redactions would land in the wrong place. Report exactly what gets rendered.
+            var box = EffectiveBox(page.GetCropBox(), page.GetMediaBox());
             int rotation = ((page.GetRotation() % 360) + 360) % 360;
             pages.Add(new PageInfo(p, box.GetX(), box.GetY(), box.GetWidth(), box.GetHeight(), rotation));
         }
         return new DocumentInfo(pages.Count, pages, encrypted);
+    }
+
+    /// <summary>The crop box clamped to the media box (what actually gets rendered).</summary>
+    private static Rectangle EffectiveBox(Rectangle crop, Rectangle media)
+    {
+        float llx = Math.Max(crop.GetLeft(), media.GetLeft());
+        float lly = Math.Max(crop.GetBottom(), media.GetBottom());
+        float urx = Math.Min(crop.GetRight(), media.GetRight());
+        float ury = Math.Min(crop.GetTop(), media.GetTop());
+        if (urx <= llx || ury <= lly) return media; // degenerate intersection — fall back
+        return new Rectangle(llx, lly, urx - llx, ury - lly);
     }
 }

--- a/src/PdfEditor.Core/Redactor.cs
+++ b/src/PdfEditor.Core/Redactor.cs
@@ -41,16 +41,25 @@ public static class Redactor
                 RemoveAnnotationsIn(page, rects);
 
                 if (drawBoxes)
-                {
-                    var canvas = new PdfCanvas(page);
-                    canvas.SaveState().SetFillColor(ColorConstants.BLACK);
-                    foreach (var r in rects)
-                        canvas.Rectangle(r.GetLeft(), r.GetBottom(), r.GetWidth(), r.GetHeight()).Fill();
-                    canvas.RestoreState();
-                }
+                    DrawBoxesInDefaultUserSpace(doc, page, rects);
             }
         }
         return new EditResult(output.ToArray(), warnings);
+    }
+
+    /// <summary>
+    /// Paints the opaque black boxes over the regions. Drawing in the page's default user space
+    /// (see <see cref="PdfContentGuard.InDefaultUserSpace"/>) keeps the boxes aligned with the
+    /// content even when the page leaves a scale/flip transform active — which is why the box used
+    /// to land in the wrong place on Chrome / Google-Docs-exported PDFs while the removal was fine.
+    /// </summary>
+    private static void DrawBoxesInDefaultUserSpace(PdfDocument doc, PdfPage page, IList<Rectangle> rects)
+    {
+        var canvas = PdfContentGuard.InDefaultUserSpace(page, doc);
+        canvas.SetFillColor(ColorConstants.BLACK);
+        foreach (var r in rects)
+            canvas.Rectangle(r.GetLeft(), r.GetBottom(), r.GetWidth(), r.GetHeight());
+        canvas.Fill();
     }
 
     private static void RemoveAnnotationsIn(PdfPage page, IList<Rectangle> regions)

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using iText.IO.Font.Constants;
 using iText.Kernel.Font;
 using iText.Kernel.Geom;
 using iText.Kernel.Pdf;
@@ -19,26 +20,85 @@ namespace PdfEditor.Core;
 /// </summary>
 public static class TextTools
 {
-    /// <summary>Returns the text inside a region plus its dominant font size.</summary>
+    /// <summary>Returns the text inside a region plus its dominant font size and style.</summary>
     public static RegionText GetTextInRegion(byte[] pdf, RectRegion region, string? password = null)
     {
         using var doc = PdfIo.OpenReadOnly(pdf, password);
         var rect = new Rectangle(region.X, region.Y, region.Width, region.Height);
         var chunks = CollectChunks(doc, region.Page).Where(c => ContainsCenter(rect, c.BBox)).ToList();
-        return new RegionText(AssembleText(chunks), chunks.Count == 0 ? 12f : chunks.Max(c => c.FontHeight));
+        float size = chunks.Count == 0 ? 12f : chunks.Max(c => c.FontHeight);
+        string dominantFont = chunks
+            .Where(c => !string.IsNullOrEmpty(c.FontName))
+            .GroupBy(c => c.FontName)
+            .OrderByDescending(g => g.Count())
+            .FirstOrDefault()?.Key ?? "";
+        var (family, bold, italic) = DetectFont(dominantFont);
+        return new RegionText(AssembleText(chunks), size, family, bold, italic);
     }
 
     /// <summary>
     /// Replaces the text inside a region: original text operators are removed from the
-    /// file and the new text is laid out inside the same rectangle.
+    /// file and the new text is laid out inside the same rectangle, in the requested font,
+    /// size, style, and colour (all optional — omitted values fall back to what was there).
     /// </summary>
     public static EditResult ReplaceTextInRegion(byte[] pdf, RectRegion region, string newText,
-        float? fontSize = null, string? password = null)
+        float? fontSize = null, string? fontFamily = null, bool bold = false, bool italic = false,
+        string? colorHex = null, string? password = null)
     {
         float size = fontSize ?? GetTextInRegion(pdf, region, password).FontSize;
         var removed = Redactor.RemoveContent(pdf, new[] { region }, password);
-        var stamped = StampText(removed.Pdf, region, newText, size, password);
+        var stamped = StampText(removed.Pdf, region, newText, size, password,
+            fontName: ResolveFont(fontFamily, bold, italic), color: ParseColor(colorHex));
         return new EditResult(stamped, removed.Warnings);
+    }
+
+    /// <summary>Maps a family name (helvetica/times/courier) + style to a standard-14 PDF font.</summary>
+    internal static string ResolveFont(string? family, bool bold, bool italic)
+    {
+        switch ((family ?? "helvetica").Trim().ToLowerInvariant())
+        {
+            case "times":
+            case "serif":
+                return bold && italic ? StandardFonts.TIMES_BOLDITALIC
+                    : bold ? StandardFonts.TIMES_BOLD
+                    : italic ? StandardFonts.TIMES_ITALIC
+                    : StandardFonts.TIMES_ROMAN;
+            case "courier":
+            case "mono":
+            case "monospace":
+                return bold && italic ? StandardFonts.COURIER_BOLDOBLIQUE
+                    : bold ? StandardFonts.COURIER_BOLD
+                    : italic ? StandardFonts.COURIER_OBLIQUE
+                    : StandardFonts.COURIER;
+            default: // helvetica / sans-serif
+                return bold && italic ? StandardFonts.HELVETICA_BOLDOBLIQUE
+                    : bold ? StandardFonts.HELVETICA_BOLD
+                    : italic ? StandardFonts.HELVETICA_OBLIQUE
+                    : StandardFonts.HELVETICA;
+        }
+    }
+
+    /// <summary>Best-effort read of a font's PostScript name into family + bold/italic flags.</summary>
+    internal static (string Family, bool Bold, bool Italic) DetectFont(string? postScriptName)
+    {
+        string n = (postScriptName ?? "").ToLowerInvariant();
+        string family =
+            n.Contains("times") || n.Contains("serif") || n.Contains("georgia") || n.Contains("roman") || n.Contains("minion") ? "times"
+            : n.Contains("courier") || n.Contains("mono") || n.Contains("consol") ? "courier"
+            : "helvetica";
+        bool bold = n.Contains("bold") || n.Contains("black") || n.Contains("heavy") || n.Contains("semibold");
+        bool italic = n.Contains("italic") || n.Contains("oblique");
+        return (family, bold, italic);
+    }
+
+    private static iText.Kernel.Colors.Color? ParseColor(string? hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex)) return null;
+        string h = hex.Trim().TrimStart('#');
+        if (h.Length != 6 ||
+            !int.TryParse(h, System.Globalization.NumberStyles.HexNumber, null, out int rgb))
+            return null;
+        return new iText.Kernel.Colors.DeviceRgb((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF);
     }
 
     /// <summary>Finds every occurrence of a phrase across the document.</summary>
@@ -87,28 +147,32 @@ public static class TextTools
     }
 
     private static byte[] StampText(byte[] pdf, RectRegion region, string text, float fontSize,
-        string? password, bool wrap = true)
+        string? password, bool wrap = true, string? fontName = null,
+        iText.Kernel.Colors.Color? color = null)
     {
         using var output = new MemoryStream();
         using (var doc = PdfIo.Open(pdf, output, password))
         {
             var page = doc.GetPage(region.Page);
-            var font = PdfFontFactory.CreateFont(iText.IO.Font.Constants.StandardFonts.HELVETICA);
+            var font = PdfFontFactory.CreateFont(fontName ?? StandardFonts.HELVETICA);
             var pdfCanvas = new PdfCanvas(page);
             if (wrap)
             {
                 var box = new Rectangle(region.X, region.Y, region.Width, region.Height);
                 using var canvas = new Canvas(pdfCanvas, box);
-                canvas.Add(new Paragraph(text).SetFont(font).SetFontSize(fontSize)
+                var paragraph = new Paragraph(text).SetFont(font).SetFontSize(fontSize)
                     .SetMargin(0).SetMultipliedLeading(1.05f)
-                    .SetVerticalAlignment(VerticalAlignment.TOP));
+                    .SetVerticalAlignment(VerticalAlignment.TOP);
+                if (color != null) paragraph.SetFontColor(color);
+                canvas.Add(paragraph);
             }
             else
             {
                 // Single-line stamp on the original baseline (used by find & replace).
                 float baseline = region.Y + fontSize * 0.21f; // approximate descender share
-                pdfCanvas.BeginText().SetFontAndSize(font, fontSize)
-                    .MoveText(region.X, baseline).ShowText(text).EndText();
+                pdfCanvas.BeginText().SetFontAndSize(font, fontSize);
+                if (color != null) pdfCanvas.SetFillColor(color);
+                pdfCanvas.MoveText(region.X, baseline).ShowText(text).EndText();
             }
         }
         return output.ToArray();
@@ -116,7 +180,7 @@ public static class TextTools
 
     // ------------------------------------------------------------ extraction
 
-    private sealed record Chunk(string Text, Rectangle BBox, float FontHeight);
+    private sealed record Chunk(string Text, Rectangle BBox, float FontHeight, string FontName);
 
     private static List<Chunk> CollectChunks(PdfDocument doc, int pageNumber)
     {
@@ -143,8 +207,11 @@ public static class TextTools
                 float minY = desc.GetStartPoint().Get(1);
                 float maxY = asc.GetStartPoint().Get(1);
                 if (maxX <= minX) continue;
+                string fontName = "";
+                try { fontName = single.GetFont()?.GetFontProgram()?.GetFontNames()?.GetFontName() ?? ""; }
+                catch { /* some embedded fonts expose no usable name; family detection just falls back */ }
                 _chunks.Add(new Chunk(single.GetText(),
-                    new Rectangle(minX, minY, maxX - minX, maxY - minY), maxY - minY));
+                    new Rectangle(minX, minY, maxX - minX, maxY - minY), maxY - minY, fontName));
             }
         }
 

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -155,7 +155,9 @@ public static class TextTools
         {
             var page = doc.GetPage(region.Page);
             var font = PdfFontFactory.CreateFont(fontName ?? StandardFonts.HELVETICA);
-            var pdfCanvas = new PdfCanvas(page);
+            // Draw in the page's default user space so the stamped text isn't thrown off by a
+            // leftover transform the page content leaves active (e.g. Chrome / Google Docs exports).
+            var pdfCanvas = PdfContentGuard.InDefaultUserSpace(page, doc);
             if (wrap)
             {
                 var box = new Rectangle(region.X, region.Y, region.Width, region.Height);

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -94,13 +94,25 @@ public sealed class MessageProcessor
     private static object GetRegionText(JsonObject p)
     {
         var text = TextTools.GetTextInRegion(Pdf(p), Region(p["region"]!.AsObject()), Password(p));
-        return new { text = text.Text, fontSize = text.FontSize };
+        return new
+        {
+            text = text.Text,
+            fontSize = text.FontSize,
+            fontFamily = text.FontFamily,
+            bold = text.Bold,
+            italic = text.Italic
+        };
     }
 
     private static object ReplaceRegionText(JsonObject p)
     {
         var result = TextTools.ReplaceTextInRegion(Pdf(p), Region(p["region"]!.AsObject()),
-            p["text"]?.GetValue<string>() ?? "", p["fontSize"]?.GetValue<float>(), Password(p));
+            p["text"]?.GetValue<string>() ?? "", p["fontSize"]?.GetValue<float>(),
+            p["fontFamily"]?.GetValue<string>(),
+            p["bold"]?.GetValue<bool>() ?? false,
+            p["italic"]?.GetValue<bool>() ?? false,
+            p["color"]?.GetValue<string>(),
+            Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }
 

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -69,7 +69,7 @@ public sealed class MessageProcessor
         {
             pageCount = info.PageCount,
             encrypted = info.IsEncrypted,
-            pages = info.Pages.Select(pg => new { number = pg.Number, x = pg.X, y = pg.Y, width = pg.Width, height = pg.Height })
+            pages = info.Pages.Select(pg => new { number = pg.Number, x = pg.X, y = pg.Y, width = pg.Width, height = pg.Height, rotation = pg.Rotation })
         };
     }
 

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -69,7 +69,7 @@ public sealed class MessageProcessor
         {
             pageCount = info.PageCount,
             encrypted = info.IsEncrypted,
-            pages = info.Pages.Select(pg => new { number = pg.Number, width = pg.Width, height = pg.Height })
+            pages = info.Pages.Select(pg => new { number = pg.Number, x = pg.X, y = pg.Y, width = pg.Width, height = pg.Height })
         };
     }
 

--- a/tests/PdfEditor.Core.Tests/PdfInspectorTests.cs
+++ b/tests/PdfEditor.Core.Tests/PdfInspectorTests.cs
@@ -1,0 +1,48 @@
+using iText.Kernel.Font;
+using iText.IO.Font.Constants;
+using iText.Kernel.Geom;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas;
+using PdfEditor.Core;
+
+namespace PdfEditor.Tests;
+
+public class PdfInspectorTests
+{
+    [Fact]
+    public void OriginZeroPage_ReportsZeroOffset()
+    {
+        byte[] pdf = TestPdfs.WithText(("hello", 72, 700, 14));
+
+        var info = PdfInspector.GetInfo(pdf);
+
+        Assert.Equal(0, info.Pages[0].X);
+        Assert.Equal(0, info.Pages[0].Y);
+        Assert.Equal(TestPdfs.PageWidth, info.Pages[0].Width);
+        Assert.Equal(TestPdfs.PageHeight, info.Pages[0].Height);
+    }
+
+    [Fact]
+    public void NonZeroOriginPage_ExposesTheBoxOrigin()
+    {
+        // A page whose MediaBox is [100 200 500 700] — origin (100,200), size 400x500.
+        // The viewer needs this origin: the rendered image's bottom-left corresponds to
+        // (100,200) in user space, not (0,0), so without it screen->document mapping (and
+        // therefore redaction placement) is offset by the origin.
+        using var ms = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfWriter(ms)))
+        {
+            var page = doc.AddNewPage(new PageSize(new Rectangle(100, 200, 400, 500)));
+            var font = PdfFontFactory.CreateFont(StandardFonts.HELVETICA);
+            new PdfCanvas(page).BeginText().SetFontAndSize(font, 14)
+                .MoveText(150, 650).ShowText("offset").EndText();
+        }
+
+        var info = PdfInspector.GetInfo(ms.ToArray());
+
+        Assert.Equal(100, info.Pages[0].X);
+        Assert.Equal(200, info.Pages[0].Y);
+        Assert.Equal(400, info.Pages[0].Width);
+        Assert.Equal(500, info.Pages[0].Height);
+    }
+}

--- a/tests/PdfEditor.Core.Tests/PdfInspectorTests.cs
+++ b/tests/PdfEditor.Core.Tests/PdfInspectorTests.cs
@@ -67,6 +67,26 @@ public class PdfInspectorTests
         Assert.Equal(500, info.Pages[0].Height);
     }
 
+    [Fact]
+    public void ClampsACropBoxThatExceedsTheMediaBox_ToWhatIsRendered()
+    {
+        // A crop box larger than / offset beyond the media box: the renderer only shows the
+        // intersection, so that is what must be reported (not iText's unclamped crop box).
+        using var ms = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfWriter(ms)))
+        {
+            var page = doc.AddNewPage(new PageSize(new Rectangle(0, 0, 612, 792)));
+            page.SetCropBox(new Rectangle(-50, -50, 712, 892)); // extends past the media box every side
+        }
+
+        var info = PdfInspector.GetInfo(ms.ToArray());
+
+        Assert.Equal(0, info.Pages[0].X);
+        Assert.Equal(0, info.Pages[0].Y);
+        Assert.Equal(612, info.Pages[0].Width);
+        Assert.Equal(792, info.Pages[0].Height);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(90)]

--- a/tests/PdfEditor.Core.Tests/PdfInspectorTests.cs
+++ b/tests/PdfEditor.Core.Tests/PdfInspectorTests.cs
@@ -44,5 +44,45 @@ public class PdfInspectorTests
         Assert.Equal(200, info.Pages[0].Y);
         Assert.Equal(400, info.Pages[0].Width);
         Assert.Equal(500, info.Pages[0].Height);
+        Assert.Equal(0, info.Pages[0].Rotation);
+    }
+
+    [Fact]
+    public void ReportsTheCropBox_NotTheMediaBox()
+    {
+        // PDFium renders the crop box; the geometry the viewer gets must match it, otherwise
+        // every mapped coordinate is wrong for any document that sets a crop box.
+        using var ms = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfWriter(ms)))
+        {
+            var page = doc.AddNewPage(new PageSize(new Rectangle(0, 0, 595, 842)));
+            page.SetCropBox(new Rectangle(50, 60, 400, 500));
+        }
+
+        var info = PdfInspector.GetInfo(ms.ToArray());
+
+        Assert.Equal(50, info.Pages[0].X);
+        Assert.Equal(60, info.Pages[0].Y);
+        Assert.Equal(400, info.Pages[0].Width);
+        Assert.Equal(500, info.Pages[0].Height);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(90)]
+    [InlineData(180)]
+    [InlineData(270)]
+    public void ExposesThePageRotation(int rotation)
+    {
+        using var ms = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfWriter(ms)))
+        {
+            var page = doc.AddNewPage(new PageSize(new Rectangle(0, 0, 595, 842)));
+            if (rotation != 0) page.SetRotation(rotation);
+        }
+
+        var info = PdfInspector.GetInfo(ms.ToArray());
+
+        Assert.Equal(rotation, info.Pages[0].Rotation);
     }
 }

--- a/tests/PdfEditor.Core.Tests/RedactorTests.cs
+++ b/tests/PdfEditor.Core.Tests/RedactorTests.cs
@@ -123,6 +123,37 @@ public class RedactorTests
     }
 
     [Fact]
+    public void BlackBox_LandsOnTheContent_WhenPageLeavesATransformActive()
+    {
+        // Regression: Chrome / Google-Docs-exported PDFs apply a top-level scale+flip matrix that
+        // is never wrapped in q/Q, so it is still active at the end of the content stream. A box
+        // appended with a plain PdfCanvas inherited that matrix and landed scaled/flipped away,
+        // even though the content removal (CTM-aware) was correct. The box must land on the word.
+        byte[] pdf = TestPdfs.ChromeStyleLeftoverCtm("SECRET");
+        var match = Assert.Single(TextTools.FindText(pdf, "SECRET"));
+        float cy = match.Y + match.Height / 2;
+
+        // The word really renders where iText reports it: some pixel along that band is dark
+        // (before redaction), proving iText's coordinates agree with what PDFium renders.
+        bool textRendersHere = false;
+        for (float dx = 1; dx < match.Width && !textRendersHere; dx += 1)
+            if (TestPdfAssert.PixelAt(pdf, 1, match.X + dx, cy, 150).Red < 128) textRendersHere = true;
+        Assert.True(textRendersHere, $"expected the word to render along y={cy:F0} but that band was blank");
+
+        var result = Redactor.Redact(pdf, new[]
+        {
+            new RectRegion(match.Page, match.X, match.Y, match.Width, match.Height)
+        });
+
+        // After redaction the box is opaque black across the whole word (not shifted elsewhere).
+        for (float dx = 2; dx < match.Width; dx += 4)
+        {
+            var boxPixel = TestPdfAssert.PixelAt(result.Pdf, 1, match.X + dx, cy, 150);
+            Assert.Equal(new SKColor(0, 0, 0, 255), boxPixel);
+        }
+    }
+
+    [Fact]
     public void NoRegions_ReturnsDocumentUnchanged()
     {
         byte[] pdf = TestPdfs.WithText(("hello", 72, 700, 12));

--- a/tests/PdfEditor.Core.Tests/TestPdfs.cs
+++ b/tests/PdfEditor.Core.Tests/TestPdfs.cs
@@ -332,4 +332,50 @@ public static class TestPdfs
         }
         return output.ToArray();
     }
+
+    /// <summary>
+    /// A raw, uncompressed page that mimics how Chrome / Skia print-to-PDF (what Google Docs
+    /// "Download as PDF" produces) structures its content: a top-level scale + Y-flip matrix
+    /// applied <em>outside</em> any q/Q, so it is never restored and stays active at the end of the
+    /// content stream. Text is drawn under that transform via a text matrix, so it renders upright
+    /// at a normal absolute position — but anything naively appended to the page inherits the
+    /// leftover matrix. Used to regression-test that redaction/edit draw in the page's default
+    /// user space regardless. The single Helvetica word renders around absolute (50, 300).
+    /// </summary>
+    public static byte[] ChromeStyleLeftoverCtm(string word = "SECRET")
+    {
+        // Top-level CTM: scale by 0.5, flip Y, translate up by 600  ->  maps (x,y) to (0.5x, 600-0.5y).
+        // Inside it: clip to the page, then a text object whose text matrix flips glyphs upright.
+        string content =
+            "0.5 0 0 -0.5 0 600 cm\n" +   // unbalanced top-level transform (never restored)
+            "q\n" +
+            "0 0 800 1200 re W n\n" +      // clip to the page (in the scaled space)
+            "BT\n/F1 48 Tf\n1 0 0 -1 100 600 Tm\n(" + word + ") Tj\nET\n" +
+            "Q\n";
+        byte[] contentBytes = Encoding.ASCII.GetBytes(content);
+
+        var objs = new List<string>
+        {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] " +
+                "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+            $"<< /Length {contentBytes.Length} >>\nstream\n{content}endstream",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        };
+
+        var sb = new StringBuilder("%PDF-1.4\n");
+        var offsets = new List<int> { 0 };
+        for (int i = 0; i < objs.Count; i++)
+        {
+            offsets.Add(sb.Length);
+            sb.Append($"{i + 1} 0 obj\n{objs[i]}\nendobj\n");
+        }
+        int xref = sb.Length;
+        sb.Append($"xref\n0 {objs.Count + 1}\n0000000000 65535 f \n");
+        for (int i = 1; i <= objs.Count; i++)
+            sb.Append($"{offsets[i].ToString().PadLeft(10, '0')} 00000 n \n");
+        sb.Append($"trailer\n<< /Size {objs.Count + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n");
+        return Encoding.Latin1.GetBytes(sb.ToString());
+    }
 }

--- a/tests/PdfEditor.Core.Tests/TextToolsTests.cs
+++ b/tests/PdfEditor.Core.Tests/TextToolsTests.cs
@@ -53,6 +53,60 @@ public class TextToolsTests
     }
 
     [Fact]
+    public void GetTextInRegion_ReportsHelveticaSansForPlainText()
+    {
+        byte[] pdf = TestPdfs.WithText(("basic helvetica", 72, 700, 14));
+
+        var region = TextTools.GetTextInRegion(pdf, new RectRegion(1, 60, 690, 300, 30));
+
+        Assert.Equal("helvetica", region.FontFamily);
+        Assert.False(region.Bold);
+        Assert.False(region.Italic);
+    }
+
+    [Fact]
+    public void ReplaceTextInRegion_AppliesTheChosenFontFamilyAndStyle()
+    {
+        byte[] pdf = TestPdfs.WithText(("plain text here", 72, 700, 14));
+        var region = new RectRegion(1, 60, 690, 300, 30);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, region, "styled words",
+            fontSize: 14, fontFamily: "times", bold: true, italic: true);
+
+        // Re-reading the region detects the family/style that was stamped.
+        var reread = TextTools.GetTextInRegion(result.Pdf, region);
+        Assert.Contains("styled words", reread.Text);
+        Assert.Equal("times", reread.FontFamily);
+        Assert.True(reread.Bold);
+        Assert.True(reread.Italic);
+    }
+
+    [Fact]
+    public void ReplaceTextInRegion_WithColour_ProducesReadableText()
+    {
+        byte[] pdf = TestPdfs.WithText(("colour me", 72, 700, 14));
+
+        var result = TextTools.ReplaceTextInRegion(pdf, new RectRegion(1, 60, 690, 300, 30),
+            "red text", fontSize: 14, colorHex: "#ff0000");
+
+        Assert.Contains("red text", TestPdfAssert.ExtractText(result.Pdf));
+    }
+
+    [Theory]
+    [InlineData("times", true, true)]
+    [InlineData("courier", false, false)]
+    [InlineData("helvetica", true, false)]
+    public void ReplaceTextInRegion_EveryFamilyStyleCombination_StaysReadable(string family, bool bold, bool italic)
+    {
+        byte[] pdf = TestPdfs.WithText(("before", 72, 700, 14));
+
+        var result = TextTools.ReplaceTextInRegion(pdf, new RectRegion(1, 60, 690, 300, 30),
+            "after words", fontSize: 14, fontFamily: family, bold: bold, italic: italic);
+
+        Assert.Contains("after words", TestPdfAssert.ExtractText(result.Pdf));
+    }
+
+    [Fact]
     public void FindText_LocatesPhraseOnCorrectPage()
     {
         byte[] pdf = TestPdfs.MultiPage(3, "Chapter");

--- a/tests/PdfEditor.Core.Tests/TextToolsTests.cs
+++ b/tests/PdfEditor.Core.Tests/TextToolsTests.cs
@@ -53,6 +53,28 @@ public class TextToolsTests
     }
 
     [Fact]
+    public void ReplaceTextInRegion_StampsNewText_WhenPageLeavesATransformActive()
+    {
+        // Regression (same root cause as the redaction box): on a Chrome / Google-Docs PDF whose
+        // content leaves a scale+flip matrix active, stamped replacement text used to be scaled and
+        // flipped away instead of landing at the region. The new glyphs must render at the region.
+        byte[] pdf = TestPdfs.ChromeStyleLeftoverCtm("SECRET");
+        var match = Assert.Single(TextTools.FindText(pdf, "SECRET"));
+        var region = new RectRegion(match.Page, match.X - 2, match.Y - 2, match.Width + 80, match.Height + 4);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, region, "PUBLIC", fontSize: match.Height);
+
+        // Some glyph of the stamped word renders dark somewhere along the region's baseline.
+        bool anyDark = false;
+        for (float dx = 0; dx < region.Width && !anyDark; dx += 2)
+        {
+            var px = TestPdfAssert.PixelAt(result.Pdf, 1, region.X + dx, match.Y + match.Height * 0.45f, 150);
+            if (px.Red < 128 && px.Green < 128 && px.Blue < 128) anyDark = true;
+        }
+        Assert.True(anyDark, "stamped replacement text did not render at the region — a leftover transform likely displaced it");
+    }
+
+    [Fact]
     public void GetTextInRegion_ReportsHelveticaSansForPlainText()
     {
         byte[] pdf = TestPdfs.WithText(("basic helvetica", 72, 700, 14));


### PR DESCRIPTION
Addresses the viewer feedback: it was slow/clunky, buttons felt dead while waiting, there was no page scrolling, and drawn redactions didn't match what got redacted. Later work on this branch: a text search-and-redact feature, and the real root-cause fix for redactions landing in the wrong place on Google-Docs-exported PDFs.

## 1. Redaction bug — the box landed in the wrong place
Investigated in three layers, each with a regression test:

- **Box origin (non-(0,0) MediaBox).** The viewer assumed the page's lower-left was `(0,0)`; PDFium renders at the true origin. `PageInfo` now carries the box origin.
- **Oversized CropBox.** PDFium renders `CropBox ∩ MediaBox`; `PdfInspector` now reports exactly that.
- **Leftover page transform (the one that matched the reported screenshots).** Reproduced with a real Chrome/Skia print-to-PDF document — which is what Google Docs "Download as PDF" produces. Chrome authors the whole page under a top-level scale + Y-flip matrix (`.24 0 0 -.24 0 792 cm`) applied **outside** any `q`/`Q`, so it is never restored and is still active at the end of the content stream. The content *removal* tracks the CTM and was correct, but the black box was appended with a plain `new PdfCanvas(page)` and inherited that matrix — scaled to ~24% and flipped, landing about a section away. New `PdfContentGuard.InDefaultUserSpace` brackets the existing content with a balanced `q`…`Q` so the box (and stamped replacement text, which had the same latent bug) draws in the page's default user space. Hand-made fixtures always ended with an identity CTM, which is why the suites never caught it.

## 2. Performance — pages cached in memory + prefetched
Revisiting a page is instant (in-memory LRU cache). Nearby pages are preloaded in the background; the document is base64-encoded once per edit.

## 3. Loading wheel while the host is working
A centered spinner covers every host round-trip so a button press never just sits there (purely visual, `pointer-events: none`).

## 4. Continuous scrolling interface
A vertical scroll of the whole document: per-page placeholders lazy-rendered from the cache as they approach the viewport, "N / M" counter tracking the most-visible page, per-page overlays so redaction/edit/sign work on any page.

## 5. Text editing controls
Choose font family (Helvetica/Times/Courier), size, bold/italic, and colour; the existing font/style is detected and pre-filled from the region.

## 6. Text search-and-redact
A "Find & mark" box in the Redact panel: type a phrase, and every occurrence document-wide is located via the native `find-text` action and marked with a redaction box over the matched words (absolute PDF coordinates, so unaffected by crop-box origin or rotation). Review, then Preview/Apply.

## Verification
- Full .NET suite (**170** tests) green — including a Chrome-style leftover-CTM fixture proving the box lands on the word and stamped text renders at the region (both fail against the old code).
- **19** Playwright e2e tests green — including offset-origin, oversized-CropBox, `/Rotate 90`, per-page, font editing, multi/no-match search-and-redact, and a leftover-transform redaction driven end-to-end through the extension + native host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)