### PR TITLE
Canonicalize shots.js output path; add SSRF guard on open-from-url (#56)

### DIFF
--- a/e2e/scripts/shots.js
+++ b/e2e/scripts/shots.js
@@ -7,13 +7,28 @@ const path = require('node:path');
 const { launchExtension } = require('../helpers/harness');
 const { buildLinkPdf, buildJsLinkPdf, buildLinkOnPage2Pdf } = require('../helpers/pdf');
 
-/** Resolves the CLI-supplied output directory, rejecting anything that isn't a plain path string. */
+/**
+ * Resolves the CLI-supplied output directory to a canonical absolute path. Rejects anything
+ * that isn't a plain path string, then canonicalizes through the nearest *existing* ancestor
+ * (the target itself is created afterward, by mkdirSync below, so it can't be realpath'd yet)
+ * so a symlinked parent can't silently redirect where screenshots get written.
+ */
 function resolveOutputDir(rawArg) {
   const target = rawArg || path.join(os.tmpdir(), 'pdf-shots');
   if (typeof target !== 'string' || target.length === 0 || target.includes('\0')) {
     throw new Error(`invalid output directory argument: ${JSON.stringify(rawArg)}`);
   }
-  return path.resolve(target);
+  const resolved = path.resolve(target);
+  const pending = [];
+  let existingAncestor = resolved;
+  while (!fs.existsSync(existingAncestor)) {
+    pending.unshift(path.basename(existingAncestor));
+    const parent = path.dirname(existingAncestor);
+    if (parent === existingAncestor) break; // reached the filesystem root without finding one
+    existingAncestor = parent;
+  }
+  const canonicalAncestor = fs.realpathSync(existingAncestor);
+  return pending.length ? path.join(canonicalAncestor, ...pending) : canonicalAncestor;
 }
 
 const OUT = resolveOutputDir(process.argv[2]);

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1411,4 +1411,18 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await expect(page.locator('#status')).toContainText('Undid last change');
     await page.close();
   });
+
+  test('open-from-url: refuses a src param pointing at a private/internal host', async () => {
+    const page = await ext.context.newPage();
+    await page.goto(`${ext.viewerUrl}?src=${encodeURIComponent('http://169.254.169.254/latest/meta-data/doc.pdf')}`);
+    await expect(page.locator('#status')).toContainText('Refusing to open');
+    await page.close();
+  });
+
+  test('open-from-url: refuses a src param that is not a PDF URL', async () => {
+    const page = await ext.context.newPage();
+    await page.goto(`${ext.viewerUrl}?src=${encodeURIComponent('https://example.com/not-a-pdf')}`);
+    await expect(page.locator('#status')).toContainText('Refusing to open');
+    await page.close();
+  });
 });

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1833,15 +1833,33 @@ async function openFilePicker() {
   $('file-input').click();
 }
 
-// Only http(s)/file URLs ending in .pdf are legitimate here -- this page is
-// opened with a `src=` query param that (in principle) reflects whatever the
-// caller passed, so re-validate it ourselves rather than trusting that every
-// caller already did (defense in depth; this must never become an arbitrary-
-// URL-fetch-with-credentials primitive).
+// Blocks loopback/private/link-local hosts -- including the 169.254.169.254 cloud metadata
+// address -- so a crafted `src=` param can't turn the credentialed fetch below into an SSRF
+// probe of internal network services. Hostname string matching only (no DNS is done client
+// side); this narrows the attack surface, it isn't a substitute for the server-side checks
+// any real internal service should already have.
+function isPrivateOrLocalHost(hostname) {
+  const h = hostname.toLowerCase();
+  if (h === 'localhost' || h === '0.0.0.0' || h === '::1' || h === '') return true;
+  if (/^127\./.test(h)) return true; // loopback
+  if (/^10\./.test(h)) return true; // RFC1918
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true; // RFC1918
+  if (/^192\.168\./.test(h)) return true; // RFC1918
+  if (/^169\.254\./.test(h)) return true; // link-local, incl. cloud metadata endpoints
+  if (/^\[?f[cd][0-9a-f]{2}:/i.test(h) || h === '[::1]') return true; // IPv6 unique-local/loopback
+  return false;
+}
+
+// Only http(s)/file URLs ending in .pdf, on a non-local/private host, are legitimate here --
+// this page is opened with a `src=` query param that (in principle) reflects whatever the
+// caller passed, so re-validate it ourselves rather than trusting that every caller already
+// did (defense in depth; this must never become an arbitrary-URL-fetch-with-credentials
+// primitive, nor a way to probe internal network services).
 function looksLikePdfUrl(rawUrl) {
   try {
     const parsed = new URL(rawUrl);
     if (!/^https?:|^file:/.test(parsed.protocol)) return false;
+    if (parsed.protocol !== 'file:' && isPrivateOrLocalHost(parsed.hostname)) return false;
     return parsed.pathname.toLowerCase().endsWith('.pdf');
   } catch {
     return false;


### PR DESCRIPTION
## Summary
Two SonarCloud findings toward #56:

**`e2e/scripts/shots.js` (path canonicalization):** the CLI-supplied output directory was validated (non-empty string, no null bytes) and `path.resolve()`'d, but never actually canonicalized — a symlinked ancestor directory could still silently redirect where screenshots get written. `resolveOutputDir()` now walks up to the nearest *existing* ancestor, `fs.realpathSync()`s it (resolving any symlinks), and rejoins the not-yet-created remainder — `mkdirSync` creates the target itself afterward, so it can't be `realpath`'d before that. This is adapted from the suggested fix rather than applied literally: the literal example confines the path to `process.cwd()`, but this script's entire purpose is writing to an arbitrary developer-chosen directory (its own default falls back to `os.tmpdir()`), so hard-confining to cwd would break the tool. Canonicalizing through real symlink resolution addresses the actual gap (an unvalidated *canonicalized* path) without changing intended behavior.

**`extension/src/viewer.js` (SSRF guard on `open-from-url`):** `looksLikePdfUrl()` — the validator gating the credentialed `fetch()` in `openFromUrl()` for the `?src=` query-param flow — checked protocol and the `.pdf` extension, but not the host. Its own existing comment already called out the risk ("this must never become an arbitrary-URL-fetch-with-credentials primitive"), but a crafted `src=` param could still point it at loopback/RFC1918/link-local addresses, including the `169.254.169.254` cloud metadata endpoint. Added `isPrivateOrLocalHost()` and wired it into the check (skipped for `file:` URLs, which have no host to check).

## Test plan
- [x] `node --check` on all modified files
- [x] Manually exercised the strengthened `resolveOutputDir()` logic (default path, relative existing path, deeply nested new path, non-string/null-byte rejection) — confirmed it correctly resolves through a symlinked ancestor (`/tmp` on this box)
- [x] Two new e2e tests: `open-from-url: refuses a src param pointing at a private/internal host` (169.254.169.254) and `open-from-url: refuses a src param that is not a PDF URL` — both pass
- [x] Full Playwright e2e suite — **58/58 pass** (56 existing + 2 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_