### PR TITLE
OCR: tell Tesseract the DPI its page image was rendered at (#20, #21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: "8.0.x"
+      - name: Install Tesseract OCR
+        # The OCR tests (and the #20/#21 page-geometry regression guards) no-op when the
+        # `tesseract` binary is absent, so without this they pass without executing anything --
+        # leaving OcrTool.cs at 0% coverage on new code and the regressions unguarded in CI.
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
       - name: Build
         run: dotnet build --configuration Release
       - name: Test with coverage (gated at 90% line coverage)

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1452,6 +1452,8 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     const file = fixture('ocr.pdf', [[{ text: 'Scanned document', x: 72, y: 700 }]]);
     const page = await openViewerWith(file);
 
+    const before = await page.locator('.page').first().boundingBox();
+
     await ui(page, '#btn-ocr');
     // Deterministic across environments: OCR either succeeds (status confirms "searchable") or,
     // when Tesseract is not installed, an in-app note naming it appears — never a silent failure.
@@ -1461,6 +1463,20 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
       if (/searchable/i.test((await page.locator('#status').textContent()) || '')) return 'done';
       return 'pending';
     }, { timeout: 60000 }).not.toBe('pending');
+
+    // Issue #21: where OCR did run, the searchable copy must occupy the same page geometry, so
+    // the page is laid out at the same on-screen size — not blown up several times over.
+    if (/searchable/i.test((await page.locator('#status').textContent()) || '')) {
+      const after = await page.locator('.page').first().boundingBox();
+      expect(Math.abs(after.width - before.width)).toBeLessThan(2);
+      expect(Math.abs(after.height - before.height)).toBeLessThan(2);
+      // Issue #20: and it is still viewable — the page image renders rather than falling back
+      // to a blank placeholder.
+      await expect.poll(
+        async () => page.locator('.page').first().locator('img.page-image').evaluate((i) => i.naturalWidth),
+        { timeout: 30000 },
+      ).toBeGreaterThan(0);
+    }
     await page.close();
   });
 

--- a/src/PdfEditor.Core/OcrTool.cs
+++ b/src/PdfEditor.Core/OcrTool.cs
@@ -29,7 +29,7 @@ public static class OcrTool
             string img = IOPath.Combine(work, "page.png");
             File.WriteAllBytes(img, PageRenderer.RenderPagePng(pdf, page, dpi, password));
             // "stdout" tells Tesseract to write the recognised text to standard output.
-            var (stdout, _, ok) = Run(tesseract, work, img, "stdout");
+            var (stdout, _, ok) = Run(tesseract, work, img, "stdout", "-c", UserDefinedDpi(dpi));
             if (!ok) throw new InvalidOperationException("Tesseract could not read the page.");
             return stdout.Trim();
         }
@@ -55,7 +55,7 @@ public static class OcrTool
                 File.WriteAllBytes(img, PageRenderer.RenderPagePng(pdf, p, dpi, password));
 
                 string outBase = IOPath.Combine(work, $"page{p}-ocr");
-                var (_, stderr, ok) = Run(tesseract, work, img, outBase, "pdf");
+                var (_, stderr, ok) = Run(tesseract, work, img, outBase, "-c", UserDefinedDpi(dpi), "pdf");
                 string outPdf = outBase + ".pdf";
                 if (!ok || !File.Exists(outPdf))
                     throw new InvalidOperationException(
@@ -67,6 +67,19 @@ public static class OcrTool
         }
         finally { TryDelete(work); }
     }
+
+    /// <summary>
+    /// Tells Tesseract the resolution the page image was rendered at. PNGs written by Skia carry
+    /// no pHYs resolution chunk, so without this Tesseract falls back to its 70 dpi guess: it then
+    /// lays the searchable PDF out at pixels/70*72 points, i.e. 300/70 ≈ 4.3x the real page. That
+    /// single wrong number caused both reported faults — the viewer sizes each page from its media
+    /// box, so the OCR'd copy appeared hugely zoomed in (#21), and re-rendering a page that big
+    /// (the viewer asks for up to 300 dpi, and a second OCR pass squares the error) needs a bitmap
+    /// too large to allocate, leaving the scan blank/unviewable (#20). Passing the true DPI makes
+    /// the output page match the input page exactly.
+    /// </summary>
+    private static string UserDefinedDpi(int dpi) =>
+        string.Create(System.Globalization.CultureInfo.InvariantCulture, $"user_defined_dpi={dpi}");
 
     private static string RequireTesseract() =>
         FindTesseract() ?? throw new InvalidOperationException(

--- a/tests/PdfEditor.Core.Tests/OcrToolTests.cs
+++ b/tests/PdfEditor.Core.Tests/OcrToolTests.cs
@@ -1,4 +1,6 @@
+using iText.Kernel.Pdf;
 using PdfEditor.Core;
+using SkiaSharp;
 
 namespace PdfEditor.Tests;
 
@@ -48,6 +50,81 @@ public class OcrToolTests
             string text = OcrTool.ExtractText(pdf, 1);
             Assert.Contains("OCR", text.ToUpperInvariant());
         }
