### PR TITLE
Potential fix for code scanning alert no. 87: Client-side cross-site scripting

### DIFF
--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -94,7 +94,16 @@ let visObserver = null;  // tracks which page is currently front-and-centre
 // ------------------------------------------------------------------ utils
 
 function setStatus(text, busy = false) {
-  $('status').innerHTML = busy ? `<span class="spinner"></span>${text}` : text;
+  const statusEl = $('status');
+  statusEl.textContent = '';
+  if (busy) {
+    const spinner = document.createElement('span');
+    spinner.className = 'spinner';
+    statusEl.appendChild(spinner);
+    statusEl.appendChild(document.createTextNode(text));
+  } else {
+    statusEl.textContent = text;
+  }
   // The loading wheel rides along with the busy-status calls that already wrap every
   // host round-trip, so any operation that makes a button "hang" shows a spinner.
   const overlay = $('busy-overlay');


### PR DESCRIPTION
Potential fix for [https://github.com/ZanattaMichael/Chromium-PDF-Editor/security/code-scanning/87](https://github.com/ZanattaMichael/Chromium-PDF-Editor/security/code-scanning/87)

General fix: never place user-controlled text into `innerHTML`. Use `textContent` / `createTextNode` for untrusted values, and build trusted markup elements (`<span class="spinner">`) with DOM methods.

Best fix here (without changing behavior): update `setStatus` in `extension/src/viewer.js` so it:
- clears the status element content,
- when `busy` is true, appends a programmatically created spinner `<span>` and then a text node for `text`,
- when not busy, sets `textContent` directly.
This preserves the spinner UI and status messaging, but removes HTML parsing of untrusted input.

No new imports or helper libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
