### PR TITLE
Resolve first batch of SonarCloud findings (#56)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -107,7 +107,7 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create the release candidate (prerelease) and attach the packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           prerelease: true

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Attach to the GitHub Release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/e2e/scripts/shots.js
+++ b/e2e/scripts/shots.js
@@ -7,7 +7,16 @@ const path = require('node:path');
 const { launchExtension } = require('../helpers/harness');
 const { buildLinkPdf, buildJsLinkPdf, buildLinkOnPage2Pdf } = require('../helpers/pdf');
 
-const OUT = process.argv[2] || path.join(os.tmpdir(), 'pdf-shots');
+/** Resolves the CLI-supplied output directory, rejecting anything that isn't a plain path string. */
+function resolveOutputDir(rawArg) {
+  const target = rawArg || path.join(os.tmpdir(), 'pdf-shots');
+  if (typeof target !== 'string' || target.length === 0 || target.includes('\0')) {
+    throw new Error(`invalid output directory argument: ${JSON.stringify(rawArg)}`);
+  }
+  return path.resolve(target);
+}
+
+const OUT = resolveOutputDir(process.argv[2]);
 fs.mkdirSync(OUT, { recursive: true });
 
 const pageImageSel = (n = 1) => `.page[data-page="${n}"] .page-image`;

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -18,6 +18,9 @@ public sealed class MessageProcessor
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
+    private const string RegionKey = "region";
+    private const string ColorKey = "color";
+
     /// <summary>Handles one request and returns the JSON frames to emit (1..n).</summary>
     public IReadOnlyList<string> Handle(string requestJson)
     {
@@ -135,27 +138,27 @@ public sealed class MessageProcessor
 
     private static object AddTextAction(JsonObject p)
     {
-        var result = TextTools.AddText(Pdf(p), Region(p["region"]!.AsObject()),
+        var result = TextTools.AddText(Pdf(p), Region(p[RegionKey]!.AsObject()),
             p["text"]?.GetValue<string>() ?? "",
             p["fontSize"]?.GetValue<float>() ?? 14f,
             p["fontFamily"]?.GetValue<string>(),
             p["bold"]?.GetValue<bool>() ?? false,
             p["italic"]?.GetValue<bool>() ?? false,
-            p["color"]?.GetValue<string>(),
+            p[ColorKey]?.GetValue<string>(),
             Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }
 
     private static object MoveTextAction(JsonObject p)
     {
-        var result = TextTools.MoveText(Pdf(p), Region(p["region"]!.AsObject()),
+        var result = TextTools.MoveText(Pdf(p), Region(p[RegionKey]!.AsObject()),
             p["dx"]!.GetValue<float>(), p["dy"]!.GetValue<float>(), Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }
 
     private static object MoveImageAction(JsonObject p)
     {
-        var region = Region(p["region"]!.AsObject());
+        var region = Region(p[RegionKey]!.AsObject());
         var result = ImageTools.MoveImage(Pdf(p), region.Page, region,
             p["dx"]!.GetValue<float>(), p["dy"]!.GetValue<float>(), Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
@@ -169,7 +172,7 @@ public sealed class MessageProcessor
                 .Select(pt => (pt!["x"]!.GetValue<float>(), pt["y"]!.GetValue<float>())).ToList())
             .ToList();
         var result = InkTools.AddInk(Pdf(p), page, strokes,
-            p["color"]?.GetValue<string>(), p["width"]?.GetValue<float>() ?? 2f, Password(p));
+            p[ColorKey]?.GetValue<string>(), p["width"]?.GetValue<float>() ?? 2f, Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }
 
@@ -183,7 +186,7 @@ public sealed class MessageProcessor
                 o["width"]!.GetValue<float>(), o["height"]!.GetValue<float>());
         }).ToList();
         var result = HighlightTool.AddHighlight(Pdf(p), page, rects,
-            p["color"]?.GetValue<string>(), Password(p));
+            p[ColorKey]?.GetValue<string>(), Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }
 
@@ -211,7 +214,7 @@ public sealed class MessageProcessor
 
     private static object AddFormFieldAction(JsonObject p)
     {
-        var region = Region(p["region"]!.AsObject());
+        var region = Region(p[RegionKey]!.AsObject());
         string type = p["fieldType"]?.GetValue<string>() ?? "text";
         string? name = p["name"]?.GetValue<string>();
         var result = type switch
@@ -385,7 +388,7 @@ public sealed class MessageProcessor
 
     private static object GetRegionText(JsonObject p)
     {
-        var text = TextTools.GetTextInRegion(Pdf(p), Region(p["region"]!.AsObject()), Password(p));
+        var text = TextTools.GetTextInRegion(Pdf(p), Region(p[RegionKey]!.AsObject()), Password(p));
         return new
         {
             text = text.Text,
@@ -398,12 +401,12 @@ public sealed class MessageProcessor
 
     private static object ReplaceRegionText(JsonObject p)
     {
-        var result = TextTools.ReplaceTextInRegion(Pdf(p), Region(p["region"]!.AsObject()),
+        var result = TextTools.ReplaceTextInRegion(Pdf(p), Region(p[RegionKey]!.AsObject()),
             p["text"]?.GetValue<string>() ?? "", p["fontSize"]?.GetValue<float>(),
             p["fontFamily"]?.GetValue<string>(),
             p["bold"]?.GetValue<bool>() ?? false,
             p["italic"]?.GetValue<bool>() ?? false,
-            p["color"]?.GetValue<string>(),
+            p[ColorKey]?.GetValue<string>(),
             Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
     }
@@ -471,7 +474,7 @@ public sealed class MessageProcessor
     private static object SignImage(JsonObject p) => new
     {
         pdf = Convert.ToBase64String(Signer.AddImageSignature(Pdf(p),
-            Region(p["region"]!.AsObject()),
+            Region(p[RegionKey]!.AsObject()),
             Convert.FromBase64String(p["png"]!.GetValue<string>()), Password(p)))
     };
 
@@ -482,7 +485,7 @@ public sealed class MessageProcessor
             p["pfxPassword"]!.GetValue<string>(),
             p["reason"]?.GetValue<string>(),
             p["location"]?.GetValue<string>(),
-            p["region"] is JsonObject r ? Region(r) : null,
+            p[RegionKey] is JsonObject r ? Region(r) : null,
             p["appearancePng"] is JsonNode img ? Convert.FromBase64String(img.GetValue<string>()) : null,
             Password(p)))
     };

--- a/src/PdfEditor.NativeHost/Program.cs
+++ b/src/PdfEditor.NativeHost/Program.cs
@@ -16,7 +16,7 @@ while (true)
     }
     catch (Exception ex)
     {
-        Console.Error.WriteLine($"[pdf-editor-host] fatal read error: {ex.Message}");
+        await Console.Error.WriteLineAsync($"[pdf-editor-host] fatal read error: {ex.Message}");
         return 1;
     }
     if (frame == null) return 0; // browser closed the pipe


### PR DESCRIPTION
## Summary
First batch of fixes toward #56 (resolve SonarCloud-flagged issues), addressing four findings reported so far:

- **`.github/workflows/release-candidate.yml`, `release-extension.yml`**: `softprops/action-gh-release@v2` was pinned to a floating tag; pinned to the full commit SHA it currently resolves to (`3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` = `v2.6.2`), matching the SHA-pinning convention `build.yml` already uses for its actions.
- **`e2e/scripts/shots.js`**: the CLI-supplied output directory (`process.argv[2]`) went straight into `fs.mkdirSync` unvalidated. Added `resolveOutputDir()` to validate the argument (must be a non-empty string, no embedded null bytes) and normalize it with `path.resolve()` before it touches the filesystem. This script's purpose is writing to an arbitrary developer-chosen directory, so it intentionally doesn't jail the path to cwd — that would break the tool.
- **`src/PdfEditor.NativeHost/Program.cs`**: the fatal-read-error diagnostic used the synchronous `Console.Error.WriteLine`; switched to `await Console.Error.WriteLineAsync(...)`.
- **`src/PdfEditor.NativeHost/MessageProcessor.cs`**: the string literals `"region"` (8x) and `"color"` (4x) are now `RegionKey`/`ColorKey` constants.

## Test plan
- [x] `dotnet build PdfEditor.sln` — 0 warnings/errors
- [x] `dotnet test` (Core, NativeHost, Integration, Perf) — all pass (219+118+17+17)
- [x] `node --check e2e/scripts/shots.js` + manual exercise of `resolveOutputDir()` (default path, relative path, empty-string fallback)
- [x] Validated both edited workflow YAML files parse correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_