+    }
+
+    /// <summary>
+    /// Issue #21: the searchable copy must occupy the same page geometry as the original. The
+    /// viewer lays every page out at (page points x zoom x 96/72), so a page that comes back
+    /// larger than it went in is drawn proportionally larger — the "OCR results are zoomed in"
+    /// symptom. Tesseract sizes its output page from the input image's resolution, so it has to
+    /// be told the DPI the page was rendered at.
+    /// </summary>
+    [Fact]
+    public void MakeSearchable_KeepsOriginalPageGeometry()
+    {
+        if (!OcrTool.CanOcr) return; // covered by MakeSearchable_BehavesPerTesseractAvailability
+
+        byte[] pdf = TestPdfs.JpegScan();
+        byte[] result = OcrTool.MakeSearchable(pdf);
+
+        var box = PageBox(result, 1);
+        // Within a pixel's worth of points at the OCR DPI (300): rounding the page to whole
+        // pixels and back cannot drift further than that.
+        Assert.Equal(TestPdfs.PageWidth, box.Width, 0.5);
+        Assert.Equal(TestPdfs.PageHeight, box.Height, 0.5);
+    }
+
+    /// <summary>
+    /// Issue #20: a JPEG-backed scan must still be viewable after OCR. When the searchable copy
+    /// comes back with an inflated page box, the viewer's render request (up to 300 dpi) asks for
+    /// a bitmap several times larger than the original page, which the renderer cannot allocate —
+    /// the page silently falls back to a blank placeholder, i.e. "the image breaks and is not
+    /// viewable anymore".
+    /// </summary>
+    [Fact]
+    public void MakeSearchable_JpegScan_StillRendersAtTheViewersMaximumDpi()
+    {
+        if (!OcrTool.CanOcr) return;
+
+        byte[] pdf = TestPdfs.JpegScan();
+        const int viewerMaxDpi = 300; // viewer.js currentDpi() caps at 300
+        var before = PngSize(PageRenderer.RenderPagePng(pdf, 1, viewerMaxDpi));
+
+        byte[] result = OcrTool.MakeSearchable(pdf);
+        var after = PngSize(PageRenderer.RenderPagePng(result, 1, viewerMaxDpi));
+
+        Assert.InRange(after.Width, before.Width - 2, before.Width + 2);
+        Assert.InRange(after.Height, before.Height - 2, before.Height + 2);
+    }
+
+    /// <summary>
+    /// OCR-ing an already-OCR'd document must not compound: each pass that enlarged the page fed
+    /// the next pass a bigger page, so a couple of rounds produced a document no renderer could
+    /// open at all.
+    /// </summary>
+    [Fact]
+    public void MakeSearchable_AppliedTwice_DoesNotCompoundThePageSize()
+    {
+        if (!OcrTool.CanOcr) return;
+
+        byte[] twice = OcrTool.MakeSearchable(OcrTool.MakeSearchable(TestPdfs.JpegScan()));
+
+        var box = PageBox(twice, 1);
+        Assert.Equal(TestPdfs.PageWidth, box.Width, 1.0);
+        Assert.Equal(TestPdfs.PageHeight, box.Height, 1.0);
+    }
+
+    private static (float Width, float Height) PageBox(byte[] pdf, int page)
+    {
+        using var doc = new PdfDocument(new PdfReader(new MemoryStream(pdf)));
+        var box = doc.GetPage(page).GetMediaBox();
+        return (box.GetWidth(), box.GetHeight());
+    }
+
+    private static (int Width, int Height) PngSize(byte[] png)
+    {
+        using var bitmap = SKBitmap.Decode(png);
+        return (bitmap.Width, bitmap.Height);
     }
 
     [Fact]

--- a/tests/PdfEditor.Core.Tests/TestPdfs.cs
+++ b/tests/PdfEditor.Core.Tests/TestPdfs.cs
@@ -79,6 +79,34 @@ public static class TestPdfs
     }
 
     /// <summary>
+    /// A "scan": one page whose entire surface is a JPEG (DCTDecode) photo of some text — the
+    /// shape of document people actually run OCR over.
+    /// </summary>
+    public static byte[] JpegScan(string text = "HELLO OCR")
+    {
+        const int pixelWidth = 1240, pixelHeight = 1754; // A4 at ~150 dpi
+        using var bitmap = new SKBitmap(pixelWidth, pixelHeight);
+        using (var c = new SKCanvas(bitmap))
+        {
+            c.Clear(SKColors.White);
+            using var paint = new SKPaint { Color = SKColors.Black, IsAntialias = true };
+            using var font = new SKFont(SKTypeface.Default, 96);
+            c.DrawText(text, 120, 400, SKTextAlign.Left, font, paint);
+        }
+        using var image = SKImage.FromBitmap(bitmap);
+        byte[] jpeg = image.Encode(SKEncodedImageFormat.Jpeg, 85).ToArray();
+
+        using var output = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfWriter(output)))
+        {
+            var page = doc.AddNewPage(new PageSize(PageWidth, PageHeight));
+            new PdfCanvas(page).AddImageFittedIntoRectangle(ImageDataFactory.Create(jpeg),
+                new Rectangle(0, 0, PageWidth, PageHeight), false);
+        }
+        return output.ToArray();
+    }
+
+    /// <summary>
     /// A page with a solid blue square drawn as a genuine inline (BI/ID/EI) image. iText's
     /// canvas API has no high-level method that reliably emits BI/ID/EI (its "asInline"
     /// flag on AddImageFittedIntoRectangle still emits a Do-based XObject in this version),


