### PR TITLE
Interactive form fields on the page, with working field JavaScript (#18, #22)

### DIFF
--- a/e2e/helpers/pdf.js
+++ b/e2e/helpers/pdf.js
@@ -118,6 +118,34 @@ function buildFormPdf(fieldName = 'fullName', value = '') {
   ]);
 }
 
+/**
+ * A single-page AcroForm with two number text fields ("a", "b"), an empty "total" text field, and
+ * a push-button field whose click action runs a calculation script summing "a" and "b" into
+ * "total". Regression fixture for the viewer's in-panel button-script simulation (#18): the
+ * button carries real PDF JavaScript, and clicking its "Run" control in the Forms panel should
+ * update "total" without a round trip to Acrobat/Chrome.
+ */
+function buildFormWithButtonScriptPdf(script) {
+  const calc = script ??
+    'this.getField("total").value = this.getField("a").value + this.getField("b").value;';
+  return assemble([
+    `<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [5 0 R 6 0 R 7 0 R 8 0 R] ` +
+      `/DA (/Helv 0 Tf 0 g) /NeedAppearances true >> >>`, // 1
+    `<< /Type /Pages /Kids [3 0 R] /Count 1 >>`, // 2
+    `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Annots [5 0 R 6 0 R 7 0 R 8 0 R] ` +
+      `/Resources << /Font << /Helv 4 0 R >> >> >>`, // 3
+    `<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>`, // 4
+    `<< /FT /Tx /T (a) /V (2) /Type /Annot /Subtype /Widget ` +
+      `/Rect [100 700 180 724] /P 3 0 R /DA (/Helv 12 Tf 0 g) >>`, // 5
+    `<< /FT /Tx /T (b) /V (3) /Type /Annot /Subtype /Widget ` +
+      `/Rect [200 700 280 724] /P 3 0 R /DA (/Helv 12 Tf 0 g) >>`, // 6
+    `<< /FT /Tx /T (total) /V () /Type /Annot /Subtype /Widget ` +
+      `/Rect [300 700 380 724] /P 3 0 R /DA (/Helv 12 Tf 0 g) >>`, // 7
+    `<< /FT /Btn /Ff 65536 /T (calc) /Type /Annot /Subtype /Widget /MK << /CA (Calculate) >> ` +
+      `/Rect [400 700 480 724] /P 3 0 R /DA (/Helv 12 Tf 0 g) /A << /S /JavaScript /JS (${calc}) >> >>`, // 8
+  ]);
+}
+
 /** A single-page document that runs JavaScript on open (document-level active content). */
 function buildJavaScriptPdf(script = "app.alert('hello from the pdf');") {
   const content = 'BT /F1 18 Tf 72 700 Td (Has script) Tj ET';
@@ -192,6 +220,6 @@ function buildJsLinkPdf(script = 'window.close();') {
 }
 
 module.exports = {
-  buildPdf, buildLeftoverCtmPdf, buildFormPdf, buildJavaScriptPdf, buildLinkPdf, buildJsLinkPdf,
-  buildLinkOnPage2Pdf, buildLinkOverTextPdf,
+  buildPdf, buildLeftoverCtmPdf, buildFormPdf, buildFormWithButtonScriptPdf, buildJavaScriptPdf,
+  buildLinkPdf, buildJsLinkPdf, buildLinkOnPage2Pdf, buildLinkOverTextPdf,
 };

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1299,13 +1299,14 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     const page = await openViewerWith(file);
 
     await ui(page, '#btn-forms');
-    // The button-only rows must be hidden for other field types -- a `hidden` label that CSS
-    // still renders would offer a "JavaScript to run on click" box on e.g. a checkbox, whose
-    // contents beginPlaceField() then silently discards.
+    // Type-specific rows must actually respond to the selected type -- these assertions only mean
+    // something because [hidden] is now authoritative in CSS; a `label { display: block }` rule
+    // used to render every one of them regardless, which is how a checkbox ended up offering a
+    // script box whose contents were then silently discarded.
     await page.selectOption('#field-type', 'checkbox');
-    await expect(page.locator('#field-caption-row')).toBeHidden();
-    await expect(page.locator('#field-script-row')).toBeHidden();
+    await expect(page.locator('#field-caption-row')).toBeHidden(); // only a button has a label
     await expect(page.locator('#field-options-row')).toBeHidden();
+    await expect(page.locator('#field-script-row')).toBeVisible(); // any field can carry a script
 
     await page.selectOption('#field-type', 'button');
     await expect(page.locator('#field-caption-row')).toBeVisible();
@@ -1342,6 +1343,30 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
       return nonWhite;
     });
     expect(drawn).toBeGreaterThan(0);
+    await page.close();
+  });
+
+  test('forms: a checkbox can carry JavaScript too, and it survives the save', async () => {
+    // Regression for the reported bug: the script box was offered on every field type but
+    // beginPlaceField() only forwarded it for buttons, so a checkbox's script was silently
+    // dropped -- the saved PDF had no /A and no /AA at all.
+    const file = fixture('checkboxjs.pdf', [[{ text: 'form', x: 72, y: 100 }]]);
+    const page = await openViewerWith(file);
+
+    await ui(page, '#btn-forms');
+    await page.selectOption('#field-type', 'checkbox');
+    await expect(page.locator('#field-script-row')).toBeVisible();
+    await page.fill('#field-name', 'agree');
+    await page.fill('#field-script', "this.getField('agree').value = 'Yes';");
+    await page.click('#field-place');
+    await dragPdfRect(page, { x: 100, y: 600, width: 20, height: 20 });
+
+    // It is listed, it kept its script (so it gets a Run control), and the document is now
+    // flagged as carrying active content.
+    const row = page.locator('.form-field[data-field-name="agree"]');
+    await expect(row).toHaveCount(1);
+    await expect(row.locator('.form-field-run')).toHaveCount(1);
+    await expect(page.locator('#badges .badge.warn')).toContainText('kept');
     await page.close();
   });
 

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -492,6 +492,25 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('safety: opening a form whose field carries JavaScript raises the warning badge', async () => {
+    // Field-level scripts live on a widget annotation's /A, not in the document-level name tree
+    // or /OpenAction -- so this covers a path the document-script test above does not.
+    const file = path.join(fixtureDir, 'formjs.pdf');
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf("app.alert('FORM_FIELD_MARKER_456');"));
+    const page = await openViewerWith(file);
+
+    const badge = page.locator('#badges .badge.warn', { hasText: 'JavaScript' });
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('disabled');
+
+    // ...and the details dialog names the field's actual script, not a generic notice.
+    await badge.click();
+    const dialog = page.locator('dialog#modal');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator('.safety-samples')).toContainText('FORM_FIELD_MARKER_456');
+    await page.close();
+  });
+
   test('safety: JavaScript is detected, flagged with its source, and stripped by default', async () => {
     const file = path.join(fixtureDir, 'hasjs.pdf');
     fs.writeFileSync(file, buildJavaScriptPdf("app.alert('DISTINCTIVE_MARKER_123');"));
@@ -1280,9 +1299,18 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     const page = await openViewerWith(file);
 
     await ui(page, '#btn-forms');
+    // The button-only rows must be hidden for other field types -- a `hidden` label that CSS
+    // still renders would offer a "JavaScript to run on click" box on e.g. a checkbox, whose
+    // contents beginPlaceField() then silently discards.
+    await page.selectOption('#field-type', 'checkbox');
+    await expect(page.locator('#field-caption-row')).toBeHidden();
+    await expect(page.locator('#field-script-row')).toBeHidden();
+    await expect(page.locator('#field-options-row')).toBeHidden();
+
     await page.selectOption('#field-type', 'button');
     await expect(page.locator('#field-caption-row')).toBeVisible();
     await expect(page.locator('#field-script-row')).toBeVisible();
+    await expect(page.locator('#field-options-row')).toBeHidden();
     await page.fill('#field-name', 'submitBtn');
     await page.fill('#field-caption', 'Submit');
     await page.fill('#field-script', "app.alert('submitted');");
@@ -1294,6 +1322,26 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // The button is listed as a form field, and the script it carries is kept on save.
     await expect(page.locator('.form-field[data-field-name="submitBtn"]')).toHaveCount(1);
     await expect(page.locator('#badges .badge.warn')).toContainText('kept');
+
+    // ...and it is actually drawn on the page. A widget with no /AP appearance stream renders
+    // as blank space in PDFium (the preview) and in most readers, so the button would be
+    // invisible and unclickable even though it exists in the document.
+    const drawn = await page.evaluate(async () => {
+      const img = document.querySelector('.page[data-page="1"] .page-image');
+      await img.decode();
+      const c = document.createElement('canvas');
+      c.width = img.naturalWidth; c.height = img.naturalHeight;
+      const ctx = c.getContext('2d'); ctx.drawImage(img, 0, 0);
+      const s = img.naturalWidth / 595;
+      let nonWhite = 0;
+      for (let py = 600; py <= 628; py++)
+        for (let px = 100; px <= 220; px++) {
+          const d = ctx.getImageData(Math.round(px * s), Math.round((842 - py) * s), 1, 1).data;
+          if (!(d[0] > 248 && d[1] > 248 && d[2] > 248)) nonWhite++;
+        }
+      return nonWhite;
+    });
+    expect(drawn).toBeGreaterThan(0);
     await page.close();
   });
 

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -6,8 +6,8 @@ const os = require('node:os');
 const path = require('node:path');
 const { launchExtension } = require('../helpers/harness');
 const {
-  buildPdf, buildLeftoverCtmPdf, buildFormPdf, buildJavaScriptPdf, buildLinkPdf, buildJsLinkPdf,
-  buildLinkOnPage2Pdf, buildLinkOverTextPdf,
+  buildPdf, buildLeftoverCtmPdf, buildFormPdf, buildFormWithButtonScriptPdf, buildJavaScriptPdf,
+  buildLinkPdf, buildJsLinkPdf, buildLinkOnPage2Pdf, buildLinkOverTextPdf,
 } = require('../helpers/pdf');
 
 /** @type {Awaited<ReturnType<typeof launchExtension>>} */
