### PR TITLE
Reset the Links panel when another document is opened (#24)

### DIFF
--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -605,6 +605,35 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('links: the panel does not keep the previous document\'s links (#24)', async () => {
+    // Regression (#24): opening another document left the Links panel listing the OLD document's
+    // URLs. loadDocument() cleared state.linkHotspots (the on-page overlay) but never state.links
+    // (the panel's list), and nothing re-ran openLinks() for the panel that was already showing.
+    const first = path.join(fixtureDir, 'links-first.pdf');
+    fs.writeFileSync(first, buildLinkPdf('https://github.com/example/FIRST-DOC'));
+    const second = path.join(fixtureDir, 'links-second.pdf');
+    fs.writeFileSync(second, buildLinkPdf('https://example.com/SECOND-DOC'));
+
+    const page = await openViewerWith(first);
+    await ui(page, '#btn-links');
+    await expect(page.locator('#links-list')).toContainText('FIRST-DOC');
+
+    // Open a different document while the panel is still on screen.
+    const chooser = page.waitForEvent('filechooser');
+    await ui(page, '#btn-open');
+    await (await chooser).setFiles(second);
+    await expect(page.locator(pageImageSel(1))).toHaveAttribute('src', /data:image\/png/);
+
+    // The first document's link must be gone — whether the panel refreshes or closes.
+    await expect(page.locator('#links-list')).not.toContainText('FIRST-DOC');
+
+    // And the panel must show the new document's link once it is on screen.
+    if (await page.locator('#panel-links').isHidden()) await ui(page, '#btn-links');
+    await expect(page.locator('#links-list')).toContainText('SECOND-DOC');
+    await expect(page.locator('#links-list')).not.toContainText('FIRST-DOC');
+    await page.close();
+  });
+
   test('links: a hotspot is drawn over the link, coloured by risk, inert until enabled', async () => {
     const file = path.join(fixtureDir, 'linkspot.pdf');
     fs.writeFileSync(file, buildLinkPdf('https://github.com/example/repo'));

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -207,6 +207,17 @@ async function loadDocument(bytes, fileName, { pushHistory = false, password } =
   state.urlVerdicts = [];
   state.formFields = [];
   const freshOpen = !!fileName; // only warn about active content when a document is first opened
+  if (freshOpen) {
+    // A panel left open across an Open must not keep showing the PREVIOUS document's data (#24).
+    // state.links backs the Links list and was never cleared here, and openLinks()/openForms()
+    // only refetch when the panel is (re)opened — so a panel already on screen kept the old rows.
+    // Drop the stale lists (model and DOM) and close the panel; reopening it fetches for the new
+    // document. Guarded on freshOpen so an edit/undo reload never closes the panel being worked in.
+    state.links = [];
+    state.scripts = [];
+    renderLinks();
+    hidePanels();
+  }
   await showDocument();
   updateChrome();
   Promise.all([refreshSignatures(), refreshSafety()]).then(() => {


### PR DESCRIPTION
## Summary
Fixes #24 — opening a new PDF left the Links side menu listing the **previous** document's URLs.

**Root cause:** `loadDocument()` cleared `state.linkHotspots` (the on-page overlay) but never `state.links`, which is what the panel's list renders. `openLinks()` only fetches when the panel is *opened*, so a panel already on screen kept its old rows — in both the model and the rendered DOM. The two are easy to conflate; only the overlay half was being reset.

**Fix:** on a fresh open, drop the stale document-derived lists (`state.links`, `state.scripts`), clear the rendered list, and close the panel so reopening it fetches for the new document.

**The part that needed care:** this is guarded on the existing `freshOpen` flag (`fileName != null`), which is what distinguishes *opening a document* from the edit/undo reloads that also go through `loadDocument()`. Without that guard it would close the panel the user is actively working in — `placeField()` in particular reloads and then immediately reopens the forms panel, so an unguarded version would have broken form-field insertion.

## Test plan
Added an e2e case: open document A with a link, leave the Links panel open, open document B, assert A's URL is gone and B's is listed.

**Confirmed the new test FAILS first** against the unfixed code — the list still showed `https://github.com/example/FIRST-DOC` after loading the second document — before the fix went in. The existing `placeField` and undo tests cover the edit path the guard protects.

- [x] `dotnet build PdfEditor.sln --configuration Release` — clean
- [x] `dotnet test --configuration Release --filter "Category!=Performance"` — **377/377**: Core 225, NativeHost 118, Integration 17, Perf 17
- [x] `node --test extension/test/formScript.test.mjs` — **14/14**
- [x] Playwright e2e — **67/67**

## Note
`state.scripts` is cleared alongside `state.links` for consistency, but the JavaScript list lives in a modal dialog rather than a side panel, so it did not exhibit the reported symptom. Other side panels (forms, compare, sanitize) are covered incidentally by closing the panel on open; I did not add separate per-panel refetch logic, since closing is the simpler and more predictable behaviour for data that belongs to a document you just navigated away from.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_