### PR TITLE
Add action plan for resolving open GitHub issues

### DIFF
--- a/.claude/agents/issue-resolver.md
+++ b/.claude/agents/issue-resolver.md
@@ -1,0 +1,50 @@
+---
+name: issue-resolver
+description: Picks up a single GitHub issue from this repo's backlog (see ACTION_PLAN.md), implements a scoped fix on a correctly-named branch, and opens a draft PR. Use when asked to work on a specific issue number from the backlog, e.g. "use issue-resolver on #18" or "pick up the next Tier 0 issue".
+tools: Read, Edit, Write, Glob, Grep, Bash
+model: inherit
+---
+
+You resolve exactly one GitHub issue (or one tightly-coupled pair, if the task
+explicitly names both) from this repository's backlog. Do not expand scope beyond
+what's needed for that issue.
+
+## Before writing code
+
+1. Read `ACTION_PLAN.md` to find the issue's tier, its stated dependencies, and
+   which other issues it's grouped with. If the issue depends on work that isn't
+   merged yet (check `git log`/open PRs), stop and report the blocker instead of
+   working around it.
+2. Fetch the live issue (title, body, comments) — don't rely solely on the summary
+   in ACTION_PLAN.md, which may be stale.
+3. Reproduce the bug or confirm the missing behavior before changing code. For UI/
+   rendering issues, actually run the app if a run/dev-server skill is available;
+   don't assume a fix works from reading code alone.
+
+## Doing the work
+
+- Branch name: `claude/issue-<number>-<short-slug>`.
+- Make the smallest correct change that resolves the issue. Don't refactor
+  unrelated code, don't fix unrelated bugs you notice along the way (file a note
+  instead), and don't add speculative configuration options beyond what the issue
+  asks for.
+- Add or update tests that would fail without your fix. If the issue is in a
+  subsystem covered by the golden-file or fuzz regression suites (#53/#54), extend
+  those rather than writing a one-off test.
+- Run the existing test suite before committing.
+
+## Finishing
+
+- Commit with a message describing why, not just what.
+- Push to `origin/<branch-name>`.
+- Open a **draft** PR titled after the issue, with `Fixes #<number>` in the body,
+  a summary of the change, and a test plan. Check for a PR template first.
+- If you could not fully resolve the issue (needs a product decision, blocked on
+  another unmerged issue, etc.), do not open a PR claiming completion — instead
+  report back exactly what's blocking it.
+
+## What not to do
+
+- Don't touch issues outside the one you were asked to resolve.
+- Don't merge your own PR or force-push over review feedback.
+- Don't mark an issue's fix "done" without a passing test that demonstrates it.

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,0 +1,157 @@
+# GitHub Issues Action Plan
+
+This document reviews all 40 currently open issues in this repository and groups them
+into a sequenced action plan. Issues are organized by theme, with a recommended
+priority tier per group. Priority favors: (1) correctness bugs affecting core
+functionality, (2) quick, high-impact fixes, (3) foundational work that unblocks
+other enhancements, and (4) larger feature/quality investments.
+
+_Generated 2026-07-28. Source: 40 open issues (#17–#56) on `zanattamichael/chromium-pdf-editor`._
+
+## Tier 0 — Critical correctness bugs (fix first)
+
+These break core, everyday functionality and should be fixed before new features are
+layered on top.
+
+- **#18 — JavaScript is not being executed within documents**: Buttons/JS in PDFs are
+  inert. Blocks #22 (form JS notifications) and #43 (form event/timing correctness).
+- **#20 — JPEG documents break during OCR parsing**: Image becomes unviewable after
+  OCR. Likely an image-decoding/re-encoding bug in the OCR pipeline.
+- **#21 — OCR results are zoomed in**: Coordinate/scale mismatch between the OCR
+  render pass and the display/overlay pass.
+- **#24 — Links side menu doesn't refresh on new document load**: Stale state bug;
+  likely a missing reset in the document-load lifecycle.
+- **#22 — Form JavaScript notification doesn't notify**: Related to #18; once JS
+  execution works, wire up the notification path.
+
+**Recommended order:** #18 → #22 → #20 → #21 → #24 (the first two are related JS-engine
+work; #20/#21 are both in the OCR image pipeline and can be fixed together; #24 is
+independent and small).
+
+## Tier 1 — High-impact UX bugs
+
+- **#23 — Highlighting is still box-drawing, not click-and-drag**: UX regression vs.
+  expected annotation behavior.
+- **#17 — Forms Menu Redesign**: Modernize to an overlay toolbar (mockups provided in
+  issue). Tagged bug+enhancement — treat as UI bug since current menu is described as
+  broken/dated.
+- **#29 — Text edits don't match existing font size/type**: Core editing fidelity bug,
+  directly related to Tier 3 font work (#28, #34, #35).
+
+## Tier 2 — Foundational/infrastructure (unblocks later work)
+
+- **#56 — Resolve all SonarCube issues flagged in build pipeline**: Pure code-quality
+  debt; do incrementally, but don't let it block feature work. Recommend splitting
+  into sub-issues by rule category (bugs vs. code smells vs. security hotspots) and
+  burning down in small PRs so review stays tractable.
+- **#19 — Async link parser + loading indicator**: Performance fix that also makes the
+  UI usable on link-heavy PDFs; pairs naturally with the #24 stale-state fix (same
+  subsystem).
+- **#52 — Export pipeline validation (post-export checks)**: A validation/diagnostics
+  step that will make every other export-affecting change (redaction, flattening,
+  watermarking, font handling) easier to verify and safer to ship.
+- **#53 — Golden-file regression suite** and **#54 — Fuzz/regression testing for
+  parser robustness**: Testing infrastructure. Stand these up early since nearly every
+  other issue below (rendering, redaction, forms, fonts) benefits from a regression
+  safety net before it's touched.
+
+**Recommended order:** #52 and #53/#54 first (safety net), then #56 (quality) and #19.
+
+## Tier 3 — Text & font fidelity
+
+- **#28 — Expand text editing fonts**
+- **#34 — Embedded font preservation mode**
+- **#35 — Font diagnostics UI** (why-substituted tooltip)
+- **#32 — Improved semantic text model** (ligatures, multi-run spans, rotated text)
+- **#33 — Reflow/line wrapping inside edit boxes**
+- **#31 — True caret/cursor editing**
+- **#29** (Tier 1, but logically part of this group)
+
+**Recommended order:** #29 → #28 → #34 → #35 → #32 → #33 → #31. Font-size/type
+matching and font expansion are quick wins; the semantic text model (#32) is a
+prerequisite for reliable reflow (#33) and caret editing (#31), which are the largest
+efforts in the whole backlog.
+
+## Tier 4 — Rendering & geometry correctness
+
+- **#36 — Deterministic preview/export parity**
+- **#37 — Transparency & blend mode preservation**
+- **#38 — Clipping paths + crop box/rotation handling**
+- **#39 — Deeper Form XObject support for editing**
+- **#40 — Robust hit-testing on transformed/zoomed pages**
+- **#45 — Accessibility/structure preservation (tagged PDF tree)**
+
+These are interrelated rendering-engine correctness issues. Recommend tackling
+**#36 first** (establishes a single source of truth for render parity/testing, which
+makes the rest verifiable), then #38 and #40 together (geometry/hit-testing share
+transform math), then #37 and #39, with #45 last since it depends on edits/redaction
+not breaking structure once the others are stable.
+
+## Tier 5 — Forms
+
+- **#42 — Form field appearance regeneration across viewers**
+- **#43 — Radio groups + event/timing correctness** (depends on #18 JS fix)
+- **#44 — Flattening modes: granular controls**
+- **#17** (Tier 1, forms menu UI, listed here for subsystem grouping)
+
+**Recommended order:** #42 → #43 (needs #18) → #44.
+
+## Tier 6 — Redaction & compliance
+
+- **#48 — Auditable redaction report**
+- **#49 — Redaction recovery-resistance guarantees (tests/verification)**
+- **#51 — Undo/redo cross-operation atomicity**
+
+Do #49 before shipping #48's "redaction complete" messaging — an audit report is only
+trustworthy once recovery-resistance is verified. #51 (undo/redo atomicity) is
+higher-risk correctness work that benefits from the regression suite (Tier 2) being in
+place first.
+
+## Tier 7 — Diff / review tooling
+
+- **#46 — Visual (pixel) diff mode**
+- **#47 — Diff UX: click hotspots to navigate to changes**
+
+**Recommended order:** #46 → #47 (navigation needs the diff surface to exist first).
+
+## Tier 8 — Performance & platform
+
+- **#50 — Cancellation + progressive processing for long operations** (OCR, signing,
+  large merges)
+
+## Tier 9 — New capabilities (larger features, schedule after above)
+
+- **#25 — Remove encryption from a document**
+- **#26 — Open image files natively / combine images into a PDF via OCR**
+- **#27 — Bates numbering**
+- **#30 — Watermarking (tamper-resistant)**
+- **#41 — Annotation appearance stream controls** (color/opacity/stroke/border/stamp)
+- **#55 — HEIC image support** (pairs naturally with #26)
+
+These are self-contained feature additions with few cross-dependencies; sequence by
+business priority once Tiers 0–8 are stable. #55 should be scheduled alongside #26
+since both touch the same image-import pipeline.
+
+## Suggested execution order (summary)
+
+1. **Stabilize**: #18, #22, #20, #21, #24, #23
+2. **Safety net**: #52, #53, #54, #56, #19
+3. **Text/font fidelity**: #29, #28, #34, #35, #32, #33, #31
+4. **Rendering/geometry**: #36, #38, #40, #37, #39, #45
+5. **Forms**: #42, #43, #44, #17
+6. **Redaction/undo**: #49, #48, #51
+7. **Diff tooling**: #46, #47
+8. **Performance**: #50
+9. **New features**: #25, #26, #55, #27, #30, #41
+
+## Notes on process
+
+- Several issues (#56 SonarCube, #53/#54 testing) are best split into smaller
+  sub-issues/PRs rather than resolved in one large change, to keep review scope
+  manageable and avoid regressions.
+- Tiers 3–7 share underlying subsystems (text model, rendering transforms, forms
+  pipeline); within each tier the issues should ideally be picked up by whoever last
+  touched that subsystem to minimize context-switching.
+- No issues are currently duplicates of each other, though #17 and #23 both touch
+  annotation/menu UX and could be scoped into a single "annotation toolbar" effort if
+  desired.

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -1,0 +1,98 @@
+# Claude Code Agent Plan — Working the Issue Backlog
+
+This describes how to use Claude Code sessions/agents to execute the tiers defined in
+`ACTION_PLAN.md`. It covers sequencing, session scoping, branch/PR strategy, and
+review checkpoints so multiple issues can be worked through safely and in parallel
+where dependencies allow.
+
+## Principles
+
+- **One issue (or tightly-coupled pair) per session/branch.** Keep diffs reviewable
+  and bisectable. Don't let a session wander into unrelated tiers.
+- **Respect the dependency order in `ACTION_PLAN.md`.** Don't start Tier 3+ work
+  until the Tier 0 stabilization bugs and Tier 2 safety net (tests, export
+  validation) are merged — later tiers assume those exist.
+- **Draft PR per issue, referencing the issue number.** Branch name convention:
+  `claude/issue-<n>-<short-slug>` (e.g. `claude/issue-18-js-execution`).
+- **A session should end with either a pushed fix + draft PR, or a written note on
+  why the issue is blocked** (e.g. needs a product decision) — never silently drop it.
+
+## Sequencing (mirrors ACTION_PLAN.md tiers)
+
+### Phase 1 — Stabilize (serial, high care)
+Run one session at a time; each of these touches core pipelines and later phases
+depend on them being correct.
+1. #18 JS execution engine → #22 form JS notification (same session, since #22 is
+   trivial once #18 lands)
+2. #20 JPEG/OCR image corruption → #21 OCR zoom (same subsystem, one session)
+3. #24 links menu stale state (independent, can run in parallel with 1–2)
+4. #23 highlight click-and-drag (independent, can run in parallel)
+
+### Phase 2 — Safety net (can parallelize across sessions)
+5. #53 golden-file regression suite
+6. #54 fuzz/regression testing
+7. #52 export pipeline validation
+8. #19 async link parser + loading indicator
+9. #56 SonarCube cleanup — split into 2–3 sub-PRs by rule category (bugs, code
+   smells, security hotspots); run as background/low-priority sessions since it's
+   pure debt paydown, not urgent.
+
+Do not start Phase 3 until #52–#54 are merged — they're the regression net every
+later phase should run against.
+
+### Phase 3 — Text & font fidelity (serial within phase; shared subsystem)
+10. #29 → #28 → #34 → #35 → #32 → #33 → #31
+    Run these as one continuous thread of sessions (same branch lineage or stacked
+    PRs) since each builds on the semantic text model introduced by #32.
+
+### Phase 4 — Rendering & geometry (pair up related issues per session)
+11. #36 (preview/export parity) — do first, establishes verification harness
+12. #38 + #40 (clipping/crop-box + hit-testing) — one session, shared transform math
+13. #37 (transparency/blend modes)
+14. #39 (nested Form XObjects)
+15. #45 (accessibility/structure preservation) — last, depends on 11–14 being stable
+
+### Phase 5 — Forms (serial)
+16. #42 → #43 → #44 → #17
+
+### Phase 6 — Redaction & undo (serial, high care — security-sensitive)
+17. #49 (recovery-resistance verification) before #48 (audit report) — don't report
+    "redacted" until recovery-resistance is proven
+18. #51 (undo/redo atomicity)
+
+### Phase 7 — Diff tooling
+19. #46 → #47
+
+### Phase 8 — Performance
+20. #50 (cancellation + progressive processing)
+
+### Phase 9 — New features (parallelizable, low coupling)
+21. #25, #26 (+ #55 HEIC alongside #26), #27, #30, #41 — any order, can run several
+    sessions concurrently since they don't share subsystems with each other.
+
+## Running it with Claude Code
+
+For each issue:
+1. Start a session (or spawn a subagent — see `issue-resolver` below) with a prompt
+   that includes: the issue number/title/body, the relevant ACTION_PLAN.md tier
+   context, and the target branch name.
+2. The session should: reproduce the bug/confirm the gap, implement the fix, add/
+   update tests, run the existing test suite, commit, push, and open a draft PR
+   linking the issue (`Fixes #<n>`).
+3. Human review gate: PRs from Phase 1 and Phase 6 (security-sensitive) get a manual
+   review before merge; later phases can use lighter review if CI is green and the
+   regression suite (Phase 2) passes.
+
+### Parallelism guidance
+- Within a phase marked "independent" or "parallelizable" above, multiple sessions
+  can run concurrently.
+- Across phases, respect the dependency arrows — e.g. don't parallelize Phase 3 work
+  with Phase 1, since Phase 3's font-size fix (#29) assumes JS/OCR pipelines aren't
+  simultaneously changing underneath it.
+
+### Subagent
+A repo-specific subagent (`.claude/agents/issue-resolver.md`) is provided to
+standardize how any session picks up a single issue from this plan: it reads the
+issue, checks `ACTION_PLAN.md` for context/dependencies, implements the fix on a
+correctly-named branch, and opens a draft PR. Invoke it per-issue rather than
+re-deriving this process from scratch each time.


### PR DESCRIPTION
## Summary
- Reviewed all 40 open issues (#17–#56) and grouped them into a sequenced action plan by theme and priority
- Adds `ACTION_PLAN.md` with tiers: critical bugs, UX bugs, foundational/testing infra, text/font fidelity, rendering/geometry, forms, redaction, diff tooling, performance, and new features
- Includes a suggested overall execution order and notes on issue dependencies (e.g. #18 blocks #22/#43, #52-#54 should land before touching redaction/rendering code)

## Test plan
- N/A — documentation-only change, no code affected

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_