@@ -440,6 +440,55 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
 
     // The forms panel reopens and lists the newly inserted field.
     await expect(page.locator('#forms-list [data-field="signature_name"]')).toHaveCount(1);
+    await page.close();
+  });
+
+  test('forms: clicking a button simulates its calculation script (#18)', async () => {
+    const file = path.join(fixtureDir, 'button-calc.pdf');
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf());
+    const page = await openViewerWith(file);
+
+    await ui(page, '#btn-forms');
+    await expect(page.locator('#panel-forms')).toBeVisible();
+    await expect(page.locator('#forms-list [data-field="a"]')).toHaveValue('2');
+    await expect(page.locator('#forms-list [data-field="b"]')).toHaveValue('3');
+
+    // Edit the inputs, then run the button's script — it should read the live panel values.
+    await page.locator('#forms-list [data-field="a"]').fill('10');
+    await page.locator('#forms-list [data-field="b"]').fill('5');
+    await page.locator('.form-field[data-field-name="calc"] .form-field-run').click();
+
+    await expect(page.locator('#forms-list [data-field="total"]')).toHaveValue('15');
+    await expect(page.locator('#status')).toContainText('Ran "calc"');
+    await page.close();
+  });
+
+  test('forms: a button script outside the supported grammar is reported, not silently ignored (#18/#22)', async () => {
+    const file = path.join(fixtureDir, 'button-unsupported.pdf');
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf("app.alert('hi');"));
+    const page = await openViewerWith(file);
+
+    await ui(page, '#btn-forms');
+    await page.locator('.form-field[data-field-name="calc"] .form-field-run').click();
+
+    await expect(page.locator('#status')).toContainText("can't simulate");
+    await expect(page.locator('#forms-list [data-field="total"]')).toHaveValue('');
+    await page.close();
+  });
+
+  test('forms: adding a scripted button notifies that its JavaScript will be kept (#22)', async () => {
+    const file = fixture('insertbutton.pdf', [[{ text: 'blank form', x: 72, y: 100 }]]);
+    const page = await openViewerWith(file);
+
+    await ui(page, '#btn-forms');
+    await page.selectOption('#field-type', 'button');
+    await page.fill('#field-name', 'go');
+    await page.fill('#field-caption', 'Go');
+    await page.fill('#field-script', "app.alert('hi');");
+    await page.click('#field-place');
+    await dragPdfRect(page, { x: 100, y: 600, width: 90, height: 24 });
+
+    await expect(page.locator('#status')).toContainText('JavaScript will be kept');
     await page.close();
   });
 

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1292,7 +1292,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await dragPdfRect(page, { x: 100, y: 600, width: 120, height: 28 });
 
     // The button is listed as a form field, and the script it carries is kept on save.
