### PR TITLE
Canonicalize shots.js output path; add SSRF guard to open-from-url (#56)

### DIFF
--- a/e2e/scripts/shots.js
+++ b/e2e/scripts/shots.js
@@ -7,13 +7,28 @@ const path = require('node:path');
 const { launchExtension } = require('../helpers/harness');
 const { buildLinkPdf, buildJsLinkPdf, buildLinkOnPage2Pdf } = require('../helpers/pdf');
 
-/** Resolves the CLI-supplied output directory, rejecting anything that isn't a plain path string. */
+/**
+ * Resolves the CLI-supplied output directory to a canonical absolute path. Rejects anything
+ * that isn't a plain path string, then canonicalizes through the nearest *existing* ancestor
+ * (the target itself is created afterward, by mkdirSync below, so it can't be realpath'd yet)
+ * so a symlinked parent can't silently redirect where screenshots get written.
+ */
 function resolveOutputDir(rawArg) {
   const target = rawArg || path.join(os.tmpdir(), 'pdf-shots');
   if (typeof target !== 'string' || target.length === 0 || target.includes('\0')) {
     throw new Error(`invalid output directory argument: ${JSON.stringify(rawArg)}`);
   }
-  return path.resolve(target);
+  const resolved = path.resolve(target);
+  const pending = [];
+  let existingAncestor = resolved;
+  while (!fs.existsSync(existingAncestor)) {
+    pending.unshift(path.basename(existingAncestor));
+    const parent = path.dirname(existingAncestor);
+    if (parent === existingAncestor) break; // reached the filesystem root without finding one
+    existingAncestor = parent;
+  }
+  const canonicalAncestor = fs.realpathSync(existingAncestor);
+  return pending.length ? path.join(canonicalAncestor, ...pending) : canonicalAncestor;
 }
 
 const OUT = resolveOutputDir(process.argv[2]);

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1411,4 +1411,18 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await expect(page.locator('#status')).toContainText('Undid last change');
     await page.close();
   });
+
+  test('open-from-url: refuses a src param pointing at a private/internal host', async () => {
+    const page = await ext.context.newPage();
+    await page.goto(`${ext.viewerUrl}?src=${encodeURIComponent('http://169.254.169.254/latest/meta-data/doc.pdf')}`);
+    await expect(page.locator('#status')).toContainText('Refusing to open');
+    await page.close();
+  });
+
+  test('open-from-url: refuses a src param that is not a PDF URL', async () => {
+    const page = await ext.context.newPage();
+    await page.goto(`${ext.viewerUrl}?src=${encodeURIComponent('https://example.com/not-a-pdf')}`);
+    await expect(page.locator('#status')).toContainText('Refusing to open');
+    await page.close();
+  });
 });

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1833,15 +1833,33 @@ async function openFilePicker() {
   $('file-input').click();
 }
 
-// Only http(s)/file URLs ending in .pdf are legitimate here -- this page is
-// opened with a `src=` query param that (in principle) reflects whatever the
-// caller passed, so re-validate it ourselves rather than trusting that every
-// caller already did (defense in depth; this must never become an arbitrary-
-// URL-fetch-with-credentials primitive).
+// Blocks loopback/private/link-local hosts -- including the 169.254.169.254 cloud metadata
+// address -- so a crafted `src=` param can't turn the credentialed fetch below into an SSRF
+// probe of internal network services. Hostname string matching only (no DNS is done client
+// side); this narrows the attack surface, it isn't a substitute for the server-side checks
+// any real internal service should already have.
+function isPrivateOrLocalHost(hostname) {
+  const h = hostname.toLowerCase();
+  if (h === 'localhost' || h === '0.0.0.0' || h === '::1' || h === '') return true;
+  if (/^127\./.test(h)) return true; // loopback
+  if (/^10\./.test(h)) return true; // RFC1918
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true; // RFC1918
+  if (/^192\.168\./.test(h)) return true; // RFC1918
+  if (/^169\.254\./.test(h)) return true; // link-local, incl. cloud metadata endpoints
+  if (/^\[?f[cd][0-9a-f]{2}:/i.test(h) || h === '[::1]') return true; // IPv6 unique-local/loopback
+  return false;
+}
+
+// Only http(s)/file URLs ending in .pdf, on a non-local/private host, are legitimate here --
+// this page is opened with a `src=` query param that (in principle) reflects whatever the
+// caller passed, so re-validate it ourselves rather than trusting that every caller already
+// did (defense in depth; this must never become an arbitrary-URL-fetch-with-credentials
+// primitive, nor a way to probe internal network services).
 function looksLikePdfUrl(rawUrl) {
   try {
     const parsed = new URL(rawUrl);
     if (!/^https?:|^file:/.test(parsed.protocol)) return false;
+    if (parsed.protocol !== 'file:' && isPrivateOrLocalHost(parsed.hostname)) return false;
     return parsed.pathname.toLowerCase().endsWith('.pdf');
   } catch {
     return false;


### PR DESCRIPTION
## Summary
Two more SonarCloud findings toward #56, both path/URL validation:

**`e2e/scripts/shots.js` (L20) — canonicalize before use**
The CLI-supplied output directory was `path.resolve()`'d but never canonicalized, so a symlinked ancestor could silently redirect where screenshots get written. `resolveOutputDir()` now walks up to the nearest *existing* ancestor, `realpathSync()`s it, and rejoins the not-yet-created remainder — the target itself can't be `realpath`'d directly since `mkdirSync` creates it immediately afterward.

Note on the suggested fix: the reference snippet jails the path to `process.cwd()`. That isn't applied here, because this script's entire purpose is writing screenshots to an arbitrary developer-chosen directory (it defaults to `os.tmpdir()`, which is already outside cwd), so a cwd jail would break the tool for its normal use. The canonicalization — which is what the rule actually asks for — is applied, along with the existing type/null-byte rejection.

**`extension/src/viewer.js` (L1841 `openFromUrl`) — validate before building the request URL**
`looksLikePdfUrl()` checked the protocol and `.pdf` extension but not the host, so a crafted `src=` query param could point the **credentialed** `fetch(url, { credentials: 'include' })` at loopback, RFC1918, or link-local addresses — including the `169.254.169.254` cloud metadata endpoint. The function's own comment already flagged this exact risk ("must never become an arbitrary-URL-fetch-with-credentials primitive"); this closes the gap. Added `isPrivateOrLocalHost()` (hostname string matching: localhost, `127.*`, `10.*`, `172.16-31.*`, `192.168.*`, `169.254.*`, IPv6 loopback/unique-local) and wired it into the existing validation, skipping the check for `file:` URLs which have no host.

An allowlist (as in the reference snippet) doesn't fit here — this viewer is meant to open PDFs from *any* public URL the user navigates to, so there is no fixed set of valid hosts. A denylist of internal ranges is the applicable control for that shape. This is client-side hostname matching only and does no DNS resolution, so it narrows the attack surface rather than being a complete SSRF defense — internal services should still have their own server-side auth.

## Test plan
- [x] `node --check` on all three modified files
- [x] Exercised `resolveOutputDir()` directly: default path, existing relative path, deeply-nested not-yet-created path, non-string arg (throws), embedded null byte (throws)
- [x] Two new e2e tests covering the `src=` guard (private/internal host, non-PDF URL), both asserting the existing "Refusing to open" path fires
- [x] Full Playwright e2e suite — **58/58 pass** (56 existing + 2 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_