### PR TITLE
Stop performance guards flaking the release workflows

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -47,7 +47,10 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        # Excludes the timing-based performance guards: this solution-wide run executes the suites
+        # in parallel on a shared runner, so their budgets would measure contention and fail at
+        # random. Performance is gated by the dedicated `perf` job in ci.yml instead.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Performance"
 
       - name: Compute the release candidate tag
         id: version

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        # Excludes the timing-based performance guards: this solution-wide run executes the suites
+        # in parallel on a shared runner, so their budgets would measure contention and fail at
+        # random. Performance is gated by the dedicated `perf` job in ci.yml instead.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Performance"
 
   package:
     needs: verify

--- a/tests/PdfEditor.Perf.Tests/PerfHarness.cs
+++ b/tests/PdfEditor.Perf.Tests/PerfHarness.cs
@@ -18,10 +18,32 @@ namespace PdfEditor.Perf.Tests;
 /// </summary>
 internal static class PerfHarness
 {
-    /// <summary>Uniform multiplier applied to every budget (default 1.0). Set >1 on slow CI.</summary>
-    public static readonly double Slack =
-        double.TryParse(Environment.GetEnvironmentVariable("PDF_EDITOR_PERF_SLACK"), out var s) && s > 0
-            ? s : 1.0;
+    /// <summary>
+    /// Uniform multiplier applied to every budget. An explicit <c>PDF_EDITOR_PERF_SLACK</c> always
+    /// wins. Otherwise it defaults to 1.0 locally but <see cref="CiSlack"/> on a CI runner (detected
+    /// via the standard <c>CI</c> variable): shared runners are slow, and a solution-wide
+    /// <c>dotnet test</c> runs the suites in parallel, so an un-slacked budget there measures
+    /// contention rather than the code and fails at random.
+    /// </summary>
+    internal const double CiSlack = 4.0;
+
+    public static readonly double Slack = ResolveSlack(
+        Environment.GetEnvironmentVariable("PDF_EDITOR_PERF_SLACK"),
+        IsCi(Environment.GetEnvironmentVariable("CI")));
+
+    /// <summary>
+    /// Pure slack resolution, split out from the ambient environment so every branch is testable:
+    /// a valid positive <paramref name="envValue"/> wins outright, otherwise CI gets
+    /// <see cref="CiSlack"/> and a local run stays strict at 1.0.
+    /// </summary>
+    internal static double ResolveSlack(string? envValue, bool isCi) =>
+        double.TryParse(envValue, out var s) && s > 0 ? s : isCi ? CiSlack : 1.0;
+
+    /// <summary>True on the common CI providers, which all set <c>CI</c> to a truthy value.</summary>
+    internal static bool IsCi(string? ci) =>
+        !string.IsNullOrEmpty(ci) &&
+        !ci.Equals("false", StringComparison.OrdinalIgnoreCase) &&
+        !ci.Equals("0", StringComparison.Ordinal);
 
     /// <summary>Builds a <paramref name="pages"/>-page PDF with ~<paramref name="wordsPerPage"/> words each.</summary>
     public static byte[] Doc(int pages, int wordsPerPage = 14)

--- a/tests/PdfEditor.Perf.Tests/PerfHarnessTests.cs
+++ b/tests/PdfEditor.Perf.Tests/PerfHarnessTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace PdfEditor.Perf.Tests;
+
+/// <summary>
+/// Guards how the budget multiplier is chosen. These are plain logic tests (no timing), so they
+/// never flake — they exist because getting this wrong is exactly what made the performance guards
+/// fail at random in solution-wide CI runs, where the suites compete for a shared runner.
+/// </summary>
+public class PerfHarnessTests
+{
+    [Theory]
+    [InlineData("2", 2.0)]      // explicit override wins...
+    [InlineData("0.5", 0.5)]    // ...including a stricter-than-default one
+    [InlineData("3", 3.0)]      // what ci.yml's dedicated perf job sets
+    public void ExplicitSlack_AlwaysWins(string env, double expected)
+    {
+        Assert.Equal(expected, PerfHarness.ResolveSlack(env, isCi: true));
+        Assert.Equal(expected, PerfHarness.ResolveSlack(env, isCi: false));
+    }
+
+    [Theory]
+    [InlineData(null)]      // variable not set at all
+    [InlineData("")]        // set but empty
+    [InlineData("abc")]     // unparseable
+    [InlineData("0")]       // non-positive: would zero out every budget
+    [InlineData("-1")]
+    public void WithoutAUsableOverride_CiIsRelaxed_AndLocalStaysStrict(string? env)
+    {
+        Assert.Equal(PerfHarness.CiSlack, PerfHarness.ResolveSlack(env, isCi: true));
+        Assert.Equal(1.0, PerfHarness.ResolveSlack(env, isCi: false));
+    }
+
+    [Fact]
+    public void CiSlack_ActuallyRelaxesTheBudgets()
+    {
+        Assert.True(PerfHarness.CiSlack > 1.0, "a CI default that doesn't relax anything is pointless");
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("1")]
+    [InlineData("True")]
+    public void CiIsDetected_FromTruthyValues(string value) => Assert.True(PerfHarness.IsCi(value));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("false")]
+    [InlineData("False")]
+    [InlineData("0")]
+    public void CiIsNotDetected_WhenUnsetOrFalsey(string? value) => Assert.False(PerfHarness.IsCi(value));
+}


### PR DESCRIPTION
Fixes the intermittent `Test Run Failed. Total tests: 12, Passed: 11, Failed: 1` in the pipeline.

## The cause

`release-candidate.yml` and `release-extension.yml` run a solution-wide `dotnet test`, which pulls in the timing-based performance guards. That run differs from the dedicated `perf` job in two ways that matter:

1. It never sets `PDF_EDITOR_PERF_SLACK`, so every budget stays at the strict local `1.0`.
2. It executes all four test projects **in parallel** on a shared two-core runner.

The budgets then measure runner contention rather than the code, and one of the twelve guards fails at random. The reported log confirms which invocation it was: the failing project is built from `PdfEditor.sln` under the `VSTest` target with the other three suites running concurrently — that is the release workflows' command, not the `perf` job's.

## The fix

**Release workflows exclude the timing guards** with `--filter "Category!=Performance"`. Performance is already gated by the dedicated `perf` job in `ci.yml` (slack `3`, nothing competing for the runner), and a release should never be blocked by a timing flake. The guards already carry the `Performance` trait, so nothing else is affected.

**`PerfHarness` defaults the slack to `4.0` when it detects a CI runner** (the standard `CI` variable) instead of `1.0`, so any workflow that does run the guards gets sane budgets without having to remember the env var. An explicit `PDF_EDITOR_PERF_SLACK` still wins.

The slack resolution is now a pure function over `(envValue, isCi)`, so all of its branches are covered by fast, deterministic tests — including that a non-positive or unparseable override never silently zeroes out a budget. Those new tests deliberately carry **no** `Performance` trait, so they run everywhere.

## Verification

| Path | Result |
| --- | --- |
| Dedicated `perf` job (`PDF_EDITOR_PERF_SLACK=3`) | 29/29 pass |
| Release workflows (`--filter "Category!=Performance"`) | 371 pass, timing guards excluded, exit `0` |
| Coverage gate (`./scripts/coverage.sh 90`) | 91.7% ≥ 90% |

The filter leaves the perf project reporting its 17 logic tests rather than "no test matches", so the exit code stays `0`.

## Note on the branch

PR #15 was squash-merged into `main` while this work was in progress, so this branch was restarted from the latest `main` and carries only this change.