### PR DESCRIPTION
## Summary
Fixes #20 (JPEG documents break during OCR and become unviewable) and #21 (OCR results are zoomed in). **Both symptoms come from one wrong number**, which is why they're fixed together as ACTION_PLAN.md suggested.

**Root cause:** `OcrTool` renders each page to PNG at 300 dpi and hands the file to Tesseract. Skia's PNG encoder writes no `pHYs` resolution chunk, so Tesseract falls back to its **70 dpi** guess and lays the searchable PDF out at `pixels / 70 * 72` points. Every page comes back **300/70 ≈ 4.29× larger** than it went in:

```
[in]  page 1 mediabox=595.0x842.0  img /Im1 filter=/DCTDecode 1240x1754
[out] page 1 mediabox=2549.8x3608.2 img /Im1 filter=/FlateDecode 2479x3508
```

- **#21 "zoomed in"** — `displaySize()` lays each page out from its media box. A box that grew 4.29× is drawn 4.29× larger at the same zoom. Nothing in the coordinate/overlay maths was wrong; it was being fed a wrong page box.
- **#20 "image breaks"** — `currentDpi()` caps at 300, so re-rendering the inflated page asks for ~18× the pixels and the bitmap allocation fails (`Unable to allocate pixels for the bitmap` in `SKBitmap..ctor` → `RenderPagePng`). `renderPageEl`'s bare `catch` then silently leaves a blank placeholder — and a JPEG-backed scan is exactly the full-bleed-image case where the *whole page* goes blank. OCR-ing an already-OCR'd file squares the error (595 → 2549.8 → **10927.5 pt**), at which point nothing opens it.

The JPEG-specific hypotheses (RGB / grayscale / noisy / `/Rotate 90` variants) were checked empirically — there is no decode or re-encode defect. The geometry blowup is the whole story.

**Fix:** pass `-c user_defined_dpi=<dpi>` on both the searchable-PDF and plain-text paths. Output geometry now matches input exactly (595.0×842.0 → 595.0×842.0), the invisible text layer lands on the glyphs, and the page image is visually identical at the same DPI.

**Also:** installs `tesseract-ocr` in `ci.yml`'s test job. Every OCR test begins `if (!OcrTool.CanOcr) return;`, so without the binary they pass while executing nothing — the regression guards added here would have been inert in CI, and `OcrTool.cs` would have shown 0% coverage on new code. (`sonarqube.yml` already installs it, via #71.)

## Test plan
Three new `OcrToolTests` cases plus a `TestPdfs.JpegScan()` helper that builds a real `DCTDecode` full-page scan, and an e2e assertion added to the existing `ocr: make searchable` test.

**Each new test was confirmed to fail first** against the unfixed code:

```
MakeSearchable_KeepsOriginalPageGeometry                    Expected: 595   Actual: 2549.830078125
MakeSearchable_AppliedTwice_DoesNotCompoundThePageSize      Expected: 595   Actual: 10927.5400390625
MakeSearchable_JpegScan_StillRendersAtTheViewersMaximumDpi  Range: (2477-2481)  Actual: 10624
```

Re-verified after rebasing onto `main` (`0af0b00`):

- [x] `dotnet build PdfEditor.sln --configuration Release` — 0 errors (3 warnings, pre-existing on `main`)
- [x] `dotnet test --configuration Release --filter "Category!=Performance"` — **380/380** (Core 228, NativeHost 118, Integration 17, Perf 17); base is 377, so +3
- [x] `node --test extension/test/formScript.test.mjs` — **14/14**
- [x] Playwright e2e — **67/67**

Tesseract 5.3.4 was present locally, so every OCR assertion ran for real rather than taking the "Tesseract absent" branch.

## Rebase note
Originally this PR also edited `build.yml`. #71 renamed that file to `sonarqube.yml` and carried the Tesseract step across, so the rebase dropped that half — git followed the rename and would otherwise have added a **duplicate** Tesseract step and reverted #71's `**/*.py` coverage exclusion. Resolved by taking main's `sonarqube.yml`; only the `ci.yml` half of the change remains, which main still needed.

## Follow-up
`renderPageEl`'s `catch {}` swallowing render failures — the reason #20 presented as a silent blank page rather than an error — is now filed separately as **#72**, along with the same pattern in `refreshFormFields()`. Deliberately out of scope here.