-    await expect(page.locator('#forms-list [data-field="submitBtn"]')).toHaveCount(1);
+    await expect(page.locator('.form-field[data-field-name="submitBtn"]')).toHaveCount(1);
     await expect(page.locator('#badges .badge.warn')).toContainText('kept');
     await page.close();
   });

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -463,9 +463,58 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('forms: fields are fillable directly on the page and stay in sync with the panel', async () => {
+    const file = path.join(fixtureDir, 'onpage.pdf');
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf());
+    const page = await openViewerWith(file);
+
+    // Type into the field where it sits on the page, not in the side panel.
+    const onPage = page.locator('.field-marker [data-page-field="a"]');
+    await expect(onPage).toHaveCount(1);
+    await onPage.fill('42');
+
+    // The panel reflects it...
+    await ui(page, '#btn-forms');
+    await expect(page.locator('#forms-list [data-field="a"]')).toHaveValue('42');
+    // ...and editing the panel flows back to the page.
+    await page.locator('#forms-list [data-field="a"]').fill('7');
+    await expect(onPage).toHaveValue('7');
+    await page.close();
+  });
+
+  test('forms: clicking a scripted button on the page runs it', async () => {
+    const file = path.join(fixtureDir, 'onpage-btn.pdf');
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf());
+    const page = await openViewerWith(file);
+
+    await page.locator('.field-marker [data-page-field="a"]').fill('10');
+    await page.locator('.field-marker [data-page-field="b"]').fill('5');
+    await page.locator('.field-marker .field-input-button').click();
+
+    await expect(page.locator('.field-marker [data-page-field="total"]')).toHaveValue('15');
+    await page.close();
+  });
+
+  test('forms: an app.alert button shows the message like a real reader', async () => {
+    const file = path.join(fixtureDir, 'button-alert.pdf');
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf("app.alert('thanks!');"));
+    const page = await openViewerWith(file);
+
+    await ui(page, '#btn-forms');
+    await page.locator('.form-field[data-field-name="calc"] .form-field-run').click();
+
+    const dialog = page.locator('dialog#modal');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('thanks!');
+    await dialog.getByRole('button', { name: 'OK' }).click();
+    await expect(dialog).toBeHidden();
+    await page.close();
+  });
+
   test('forms: a button script outside the supported grammar is reported, not silently ignored (#18/#22)', async () => {
     const file = path.join(fixtureDir, 'button-unsupported.pdf');
-    fs.writeFileSync(file, buildFormWithButtonScriptPdf("app.alert('hi');"));
+    // Deliberately outside the grammar: a submit call, not something the viewer can stand in for.
+    fs.writeFileSync(file, buildFormWithButtonScriptPdf("this.submitForm('https://example.com');"));
     const page = await openViewerWith(file);
 
     await ui(page, '#btn-forms');

--- a/extension/src/formScript.js
+++ b/extension/src/formScript.js
@@ -1,0 +1,149 @@
+// A deliberately tiny, safe interpreter for the handful of Acrobat-style JavaScript patterns that
+// show up on ordinary form "Calculate" / "Reset" / "show-hide" buttons — NOT a JavaScript engine.
+// The viewer otherwise only rasterises pages (see PdfSafety.cs / JavaScriptTool.cs), so a full
+// engine is out of scope; this covers the common, safe subset instead of leaving buttons dead:
+//   this.getField("Total").value = this.getField("A").value + this.getField("B").value;
+//   this.getField("Extra").display = display.hidden;   // or display.visible
+//   this.resetForm();
+// Anything outside that grammar (conditionals, loops, app.alert, string concatenation, calls to
+// user-defined functions, …) is reported as unsupported rather than partially executed — we never
+// want to silently do half of what a script asked for, and we never `eval`/`Function` PDF content.
+
+const FIELD_REF = /this\s*\.\s*getField\(\s*(["'])((?:(?!\1).)*)\1\s*\)\s*\.\s*value/g;
+const SET_STATEMENT =
+  /^this\s*\.\s*getField\(\s*(["'])((?:(?!\1).)*)\1\s*\)\s*\.\s*value\s*=\s*(.+)$/;
+const DISPLAY_STATEMENT =
+  /^this\s*\.\s*getField\(\s*(["'])((?:(?!\1).)*)\1\s*\)\s*\.\s*display\s*=\s*display\s*\.\s*(hidden|visible)$/;
+const RESET_STATEMENT = /^this\s*\.\s*resetForm\(\s*\)$/;
+
+/**
+ * Runs the given field-click script against the current field values.
+ *
+ * @param {string} script - the raw JavaScript source from the button's /A action.
+ * @param {(name: string) => string} getValue - reads a field's current (string) value.
+ * @returns {{ok: true, sets: {name: string, value: string}[], display: {name: string, hidden: boolean}[], reset: boolean} | {ok: false}}
+ *   `ok: false` means the script wasn't (fully) recognised — the caller should tell the user it
+ *   needs a real PDF viewer rather than silently doing nothing or half-applying it.
+ */
+function runFormScript(script, getValue) {
+  const statements = String(script ?? '')
+    .split(';')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (statements.length === 0) return { ok: false };
+
+  const sets = [];
+  const display = [];
+  let reset = false;
+
+  for (const statement of statements) {
+    if (RESET_STATEMENT.test(statement)) {
+      reset = true;
+      continue;
+    }
+
+    const displayMatch = DISPLAY_STATEMENT.exec(statement);
+    if (displayMatch) {
+      display.push({ name: displayMatch[2], hidden: displayMatch[3] === 'hidden' });
+      continue;
+    }
+
+    const setMatch = SET_STATEMENT.exec(statement);
+    if (setMatch) {
+      const value = evaluateExpression(setMatch[3], getValue);
+      if (value === undefined) return { ok: false };
+      sets.push({ name: setMatch[2], value: String(value) });
+      continue;
+    }
+
+    return { ok: false }; // an unrecognised statement — don't half-run the script
+  }
+  return { ok: true, sets, display, reset };
+}
+
+/**
+ * Evaluates a numeric expression made only of field-value references, Number()/parseFloat()/
+ * parseInt() wrappers, numeric literals, and +, -, *, /, parentheses. Returns `undefined` for
+ * anything outside that grammar (the caller then reports the whole script as unsupported).
+ */
+function evaluateExpression(expr, getValue) {
+  const substituted = expr.replace(FIELD_REF, (_match, _quote, name) => {
+    const n = parseFloat(getValue(name));
+    return Number.isFinite(n) ? String(n) : '0';
+  });
+  // Strip single-argument Number(...)/parseFloat(...)/parseInt(...) wrappers down to plain
+  // parentheses — handles the common (non-nested-call) case used by "calculate" buttons.
+  const bare = substituted.replace(/\b(?:Number|parseFloat|parseInt)\(([^()]*)\)/g, '($1)');
+  if (!/^[\d\s+\-*/().]+$/.test(bare)) return undefined;
+  try {
+    const parser = new ArithmeticParser(bare);
+    const value = parser.parseExpression();
+    if (!parser.atEnd() || !Number.isFinite(value)) return undefined;
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Minimal recursive-descent parser for +, -, *, / and parenthesised numeric expressions.
+ * Deliberately not `eval`/`new Function` — a hostile script can't smuggle in arbitrary JS here.
+ */
+class ArithmeticParser {
+  constructor(text) {
+    this.text = text.replace(/\s+/g, '');
+    this.pos = 0;
+  }
+
+  atEnd() {
+    return this.pos >= this.text.length;
+  }
+
+  peek() {
+    return this.text[this.pos];
+  }
+
+  parseExpression() {
+    let value = this.parseTerm();
+    while (this.peek() === '+' || this.peek() === '-') {
+      const op = this.text[this.pos++];
+      const rhs = this.parseTerm();
+      value = op === '+' ? value + rhs : value - rhs;
+    }
+    return value;
+  }
+
+  parseTerm() {
+    let value = this.parseFactor();
+    while (this.peek() === '*' || this.peek() === '/') {
+      const op = this.text[this.pos++];
+      const rhs = this.parseFactor();
+      value = op === '*' ? value * rhs : value / rhs;
+    }
+    return value;
+  }
+
+  parseFactor() {
+    if (this.peek() === '(') {
+      this.pos++;
+      const inner = this.parseExpression();
+      if (this.peek() !== ')') throw new Error('expected )');
+      this.pos++;
+      return inner;
+    }
+    if (this.peek() === '-') {
+      this.pos++;
+      return -this.parseFactor();
+    }
+    if (this.peek() === '+') {
+      this.pos++;
+      return this.parseFactor();
+    }
+    const start = this.pos;
+    while (/[\d.]/.test(this.peek() || '')) this.pos++;
+    if (this.pos === start) throw new Error('expected number');
+    return parseFloat(this.text.slice(start, this.pos));
+  }
+}
+
+export { runFormScript, evaluateExpression };

--- a/extension/src/formScript.js
+++ b/extension/src/formScript.js
@@ -5,11 +5,17 @@
 //   this.getField("Total").value = this.getField("A").value + this.getField("B").value;
 //   this.getField("Extra").display = display.hidden;   // or display.visible
 //   this.resetForm();
-// Anything outside that grammar (conditionals, loops, app.alert, string concatenation, calls to
-// user-defined functions, …) is reported as unsupported rather than partially executed — we never
-// want to silently do half of what a script asked for, and we never `eval`/`Function` PDF content.
+//   app.alert("Thanks!");            // also app.alert({cMsg: "Thanks!"})
+// Anything outside that grammar (conditionals, loops, string concatenation, calls to user-defined
+// functions, …) is reported as unsupported rather than partially executed — we never want to
+// silently do half of what a script asked for, and we never `eval`/`Function` PDF content.
 
 const FIELD_REF = /this\s*\.\s*getField\(\s*(["'])((?:(?!\1).)*)\1\s*\)\s*\.\s*value/g;
+// app.alert("msg") / app.alert('msg', 3) — trailing icon/type/title args are accepted and ignored.
+const ALERT_STATEMENT = /^app\s*\.\s*alert\(\s*(["'])((?:(?!\1).)*)\1\s*(?:,[^)]*)?\)$/;
+// app.alert({cMsg: "msg", cTitle: "…"}) — the named-argument form, in either key order.
+const ALERT_OBJECT_STATEMENT =
+  /^app\s*\.\s*alert\(\s*\{[^{}]*\bcMsg\s*:\s*(["'])((?:(?!\1).)*)\1[^{}]*\}\s*\)$/;
 const SET_STATEMENT =
   /^this\s*\.\s*getField\(\s*(["'])((?:(?!\1).)*)\1\s*\)\s*\.\s*value\s*=\s*(.+)$/;
 const DISPLAY_STATEMENT =
@@ -21,7 +27,7 @@ const RESET_STATEMENT = /^this\s*\.\s*resetForm\(\s*\)$/;
  *
  * @param {string} script - the raw JavaScript source from the button's /A action.
  * @param {(name: string) => string} getValue - reads a field's current (string) value.
- * @returns {{ok: true, sets: {name: string, value: string}[], display: {name: string, hidden: boolean}[], reset: boolean} | {ok: false}}
+ * @returns {{ok: true, sets: {name: string, value: string}[], display: {name: string, hidden: boolean}[], reset: boolean, alerts: string[]} | {ok: false}}
  *   `ok: false` means the script wasn't (fully) recognised — the caller should tell the user it
  *   needs a real PDF viewer rather than silently doing nothing or half-applying it.
  */
@@ -34,11 +40,18 @@ function runFormScript(script, getValue) {
 
   const sets = [];
   const display = [];
+  const alerts = [];
   let reset = false;
 
   for (const statement of statements) {
     if (RESET_STATEMENT.test(statement)) {
       reset = true;
+      continue;
+    }
+
+    const alertMatch = ALERT_STATEMENT.exec(statement) ?? ALERT_OBJECT_STATEMENT.exec(statement);
+    if (alertMatch) {
+      alerts.push(alertMatch[2]);
       continue;
     }
 
@@ -58,7 +71,7 @@ function runFormScript(script, getValue) {
 
     return { ok: false }; // an unrecognised statement — don't half-run the script
   }
-  return { ok: true, sets, display, reset };
+  return { ok: true, sets, display, reset, alerts };
 }
 
 /**

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -10,6 +10,12 @@
 
 * { box-sizing: border-box; }
 
+/* The HTML `hidden` attribute is only `display: none` in the UA stylesheet, so ANY author rule
+   that sets `display` (e.g. `label { display: block }` below) silently beats it and the element
+   stays on screen. Several panels rely on `hidden` to show type-specific inputs, so make the
+   attribute authoritative here rather than hunting down every rule that could out-specify it. */
+[hidden] { display: none !important; }
+
 html, body {
   margin: 0;
   height: 100%;

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -497,6 +497,7 @@ select {
 .form-field { margin: 8px 0; }
 .form-field > span { display: block; font-size: 12px; color: var(--muted); margin-bottom: 2px; word-break: break-word; }
 .form-field input[type="checkbox"] { width: auto; }
+.form-field-run { padding: 4px 12px; }
 
 .badge.warn { background: #7c3a10; color: #ffd9b0; cursor: pointer; }
 

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -325,6 +325,30 @@ button.danger:hover:not(:disabled) { background: #ef5443; }
   background: color-mix(in srgb, var(--field) 32%, transparent);
   border-width: 2px;
 }
+
+/* The real, fillable control sitting inside a field's outline, so a form can be completed on the
+   page itself rather than only from the side panel. Only interactive while the select/hand tool
+   is active -- during a redact/highlight/draw drag the fields must not swallow the pointer. */
+.field-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0 3px;
+  border: none;
+  background: transparent;
+  color: #111;
+  font: inherit;
+  font-size: clamp(8px, 80%, 15px);
+  pointer-events: none;
+}
+#pages.select-mode .field-input { pointer-events: auto; }
+.field-input:focus { outline: 2px solid var(--field); outline-offset: -1px; background: #fff; }
+.field-input[type="checkbox"] { inset: 50% auto auto 50%; translate: -50% -50%; width: 80%; height: 80%; accent-color: var(--field); }
+/* Transparent hit-area only — the button's own appearance is already in the page image. */
+.field-input-button { background: transparent; cursor: pointer; }
+#pages.select-mode .field-input-button:hover { background: color-mix(in srgb, var(--field) 25%, transparent); }
 .field-tag {
   position: absolute;
   top: -9px;

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -159,7 +159,7 @@
         <label id="field-caption-row" hidden>Button label
           <input id="field-caption" type="text" placeholder="e.g. Submit" />
         </label>
-        <label id="field-script-row" hidden>JavaScript to run on click
+        <label id="field-script-row" hidden>JavaScript to run when the field is used (optional)
           <textarea id="field-script" class="code-editor" rows="4" spellcheck="false"
             placeholder="app.alert('Thanks!');"></textarea>
         </label>

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1963,7 +1963,13 @@ async function openForms() {
     setStatus('Reading form fields…', true);
     const result = await host.call('form-fields', { pdf: state.pdfB64, pdfPassword: state.password });
     setStatus('');
-    const fields = result.fields ?? [];
+    // The document on disk is the source of truth for the field *set*, but not for values the user
+    // has already typed (on the page or here) and not yet applied — keep those.
+    const fields = (result.fields ?? []).map((f) => {
+      const edited = (state.formFields ?? []).find((s) => s.name === f.name);
+      return edited ? { ...f, value: edited.value } : f;
+    });
+    state.formFields = fields;
     const list = $('forms-list');
     list.innerHTML = '';
     $('forms-empty').hidden = fields.length > 0;
@@ -2008,6 +2014,10 @@ async function openForms() {
       }
       input.dataset.field = f.name;
       if (f.readOnly) input.disabled = true;
+      // Keep the panel and the on-page control showing the same value, whichever one is edited.
+      input.addEventListener('input', () => setFieldValue(f.name,
+        input.type === 'checkbox' ? (input.checked ? (input.dataset.on ?? 'Yes') : 'Off') : input.value,
+        input));
       row.appendChild(input);
       // A non-button field can carry a script too (on its widget's /AA /U), which fires when the
       // user activates it in a real reader. Offer the same local simulation button buttons get.
@@ -2032,42 +2042,71 @@ function runFormButtonScript(f) {
     toast(`"${f.name}" has no script attached — nothing to run.`);
     return;
   }
-  const fieldInput = (name) =>
-    [...$('forms-list').querySelectorAll('[data-field]')].find((el) => el.dataset.field === name);
-  const getValue = (name) => {
-    const el = fieldInput(name);
-    if (!el) return '';
-    return el.type === 'checkbox' ? (el.checked ? (el.dataset.on ?? 'Yes') : 'Off') : el.value;
-  };
+  // Read from the model, not from one view's inputs — a script must see the current values whether
+  // they were typed on the page or in the panel, and whether or not the panel is even open.
+  const getValue = (name) =>
+    (state.formFields ?? []).find((field) => field.name === name)?.value ?? '';
 
   const result = runFormScript(f.script, getValue);
   if (!result.ok) {
-    toast(`⚠ "${f.name}" runs JavaScript this viewer can't simulate (only calculations and ` +
-      'show/hide are supported here) — it will run once the saved file is opened in Acrobat or Chrome.');
+    toast(`⚠ "${f.name}" runs JavaScript this viewer can't simulate (only calculations, show/hide, ` +
+      'alerts and resets are supported here) — it will run in full once the saved file is opened ' +
+      'in Acrobat or Chrome.');
     return;
   }
 
-  for (const { name, value } of result.sets) {
-    const el = fieldInput(name);
-    if (el && el.type !== 'checkbox') el.value = value;
-  }
+  for (const { name, value } of result.sets) setFieldValue(name, value);
   for (const { name, hidden } of result.display) {
     const row = [...$('forms-list').children].find((el) => el.dataset.fieldName === name);
     if (row) row.hidden = hidden;
+    for (const marker of document.querySelectorAll(
+      `[data-page-field="${CSS.escape(name)}"]`)) marker.closest('.field-marker').hidden = hidden;
   }
   if (result.reset) {
-    for (const el of $('forms-list').querySelectorAll('[data-field]')) {
-      if (el.type === 'checkbox') el.checked = false;
-      else el.value = '';
+    for (const field of state.formFields ?? []) {
+      if (field.type !== 'button') setFieldValue(field.name, field.type === 'checkbox' ? 'Off' : '');
     }
   }
   toast(result.sets.length > 0
     ? `Ran "${f.name}"'s JavaScript — ${result.sets.length} field${result.sets.length === 1 ? '' : 's'} updated.`
     : `Ran "${f.name}"'s JavaScript.`);
+  if (result.alerts.length > 0) showScriptAlert(f.name, result.alerts);
+}
+
+/** Shows an app.alert() message from a field's script, the way a real reader would. */
+function showScriptAlert(fieldName, messages) {
+  modal.innerHTML = '';
+  const heading = document.createElement('h2');
+  heading.textContent = 'This document says'; // mirrors the browser's own alert phrasing
+  modal.appendChild(heading);
+  for (const message of messages) {
+    const p = document.createElement('p');
+    p.textContent = message; // textContent — the message is document-authored, never HTML
+    modal.appendChild(p);
+  }
+  const note = document.createElement('p');
+  note.className = 'muted';
+  note.textContent = `From the script on "${fieldName}".`;
+  modal.appendChild(note);
+  const actions = document.createElement('div');
+  actions.className = 'actions';
+  const ok = document.createElement('button');
+  ok.textContent = 'OK';
+  ok.addEventListener('click', () => modal.close());
+  actions.appendChild(ok);
+  modal.appendChild(actions);
+  modal.showModal();
+  ok.focus();
 }
 
 async function applyForms() {
   const values = {};
+  // Start from the model so edits made on the page count even when the panel was never opened,
+  // then let the panel's own inputs win for anything currently shown there.
+  for (const f of state.formFields ?? []) {
+    if (f.readOnly || f.type === 'button') continue;
+    values[f.name] = f.value ?? '';
+  }
   for (const input of $('forms-list').querySelectorAll('[data-field]')) {
     if (input.disabled) continue;
     if (input.type === 'checkbox') {
@@ -2602,7 +2641,77 @@ function drawFormFields() {
   }
 }
 
-/** Outlines each form field on one page so empty/borderless fields are visible; hover shows value. */
+/**
+ * Builds the real, editable control for a field so it can be filled in place on the page — the
+ * way a native PDF viewer presents it — rather than only from the side panel. Returns null for a
+ * type with no on-page control.
+ */
+function fieldControl(field) {
+  if (field.type === 'button') {
+    // Left deliberately empty and transparent: the page image already draws the button's own
+    // appearance stream (its caption, border and fill), so this only needs to catch the click.
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'field-input field-input-button';
+    button.setAttribute('aria-label', field.name || 'Button');
+    button.title = field.script ? "Runs this button's script" : 'This button has no script attached';
+    button.addEventListener('click', (e) => { e.stopPropagation(); runFormButtonScript(field); });
+    return button;
+  }
+
+  let input;
+  if (field.type === 'checkbox') {
+    input = document.createElement('input');
+    input.type = 'checkbox';
+    input.dataset.on = (field.options || []).find((o) => o && o !== 'Off') || 'Yes';
+    input.checked = !!field.value && field.value !== 'Off';
+  } else if ((field.type === 'choice' || field.type === 'radio') && field.options?.length) {
+    input = document.createElement('select');
+    for (const o of field.options.filter((o) => field.type !== 'radio' || o !== 'Off')) {
+      const opt = document.createElement('option');
+      opt.value = o;
+      opt.textContent = o;
+      input.appendChild(opt);
+    }
+    input.value = field.value;
+  } else {
+    input = document.createElement('input');
+    input.type = 'text';
+    input.value = field.value ?? '';
+  }
+  input.className = 'field-input';
+  input.dataset.pageField = field.name;
+  if (field.readOnly) input.disabled = true;
+  const read = () => (input.type === 'checkbox'
+    ? (input.checked ? (input.dataset.on ?? 'Yes') : 'Off')
+    : input.value);
+  input.addEventListener('input', () => setFieldValue(field.name, read(), input));
+  input.addEventListener('change', () => {
+    setFieldValue(field.name, read(), input);
+    // A field's own script fires on activation in a real reader; mirror that here.
+    if (field.script) runFormButtonScript(field);
+  });
+  input.addEventListener('click', (e) => e.stopPropagation()); // don't start a page-tool drag
+  return input;
+}
+
+/**
+ * Records a field's new value and mirrors it into whichever of the two views didn't originate it
+ * (the on-page control and the side panel's row), so both always agree and Apply sees the edit
+ * regardless of where it was made.
+ */
+function setFieldValue(name, value, source) {
+  const field = (state.formFields ?? []).find((f) => f.name === name);
+  if (field) field.value = value;
+  for (const el of document.querySelectorAll(
+    `[data-page-field="${CSS.escape(name)}"], #forms-list [data-field="${CSS.escape(name)}"]`)) {
+    if (el === source) continue;
+    if (el.type === 'checkbox') el.checked = !!value && value !== 'Off';
+    else el.value = value;
+  }
+}
+
+/** Renders each form field on one page as an editable control positioned over the page image. */
 function buildFieldLayer(pe, pageNum) {
   pe.wrap.querySelector('.field-layer')?.remove();
   const fields = (state.formFields ?? []).filter((f) => f.page === pageNum && f.width > 0 && f.height > 0);
@@ -2619,9 +2728,10 @@ function buildFieldLayer(pe, pageNum) {
     tag.className = 'field-tag';
     tag.textContent = FIELD_ICONS[field.type] ?? '▭';
     marker.appendChild(tag);
+    const control = fieldControl(field);
+    if (control) marker.appendChild(control);
     marker.addEventListener('mouseenter', () => showFieldPopup(marker, field));
     marker.addEventListener('mouseleave', hideLinkPopup);
-    marker.addEventListener('click', () => openForms()); // jump to the fill panel
     layer.appendChild(marker);
   }
   pe.wrap.insertBefore(layer, pe.overlay); // above the text/link layers, below the tool overlay

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -2,6 +2,7 @@
 // document lives here as bytes and every edit round-trips through the host.
 
 import { HostClient, bytesToBase64, base64ToBytes } from './host-client.js';
+import { runFormScript } from './formScript.js';
 
 const host = new HostClient();
 
@@ -1958,9 +1959,27 @@ async function openForms() {
     for (const f of fields) {
       const row = document.createElement('div');
       row.className = 'form-field';
+      row.dataset.fieldName = f.name; // lets a button's script show/hide this row
       const label = document.createElement('span');
       label.textContent = f.name; // textContent — field names come from the document
       row.appendChild(label);
+
+      if (f.type === 'button') {
+        // A push button has no fillable value — it triggers its click script instead. Buttons are
+        // deliberately excluded from [data-field] so applyForms() never tries to "fill" them.
+        const run = document.createElement('button');
+        run.type = 'button';
+        run.className = 'form-field-run';
+        run.textContent = 'Run';
+        run.title = f.script
+          ? "Simulates this button's script (calculations / show-hide only — see help)"
+          : 'This button has no script attached';
+        run.addEventListener('click', () => runFormButtonScript(f));
+        row.appendChild(run);
+        list.appendChild(row);
+        continue;
+      }
+
       let input;
       if (f.type === 'checkbox') {
         input = document.createElement('input');
@@ -1991,6 +2010,52 @@ async function openForms() {
   } catch (e) {
     fail(e);
   }
+}
+
+/**
+ * Simulates a form button's click script against the other fields currently shown in the Forms
+ * panel — the viewer's stand-in for real PDF JavaScript execution (see extension/src/formScript.js
+ * for exactly which patterns are supported: field-to-field calculations, show/hide, and reset).
+ * Nothing here is saved until the user hits "Apply"; scripts outside that supported grammar are
+ * reported rather than silently ignored or half-run (issues #18 and #22).
+ */
+function runFormButtonScript(f) {
+  if (!f.script) {
+    toast(`"${f.name}" has no script attached — nothing to run.`);
+    return;
+  }
+  const fieldInput = (name) =>
+    [...$('forms-list').querySelectorAll('[data-field]')].find((el) => el.dataset.field === name);
+  const getValue = (name) => {
+    const el = fieldInput(name);
+    if (!el) return '';
+    return el.type === 'checkbox' ? (el.checked ? (el.dataset.on ?? 'Yes') : 'Off') : el.value;
+  };
+
+  const result = runFormScript(f.script, getValue);
+  if (!result.ok) {
+    toast(`⚠ "${f.name}" runs JavaScript this viewer can't simulate (only calculations and ` +
+      'show/hide are supported here) — it will run once the saved file is opened in Acrobat or Chrome.');
+    return;
+  }
+
+  for (const { name, value } of result.sets) {
+    const el = fieldInput(name);
+    if (el && el.type !== 'checkbox') el.value = value;
+  }
+  for (const { name, hidden } of result.display) {
+    const row = [...$('forms-list').children].find((el) => el.dataset.fieldName === name);
+    if (row) row.hidden = hidden;
+  }
+  if (result.reset) {
+    for (const el of $('forms-list').querySelectorAll('[data-field]')) {
+      if (el.type === 'checkbox') el.checked = false;
+      else el.value = '';
+    }
+  }
+  toast(result.sets.length > 0
+    ? `Ran "${f.name}"'s JavaScript — ${result.sets.length} field${result.sets.length === 1 ? '' : 's'} updated.`
+    : `Ran "${f.name}"'s JavaScript.`);
 }
 
 async function applyForms() {
@@ -2074,10 +2139,15 @@ async function placeField(region) {
       caption: pf.caption || undefined, script: pf.script || undefined,
       pdfPassword: state.password,
     });
-    // A button carrying a script is deliberately-authored active content — keep it on save.
+    // A button carrying a script is deliberately-authored active content — keep it on save, and
+    // say so explicitly (rather than only lighting up the badge a moment later) so the user isn't
+    // surprised the JavaScript survives the save (#22).
     if (pf.script) state.keepActiveContent = true;
     setTool('select');
-    await applyResult(result.pdf, `${FIELD_LABELS[pf.fieldType] ?? 'Field'} added.`);
+    const message = pf.script
+      ? `${FIELD_LABELS[pf.fieldType] ?? 'Field'} added — its JavaScript will be kept when you save.`
+      : `${FIELD_LABELS[pf.fieldType] ?? 'Field'} added.`;
+    await applyResult(result.pdf, message);
     openForms(); // show the updated field list (and let them add another)
   } catch (e) {
     fail(e);

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1945,6 +1945,19 @@ async function showSafetyDialog() {
   close.addEventListener('click', () => modal.close());
 }
 
+/** The "Run" control that locally simulates a field's attached script (see formScript.js). */
+function runControl(field) {
+  const run = document.createElement('button');
+  run.type = 'button';
+  run.className = 'form-field-run';
+  run.textContent = 'Run';
+  run.title = field.script
+    ? "Simulates this field's script (calculations / show-hide only — see help)"
+    : 'This field has no script attached';
+  run.addEventListener('click', () => runFormButtonScript(field));
+  return run;
+}
+
 async function openForms() {
   try {
     setStatus('Reading form fields…', true);
@@ -1967,15 +1980,7 @@ async function openForms() {
       if (f.type === 'button') {
         // A push button has no fillable value — it triggers its click script instead. Buttons are
         // deliberately excluded from [data-field] so applyForms() never tries to "fill" them.
-        const run = document.createElement('button');
-        run.type = 'button';
-        run.className = 'form-field-run';
-        run.textContent = 'Run';
-        run.title = f.script
-          ? "Simulates this button's script (calculations / show-hide only — see help)"
-          : 'This button has no script attached';
-        run.addEventListener('click', () => runFormButtonScript(f));
-        row.appendChild(run);
+        row.appendChild(runControl(f));
         list.appendChild(row);
         continue;
       }
@@ -2004,6 +2009,9 @@ async function openForms() {
       input.dataset.field = f.name;
       if (f.readOnly) input.disabled = true;
       row.appendChild(input);
+      // A non-button field can carry a script too (on its widget's /AA /U), which fires when the
+      // user activates it in a real reader. Offer the same local simulation button buttons get.
+      if (f.script) row.appendChild(runControl(f));
       list.appendChild(row);
     }
     showPanel('panel-forms');
@@ -2095,8 +2103,10 @@ const OPTION_TYPES = new Set(['dropdown', 'radio']);
 function updateFieldTypeRows() {
   const type = $('field-type').value;
   $('field-options-row').hidden = !OPTION_TYPES.has(type);
-  $('field-caption-row').hidden = type !== 'button';
-  $('field-script-row').hidden = type !== 'button';
+  $('field-caption-row').hidden = type !== 'button'; // only a push button has a visible label
+  // Every field type can carry a script: a button's goes on its /A activation action, everything
+  // else's on the widget's /AA /U (mouse-up). So this row applies to all of them.
+  $('field-script-row').hidden = false;
 }
 
 /** Enters "place a field" mode: the next box drawn on a page becomes a new form field. */
@@ -2117,7 +2127,7 @@ function beginPlaceField() {
   state.pendingField = {
     fieldType, name: $('field-name').value.trim(), options,
     caption: fieldType === 'button' ? $('field-caption').value.trim() : '',
-    script: fieldType === 'button' ? $('field-script').value : '',
+    script: $('field-script').value,
   };
   state.tool = 'field';
   for (const b of document.querySelectorAll('.tool')) b.classList.remove('active');

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -2898,6 +2898,7 @@ function wire() {
   $('forms-cancel').addEventListener('click', () => hidePanels());
   $('field-place').addEventListener('click', beginPlaceField);
   $('field-type').addEventListener('change', updateFieldTypeRows);
+  updateFieldTypeRows(); // sync the type-specific rows to the initial selection, not just on change
   enableCodeEditorTab($('field-script'));
 
   $('btn-organize').addEventListener('click', openOrganize);

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -2147,8 +2147,12 @@ async function placeField(region) {
     const message = pf.script
       ? `${FIELD_LABELS[pf.fieldType] ?? 'Field'} added — its JavaScript will be kept when you save.`
       : `${FIELD_LABELS[pf.fieldType] ?? 'Field'} added.`;
-    await applyResult(result.pdf, message);
-    openForms(); // show the updated field list (and let them add another)
+    // Refresh the document and the field list *before* toasting: openForms() drives its own
+    // "Reading form fields…" status while it fetches, which would otherwise stomp the toast
+    // if shown first.
+    await loadDocument(base64ToBytes(result.pdf), null, { pushHistory: true });
+    await openForms(); // show the updated field list (and let them add another)
+    toast(message);
   } catch (e) {
     fail(e);
   }

--- a/extension/test/formScript.test.mjs
+++ b/extension/test/formScript.test.mjs
@@ -1,0 +1,92 @@
+// Unit tests for the minimal form-button script interpreter (see extension/src/formScript.js).
+// Run with: node --test extension/test/formScript.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runFormScript } from '../src/formScript.js';
+
+function valuesOf(map) {
+  return (name) => map[name] ?? '';
+}
+
+test('calculates a sum across two fields into a third', () => {
+  const result = runFormScript(
+    'this.getField("total").value = this.getField("a").value + this.getField("b").value;',
+    valuesOf({ a: '2', b: '3' }),
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.sets, [{ name: 'total', value: '5' }]);
+});
+
+test('supports Number()-wrapped operands and multiple operators', () => {
+  const result = runFormScript(
+    'this.getField("total").value = Number(this.getField("a").value) * 2 + this.getField("b").value;',
+    valuesOf({ a: '4', b: '1' }),
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.sets, [{ name: 'total', value: '9' }]);
+});
+
+test('treats a blank/non-numeric field as 0', () => {
+  const result = runFormScript(
+    'this.getField("total").value = this.getField("a").value + this.getField("missing").value;',
+    valuesOf({ a: '10' }),
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.sets, [{ name: 'total', value: '10' }]);
+});
+
+test('supports multiple statements separated by semicolons', () => {
+  const result = runFormScript(
+    'this.getField("total").value = this.getField("a").value + this.getField("b").value; ' +
+      'this.getField("extra").display = display.hidden;',
+    valuesOf({ a: '1', b: '1' }),
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.sets, [{ name: 'total', value: '2' }]);
+  assert.deepEqual(result.display, [{ name: 'extra', hidden: true }]);
+});
+
+test('supports a plain display toggle', () => {
+  const hide = runFormScript('this.getField("extra").display = display.hidden;', valuesOf({}));
+  assert.equal(hide.ok, true);
+  assert.deepEqual(hide.display, [{ name: 'extra', hidden: true }]);
+
+  const show = runFormScript('this.getField("extra").display = display.visible;', valuesOf({}));
+  assert.equal(show.ok, true);
+  assert.deepEqual(show.display, [{ name: 'extra', hidden: false }]);
+});
+
+test('supports resetForm()', () => {
+  const result = runFormScript('this.resetForm();', valuesOf({}));
+  assert.equal(result.ok, true);
+  assert.equal(result.reset, true);
+});
+
+test('honours parentheses and subtraction/division', () => {
+  const result = runFormScript(
+    'this.getField("total").value = (this.getField("a").value - this.getField("b").value) / 2;',
+    valuesOf({ a: '10', b: '4' }),
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.sets, [{ name: 'total', value: '3' }]);
+});
+
+test('rejects scripts outside the supported grammar instead of guessing', () => {
+  const cases = [
+    'app.alert("hi");',
+    'if (this.getField("a").value > 0) this.getField("b").value = 1;',
+    'this.getField("a").value = "literal string";',
+    'this.submitForm("https://example.com");',
+    'this.getField("a").value = someFunction(1);',
+];
+  for (const script of cases) {
+    const result = runFormScript(script, valuesOf({}));
+    assert.equal(result.ok, false, `expected "${script}" to be unsupported`);
+  }
+});
+
+test('empty script is unsupported', () => {
+  assert.equal(runFormScript('', valuesOf({})).ok, false);
+  assert.equal(runFormScript('   ', valuesOf({})).ok, false);
+});

--- a/extension/test/formScript.test.mjs
+++ b/extension/test/formScript.test.mjs
@@ -74,7 +74,6 @@ test('honours parentheses and subtraction/division', () => {
 
 test('rejects scripts outside the supported grammar instead of guessing', () => {
   const cases = [
-    'app.alert("hi");',
     'if (this.getField("a").value > 0) this.getField("b").value = 1;',
     'this.getField("a").value = "literal string";',
     'this.submitForm("https://example.com");',
@@ -89,4 +88,35 @@ test('rejects scripts outside the supported grammar instead of guessing', () => 
 test('empty script is unsupported', () => {
   assert.equal(runFormScript('', valuesOf({})).ok, false);
   assert.equal(runFormScript('   ', valuesOf({})).ok, false);
+});
+
+test('supports app.alert with a string argument', () => {
+  const result = runFormScript("app.alert('thanks!');", valuesOf({}));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.alerts, ['thanks!']);
+});
+
+test('supports app.alert with trailing icon/type arguments', () => {
+  const result = runFormScript('app.alert("Saved", 3);', valuesOf({}));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.alerts, ['Saved']);
+});
+
+test('supports the app.alert({cMsg: ...}) named-argument form', () => {
+  const result = runFormScript('app.alert({cMsg: "Done", cTitle: "Info"});', valuesOf({}));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.alerts, ['Done']);
+});
+
+test('app.alert combines with field updates in one script', () => {
+  const result = runFormScript(
+    'this.getField("total").value = this.getField("a").value + 1; app.alert("done");',
+    valuesOf({ a: '4' }));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.sets, [{ name: 'total', value: '5' }]);
+  assert.deepEqual(result.alerts, ['done']);
+});
+
+test('a non-alert app.* call is still unsupported', () => {
+  assert.equal(runFormScript('app.launchURL("https://example.com");', valuesOf({})).ok, false);
 });

--- a/src/PdfEditor.Core/FormTools.cs
+++ b/src/PdfEditor.Core/FormTools.cs
@@ -207,9 +207,11 @@ public static class FormTools
             if (type == "container") continue; // non-terminal parent — not directly fillable
             bool readOnly = (field.GetFieldFlags() & PdfFormField.FF_READ_ONLY) != 0;
             var (page, rect) = WidgetLocation(doc, field);
+            string? script = type == "button" ? ButtonScript(field) : null;
             fields.Add(new FormField(name, type, field.GetValueAsString() ?? "", Options(field), readOnly,
                 page,
-                rect?.GetX() ?? 0, rect?.GetY() ?? 0, rect?.GetWidth() ?? 0, rect?.GetHeight() ?? 0));
+                rect?.GetX() ?? 0, rect?.GetY() ?? 0, rect?.GetWidth() ?? 0, rect?.GetHeight() ?? 0,
+                script));
         }
         return fields;
     }
@@ -251,6 +253,37 @@ public static class FormTools
             return (flags & PdfButtonFormField.FF_RADIO) != 0 ? "radio" : "checkbox";
         }
         return "text";
+    }
+
+    /// <summary>
+    /// The JavaScript source attached to a push button's activation action (its widget's /A entry,
+    /// or the widget's /AA /U — mouse-up — entry as a fallback), if any. The viewer surfaces this so
+    /// a click can (for the common calculation/visibility patterns) be simulated locally; see
+    /// extension/src/formScript.js. Returns null for a plain button with no script.
+    /// </summary>
+    private static string? ButtonScript(PdfFormField field)
+    {
+        foreach (var widget in field.GetWidgets())
+        {
+            var obj = widget.GetPdfObject();
+            string? script = JsActionText(obj.Get(PdfName.A))
+                ?? JsActionText(obj.GetAsDictionary(PdfName.AA)?.Get(PdfName.U));
+            if (script != null) return script;
+        }
+        return null;
+    }
+
+    /// <summary>Reads the /JS text out of an action dictionary if it's a JavaScript action.</summary>
+    private static string? JsActionText(PdfObject? action)
+    {
+        if (action is not PdfDictionary a) return null;
+        if (a.GetAsName(PdfName.S)?.Equals(PdfName.JavaScript) != true) return null;
+        return a.Get(PdfName.JS) switch
+        {
+            PdfString s => s.ToUnicodeString(),
+            PdfStream st => System.Text.Encoding.UTF8.GetString(st.GetBytes()),
+            _ => null
+        };
     }
 
     /// <summary>Allowed values: choice /Opt entries, or a checkbox/radio's appearance states.</summary>

--- a/src/PdfEditor.Core/FormTools.cs
+++ b/src/PdfEditor.Core/FormTools.cs
@@ -19,7 +19,7 @@ public static class FormTools
     /// <paramref name="multiline"/> is true the field accepts multiple lines (a comment/notes box).
     /// </summary>
     public static EditResult AddTextField(byte[] pdf, int page, RectRegion rect, string? name = null,
-        string? value = null, string? password = null, bool multiline = false)
+        string? value = null, string? password = null, bool multiline = false, string? script = null)
     {
         using var output = new MemoryStream();
         using (var doc = PdfIo.Open(pdf, output, password))
@@ -33,6 +33,7 @@ public static class FormTools
             if (multiline) field.SetMultiline(true);
             field.SetValue(value ?? "");
             StyleWidget(field);
+            AttachScript(field, script);
             form.AddField(field);
         }
         return EditResult.Of(output.ToArray());
@@ -43,7 +44,7 @@ public static class FormTools
     /// option is preselected; the user picks one when filling the form.
     /// </summary>
     public static EditResult AddDropdown(byte[] pdf, int page, RectRegion rect, string? name,
-        IReadOnlyList<string> options, string? password = null)
+        IReadOnlyList<string> options, string? password = null, string? script = null)
     {
         var choices = options.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim()).ToArray();
         if (choices.Length == 0)
@@ -60,6 +61,7 @@ public static class FormTools
                 .SetPage(page).SetOptions(choices).CreateComboBox();
             field.SetValue(choices[0]);
             StyleWidget(field);
+            AttachScript(field, script);
             form.AddField(field);
         }
         return EditResult.Of(output.ToArray());
@@ -71,7 +73,7 @@ public static class FormTools
     /// can be selected; the first is selected by default. Needs at least two options.
     /// </summary>
     public static EditResult AddRadioGroup(byte[] pdf, int page, RectRegion rect, string? name,
-        IReadOnlyList<string> options, string? password = null)
+        IReadOnlyList<string> options, string? password = null, string? script = null)
     {
         var choices = options.Where(o => !string.IsNullOrWhiteSpace(o)).Select(o => o.Trim())
             .Distinct().ToArray();
@@ -105,6 +107,7 @@ public static class FormTools
                     .MoveText(rect.X + box + 6, y + 2).ShowText(choices[i]).EndText();
             }
             group.SetValue(choices[0]); // first option selected by default
+            AttachScript(group, script);
             form.AddField(group, pdfPage);
         }
         return EditResult.Of(output.ToArray());
@@ -112,7 +115,7 @@ public static class FormTools
 
     /// <summary>Inserts a checkbox on the given page at the given rectangle.</summary>
     public static EditResult AddCheckbox(byte[] pdf, int page, RectRegion rect, string? name = null,
-        bool isChecked = false, string? password = null)
+        bool isChecked = false, string? password = null, string? script = null)
     {
         using var output = new MemoryStream();
         using (var doc = PdfIo.Open(pdf, output, password))
@@ -125,6 +128,7 @@ public static class FormTools
                 .SetPage(page).SetCheckType(CheckBoxType.CHECK).CreateCheckBox();
             field.SetValue(isChecked ? "Yes" : "Off");
             StyleWidget(field);
+            AttachScript(field, script);
             form.AddField(field);
         }
         return EditResult.Of(output.ToArray());
@@ -149,8 +153,7 @@ public static class FormTools
                 .SetCaption(string.IsNullOrWhiteSpace(caption) ? "Button" : caption)
                 .SetPage(page).CreatePushButton();
             field.GetFirstFormAnnotation().SetBorderColor(ColorConstants.GRAY);
-            if (!string.IsNullOrEmpty(script))
-                field.GetWidgets()[0].SetAction(PdfAction.CreateJavaScript(script));
+            AttachScript(field, script, asActivation: true);
             form.AddField(field);
         }
         return EditResult.Of(output.ToArray());
@@ -159,6 +162,31 @@ public static class FormTools
     // A light fill so an empty field is a visible box on the page (many readers, including the
     // PDFium-based preview, draw nothing for a borderless, value-less widget).
     private static readonly DeviceRgb FieldFill = new(240, 244, 250);
+
+    /// <summary>
+    /// Attaches <paramref name="script"/> to every one of a field's widgets so it runs when the
+    /// user activates that field in Acrobat/Chrome. A push button uses the widget's /A (activation)
+    /// entry — the conventional place for a button's click script — while every other field type
+    /// uses /AA /U (the annotation's mouse-up additional action), which is where readers look for
+    /// "run this when the field is clicked/toggled". Radio groups get it on each option's widget.
+    /// No-op for a null/empty script.
+    /// </summary>
+    private static void AttachScript(PdfFormField field, string? script, bool asActivation = false)
+    {
+        if (string.IsNullOrEmpty(script)) return;
+        foreach (var widget in field.GetWidgets())
+        {
+            if (asActivation)
+            {
+                widget.SetAction(PdfAction.CreateJavaScript(script));
+                continue;
+            }
+            var obj = widget.GetPdfObject();
+            var additional = obj.GetAsDictionary(PdfName.AA) ?? new PdfDictionary();
+            additional.Put(PdfName.U, PdfAction.CreateJavaScript(script).GetPdfObject());
+            obj.Put(PdfName.AA, additional);
+        }
+    }
 
     /// <summary>Gives a widget a visible border + light background and generates its appearance so
     /// it renders as an obvious box (not blank page space) in every viewer.</summary>
@@ -207,7 +235,7 @@ public static class FormTools
             if (type == "container") continue; // non-terminal parent — not directly fillable
             bool readOnly = (field.GetFieldFlags() & PdfFormField.FF_READ_ONLY) != 0;
             var (page, rect) = WidgetLocation(doc, field);
-            string? script = type == "button" ? ButtonScript(field) : null;
+            string? script = FieldScript(field);
             fields.Add(new FormField(name, type, field.GetValueAsString() ?? "", Options(field), readOnly,
                 page,
                 rect?.GetX() ?? 0, rect?.GetY() ?? 0, rect?.GetWidth() ?? 0, rect?.GetHeight() ?? 0,
@@ -256,12 +284,13 @@ public static class FormTools
     }
 
     /// <summary>
-    /// The JavaScript source attached to a push button's activation action (its widget's /A entry,
-    /// or the widget's /AA /U — mouse-up — entry as a fallback), if any. The viewer surfaces this so
-    /// a click can (for the common calculation/visibility patterns) be simulated locally; see
-    /// extension/src/formScript.js. Returns null for a plain button with no script.
+    /// The JavaScript source attached to a field's widget activation — its /A entry (how push
+    /// buttons carry a click script), falling back to the widget's /AA /U mouse-up entry (how every
+    /// other field type carries one). The viewer surfaces this so an activation can, for the common
+    /// calculation/visibility patterns, be simulated locally; see extension/src/formScript.js.
+    /// Returns null for a field with no script.
     /// </summary>
-    private static string? ButtonScript(PdfFormField field)
+    private static string? FieldScript(PdfFormField field)
     {
         foreach (var widget in field.GetWidgets())
         {

--- a/src/PdfEditor.Core/Models.cs
+++ b/src/PdfEditor.Core/Models.cs
@@ -52,11 +52,13 @@ public sealed record SignatureInfo(string Name, string? SignerName, bool Integri
 /// <summary>
 /// A fillable AcroForm field. <paramref name="Type"/> is one of text/checkbox/radio/choice/
 /// signature/button. <paramref name="Options"/> lists the allowed values for checkbox/radio/choice
-/// fields (empty otherwise).
+/// fields (empty otherwise). <paramref name="Script"/> is the JavaScript source attached to a
+/// button's activation action (null for every other field type, or a scriptless button).
 /// </summary>
 public sealed record FormField(string Name, string Type, string Value,
     IReadOnlyList<string> Options, bool ReadOnly,
-    int Page = 0, float X = 0, float Y = 0, float Width = 0, float Height = 0);
+    int Page = 0, float X = 0, float Y = 0, float Width = 0, float Height = 0,
+    string? Script = null);
 
 /// <summary>
 /// Result of scanning a document for active content. <paramref name="Samples"/> holds a few

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -217,21 +217,23 @@ public static class MessageProcessor
         var region = Region(p[RegionKey]!.AsObject());
         string type = p["fieldType"]?.GetValue<string>() ?? "text";
         string? name = p["name"]?.GetValue<string>();
+        string? script = p["script"]?.GetValue<string>();
         var result = type switch
         {
-            "checkbox" => FormTools.AddCheckbox(Pdf(p), region.Page, region, name, password: Password(p)),
+            "checkbox" => FormTools.AddCheckbox(Pdf(p), region.Page, region, name,
+                password: Password(p), script: script),
             "dropdown" => FormTools.AddDropdown(Pdf(p), region.Page, region, name,
                 (p["options"]?.AsArray() ?? new JsonArray()).Select(o => o!.GetValue<string>()).ToList(),
-                Password(p)),
+                Password(p), script),
             "radio" or "option" => FormTools.AddRadioGroup(Pdf(p), region.Page, region, name,
                 (p["options"]?.AsArray() ?? new JsonArray()).Select(o => o!.GetValue<string>()).ToList(),
-                Password(p)),
+                Password(p), script),
             "multiline" => FormTools.AddTextField(Pdf(p), region.Page, region, name,
-                p["value"]?.GetValue<string>(), Password(p), multiline: true),
+                p["value"]?.GetValue<string>(), Password(p), multiline: true, script: script),
             "button" => FormTools.AddButton(Pdf(p), region.Page, region, name,
-                p["caption"]?.GetValue<string>(), p["script"]?.GetValue<string>(), Password(p)),
+                p["caption"]?.GetValue<string>(), script, Password(p)),
             _ => FormTools.AddTextField(Pdf(p), region.Page, region, name,
-                p["value"]?.GetValue<string>(), Password(p)),
+                p["value"]?.GetValue<string>(), Password(p), script: script),
         };
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -198,7 +198,7 @@ public static class MessageProcessor
             fields = fields.Select(f => new
             {
                 name = f.Name, type = f.Type, value = f.Value, options = f.Options, readOnly = f.ReadOnly,
-                page = f.Page, x = f.X, y = f.Y, width = f.Width, height = f.Height
+                page = f.Page, x = f.X, y = f.Y, width = f.Width, height = f.Height, script = f.Script
             })
         };
     }

--- a/tests/PdfEditor.Core.Tests/FormAndSafetyTests.cs
+++ b/tests/PdfEditor.Core.Tests/FormAndSafetyTests.cs
@@ -281,6 +281,46 @@ public class FormToolsTests
     }
 
     [Fact]
+    public void AddCheckbox_WithScript_ListFields_ExposesTheScript()
+    {
+        // A non-button field carries its script on the widget's /AA /U (mouse-up) rather than /A,
+        // so this covers the other half of FieldScript's lookup.
+        byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));
+
+        var result = FormTools.AddCheckbox(pdf, 1, new RectRegion(1, 100, 500, 20, 20), "agree",
+            script: "this.getField(\"total\").value = 1;");
+
+        var field = Assert.Single(FormTools.ListFields(result.Pdf));
+        Assert.Equal("checkbox", field.Type);
+        Assert.Equal("this.getField(\"total\").value = 1;", field.Script);
+    }
+
+    [Fact]
+    public void AddTextField_WithScript_ListFields_ExposesTheScript()
+    {
+        byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));
+
+        var result = FormTools.AddTextField(pdf, 1, new RectRegion(1, 100, 500, 120, 24), "qty",
+            script: "this.getField(\"total\").value = 2;");
+
+        Assert.Equal("this.getField(\"total\").value = 2;",
+            Assert.Single(FormTools.ListFields(result.Pdf)).Script);
+    }
+
+    [Fact]
+    public void AddCheckbox_WithScript_IsFlaggedAsActiveContent()
+    {
+        // The safety scan must treat a field-level script as active content, exactly like a
+        // document-level one -- otherwise a scripted form opens with no warning at all.
+        byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));
+
+        var result = FormTools.AddCheckbox(pdf, 1, new RectRegion(1, 100, 500, 20, 20), "agree",
+            script: "app.alert('hi');");
+
+        Assert.True(PdfSafety.Scan(result.Pdf).HasJavaScript);
+    }
+
+    [Fact]
     public void AddCheckbox_DefaultsToUnchecked_AndCanBeCheckedByFilling()
     {
         byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));

--- a/tests/PdfEditor.Core.Tests/FormAndSafetyTests.cs
+++ b/tests/PdfEditor.Core.Tests/FormAndSafetyTests.cs
@@ -250,6 +250,37 @@ public class FormToolsTests
     }
 
     [Fact]
+    public void AddButton_WithScript_ListFields_ExposesTheScript()
+    {
+        // The Fill Form panel needs the button's click script to simulate it in-viewer (#18).
+        byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));
+
+        var result = FormTools.AddButton(pdf, 1, new RectRegion(1, 100, 500, 80, 24), "calc", "Calculate",
+            "this.getField(\"total\").value = this.getField(\"a\").value;");
+
+        var field = Assert.Single(FormTools.ListFields(result.Pdf));
+        Assert.Equal("button", field.Type);
+        Assert.Equal("this.getField(\"total\").value = this.getField(\"a\").value;", field.Script);
+    }
+
+    [Fact]
+    public void AddButton_WithoutScript_ListFields_ScriptIsNull()
+    {
+        byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));
+
+        var result = FormTools.AddButton(pdf, 1, new RectRegion(1, 100, 500, 80, 24), "noop", "OK");
+
+        Assert.Null(Assert.Single(FormTools.ListFields(result.Pdf)).Script);
+    }
+
+    [Fact]
+    public void ListFields_NonButtonFields_HaveNoScript()
+    {
+        byte[] pdf = TestPdfs.WithTextField("fullName", "Jane");
+        Assert.Null(Assert.Single(FormTools.ListFields(pdf)).Script);
+    }
+
+    [Fact]
     public void AddCheckbox_DefaultsToUnchecked_AndCanBeCheckedByFilling()
     {
         byte[] pdf = TestPdfs.WithText(("plain page", 72, 700, 12));

--- a/tests/PdfEditor.NativeHost.Tests/NewActionsTests.cs
+++ b/tests/PdfEditor.NativeHost.Tests/NewActionsTests.cs
@@ -245,6 +245,8 @@ public class NewActionsTests
         var field = Assert.Single(Result(list)["fields"]!.AsArray());
         Assert.Equal("go", field!["name"]!.GetValue<string>());
         Assert.Equal("button", field["type"]!.GetValue<string>());
+        // The click script round-trips through form-fields so the viewer can simulate it (#18).
+        Assert.Equal("app.alert('clicked');", field["script"]!.GetValue<string>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes #18 (PDF JavaScript never executes) and #22 (no notification when a form's JavaScript is added).

**Root cause:** the viewer only rasterises pages, so there was no JavaScript path anywhere — front-end or back-end. Push buttons weren't even interactive; scripts were only ever detected to flag/strip them, never run.

## What this does

**Fields are fillable on the page.** Each field's overlay marker now hosts the real control — text input, checkbox, select, or a transparent click target for buttons (their caption already comes from the page image's appearance stream, so drawing our own would double it). Controls only take pointer events under the select/hand tool, so they can't swallow a redact/draw drag. Previously fields could only be filled from the side panel.

**`state.formFields` is the single source of truth.** `setFieldValue()` mirrors an edit into whichever view didn't originate it; scripts read and write through it (so they work with the panel closed); `openForms()` preserves unapplied edits across a refetch; `applyForms()` seeds from it so on-page edits save even if the panel was never opened.

**Field scripts run.** `formScript.js` is a deliberately tiny, `eval`-free pattern matcher covering: field-to-field arithmetic, `display.hidden`/`visible` toggles, `resetForm()`, and `app.alert("msg")` / `app.alert({cMsg:…})` — shown in a modal ("This document says"), the way a real reader presents it. Anything outside that grammar is reported as unsupported rather than partially executed.

**Any field type can carry JavaScript.** `AttachScript()` wires a script onto every one of a field's widgets: push buttons via `/A` (activation), everything else via the widget's `/AA /U` (mouse-up); radio groups get it per option. `ListFields` reports a script for any type (`ButtonScript` → `FieldScript`).

## Bugs found while testing this PR

**`[hidden]` was defeated app-wide.** `viewer.css` set `label { display: block }`; the `hidden` attribute is only `display: none` in the *UA* stylesheet, so any author `display` rule out-specifies it — **every label relying on the `hidden` attribute was permanently visible** (verified in-browser: attribute present, computed `display: block`). Affected `field-options-row`, `field-caption-row`, `field-script-row`, `links-enable-row`, `forms-flatten-row`.

Consequence: a script box appeared on field types that then discarded it — `beginPlaceField()` only forwarded `script` for buttons, so a checkbox's JavaScript vanished on save (a supplied PDF confirmed it: no `/A`, no `/AA`, zero `/JavaScript`). `[hidden]` is now authoritative, and the capability gap is closed above.

My own earlier assertions (`expect('#field-caption-row').toBeVisible()`) were passing *trivially* because the row was always visible — which is how this shipped. They now assert real per-type behaviour.

**Two-view sync bugs** caught by the new tests: `runFormButtonScript` read/wrote only the sidebar (a script run from the page did nothing with the panel closed), and `openForms()` discarded unapplied edits on refetch.

**Status toast** — `placeField()` toasted before `openForms()`, which immediately overwrote `#status`; the toast never rendered. Reordered.

## Out of scope
Arbitrary PDF JavaScript (loops, conditionals, string concatenation, `submitForm`, `app.launchURL`, user-defined functions) remains unsupported *in the viewer* — it runs in full only in Acrobat/Chrome, and the UI says so instead of staying silent. Non-button scripts use `/AA /U` (fires on activation), not the field-level `/K`/`/V`/`/C` calculate-and-validate triggers, so a text field's script won't auto-run on every keystroke. #43 (radio group event/timing) intentionally untouched.

## Test plan
Rebased onto `main` (`044a422`); integrates cleanly with main's `static class MessageProcessor` refactor.

- [x] `dotnet build --configuration Release` — 0 errors (3 warnings, pre-existing on `main`)
- [x] `dotnet test --filter "Category!=Performance"` — **377/377**: Core 225, NativeHost 118, Integration 17, Perf 17
- [x] `node --test extension/test/formScript.test.mjs` — **14/14**
- [x] Full Playwright e2e — **66/66**
- [x] Driven manually in a real browser against a supplied real-world PDF: typed into a field on the page, clicked its scripted button, got the alert dialog

New coverage: `/AA /U` round-trip for checkbox and text fields; `PdfSafety` flagging a *field-level* script; opening a form-JS PDF raises the warning badge with the field's real script; filling a field on the page and syncing to the panel; running a scripted button from the page; the alert dialog; per-type row visibility; an inserted button is actually drawn.