### PR TITLE
Export pipeline validation: post-export structural checks (#52)

### DIFF
--- a/src/PdfEditor.Core/ExportValidator.cs
+++ b/src/PdfEditor.Core/ExportValidator.cs
@@ -1,0 +1,659 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using iText.Forms;
+using iText.Forms.Fields;
+using iText.Kernel.Pdf;
+
+namespace PdfEditor.Core;
+
+/// <summary>
+/// Post-export sanity checks on the bytes this application is about to hand back to the user.
+/// <para>
+/// Every export path (redaction, flattening, signing, OCR, sanitising, merging) rewrites the
+/// document, and a writer bug shows up as a file that opens in one viewer and not another. This
+/// validator re-reads the finished bytes the way a strict consumer would and reports what is
+/// wrong <em>and where</em>: cross-reference/trailer integrity, stream length and filter/decode
+/// round-trip, page-tree consistency, and the cheap AcroForm appearance invariants.
+/// </para>
+/// <para>
+/// It is deliberately read-only and never throws for a malformed document — a broken file is a
+/// report full of findings, not an exception — so callers can run it after a save without any
+/// risk of failing an export that would otherwise have succeeded.
+/// </para>
+/// </summary>
+public static class ExportValidator
+{
+    /// <summary>Filters defined by the PDF specification; anything else no viewer can decode.</summary>
+    private static readonly HashSet<string> KnownFilters = new(StringComparer.Ordinal)
+    {
+        "FlateDecode", "LZWDecode", "ASCII85Decode", "ASCIIHexDecode", "RunLengthDecode",
+        "CCITTFaxDecode", "JBIG2Decode", "DCTDecode", "JPXDecode", "Crypt",
+        "Fl", "LZW", "A85", "AHx", "RL", "CCF"  // abbreviations legal in inline images
+    };
+
+    private static readonly Regex LengthPattern =
+        new(@"/Length\s+(\d+)(\s+\d+\s+R)?", RegexOptions.Compiled, TimeSpan.FromSeconds(2));
+
+    private static readonly Regex ObjectHeaderPattern =
+        new(@"(\d+)\s+(\d+)\s+obj", RegexOptions.Compiled, TimeSpan.FromSeconds(2));
+
+    /// <summary>The most cross-reference problems worth listing; beyond this they all share a cause.</summary>
+    private const int MaxXrefFindings = 10;
+
+    /// <summary>
+    /// Re-reads an exported document and reports everything that would make a viewer struggle
+    /// with it. Never throws: an unreadable document comes back as a report whose
+    /// <see cref="ValidationReport.IsValid"/> is false.
+    /// </summary>
+    public static ValidationReport Validate(byte[] pdf, string? password = null)
+    {
+        ArgumentNullException.ThrowIfNull(pdf);
+        var findings = new List<ValidationFinding>();
+
+        // Latin-1 maps every byte to exactly one char, so string offsets are byte offsets.
+        string raw = Encoding.Latin1.GetString(pdf);
+        CheckHeader(raw, findings);
+        CheckEofMarker(raw, findings);
+        CheckCrossReferences(raw, findings);
+        CheckStreamLengths(raw, findings);
+        CheckWithParser(pdf, password, findings);
+
+        return new ValidationReport(findings);
+    }
+
+    // --------------------------------------------------------------- file markers
+
+    private static void CheckHeader(string raw, List<ValidationFinding> findings)
+    {
+        // The signature must appear within the first 1024 bytes (Acrobat's own tolerance).
+        int index = raw.Length == 0 ? -1
+            : raw.IndexOf("%PDF-", 0, Math.Min(raw.Length, 1024), StringComparison.Ordinal);
+        if (index == 0) return;
+
+        string start = raw.Length == 0 ? "<empty file>" : Printable(raw[..Math.Min(16, raw.Length)]);
+        findings.Add(new ValidationFinding("PDF001", ValidationSeverity.Error, "byte offset 0",
+            index < 0
+                ? $"The output does not contain the '%PDF-' signature in its first 1024 bytes "
+                  + $"(it starts with \"{start}\"). Viewers will refuse to open it — the export "
+                  + "most likely wrote something other than a PDF, or wrote nothing at all."
+                : $"The '%PDF-' signature is at byte offset {index} instead of 0 (the file starts "
+                  + $"with \"{start}\"). Strict viewers only look at offset 0; strip whatever "
+                  + "precedes the signature."));
+    }
+
+    private static void CheckEofMarker(string raw, List<ValidationFinding> findings)
+    {
+        const int tailSize = 2048;
+        int from = Math.Max(0, raw.Length - tailSize);
+        if (raw.IndexOf("%%EOF", from, StringComparison.Ordinal) >= 0) return;
+        findings.Add(new ValidationFinding("PDF002", ValidationSeverity.Error,
+            $"byte offset {raw.Length} (end of file)",
+            $"No '%%EOF' marker in the last {tailSize} bytes of the {raw.Length}-byte output. "
+            + "The file is truncated: the writer was interrupted or the stream was closed before "
+            + "the trailer was flushed."));
+    }
+
+    // --------------------------------------------------------------- cross-reference table
+
+    private static void CheckCrossReferences(string raw, List<ValidationFinding> findings)
+    {
+        int marker = raw.LastIndexOf("startxref", StringComparison.Ordinal);
+        if (marker < 0)
+        {
+            if (raw.Length > 0)
+                findings.Add(new ValidationFinding("PDF003", ValidationSeverity.Error, "trailer",
+                    "The output has no 'startxref' keyword, so no viewer can find the "
+                    + "cross-reference table. The trailer was never written."));
+            return;
+        }
+
+        int cursor = marker + "startxref".Length;
+        long? offset = ReadInteger(raw, ref cursor);
+        if (offset is null)
+        {
+            findings.Add(new ValidationFinding("PDF003", ValidationSeverity.Error,
+                $"byte offset {marker}",
+                "The 'startxref' keyword is not followed by a byte offset. The trailer is "
+                + "malformed and the cross-reference table cannot be located."));
+            return;
+        }
+
+        if (offset <= 0 || offset >= raw.Length)
+        {
+            findings.Add(new ValidationFinding("PDF003", ValidationSeverity.Error,
+                $"byte offset {marker}",
+                $"'startxref' names byte offset {offset}, but the file is {raw.Length} bytes long. "
+                + "The offset was computed against a different (longer or earlier) buffer than the "
+                + "one that was written."));
+            return;
+        }
+
+        int at = (int)offset.Value;
+        if (raw.AsSpan(at).StartsWith("xref"))
+        {
+            CheckXrefTable(raw, at, findings);
+            return;
+        }
+        if (ObjectHeaderPattern.Match(raw, at, Math.Min(32, raw.Length - at)) is { Success: true, Index: var i }
+            && i == at)
+        {
+            return; // cross-reference stream; its own contents are validated by the parser pass
+        }
+
+        findings.Add(new ValidationFinding("PDF003", ValidationSeverity.Error,
+            $"byte offset {at}",
+            $"'startxref' names byte offset {at}, but the bytes there are "
+            + $"\"{Printable(raw.Substring(at, Math.Min(24, raw.Length - at)))}\" — neither an "
+            + "'xref' table nor a cross-reference stream object header."));
+    }
+
+    /// <summary>
+    /// Walks a classic cross-reference table and verifies each in-use entry actually points at
+    /// the object header it claims. This is the check that catches an export writing correct
+    /// objects behind a stale offset table — parsers silently repair it, so nothing downstream
+    /// would ever notice.
+    /// </summary>
+    private static void CheckXrefTable(string raw, int start, List<ValidationFinding> findings)
+    {
+        int cursor = start + "xref".Length;
+        int reported = 0;
+        while (reported < MaxXrefFindings)
+        {
+            SkipWhitespace(raw, ref cursor);
+            if (raw.AsSpan(Math.Min(cursor, raw.Length)).StartsWith("trailer")) return;
+
+            long? first = ReadInteger(raw, ref cursor);
+            long? count = ReadInteger(raw, ref cursor);
+            if (first is null || count is null || count < 0 || count > 10_000_000)
+            {
+                findings.Add(new ValidationFinding("PDF003", ValidationSeverity.Error,
+                    $"byte offset {cursor}",
+                    "The cross-reference table has a malformed subsection header (expected "
+                    + "'<first-object-number> <count>'). The table cannot be read past this point."));
+                return;
+            }
+
+            for (long i = 0; i < count && reported < MaxXrefFindings; i++)
+            {
+                long objectNumber = first.Value + i;
+                long? entryOffset = ReadInteger(raw, ref cursor);
+                long? generation = ReadInteger(raw, ref cursor);
+                SkipWhitespace(raw, ref cursor);
+                char kind = cursor < raw.Length ? raw[cursor++] : '?';
+                if (entryOffset is null || generation is null || kind == '?') return;
+                if (kind != 'n') continue; // free entry: nothing to point at
+
+                if (CheckXrefEntry(raw, objectNumber, generation.Value, entryOffset.Value) is { } finding)
+                {
+                    findings.Add(finding);
+                    reported++;
+                }
+            }
+        }
+    }
+
+    private static ValidationFinding? CheckXrefEntry(string raw, long objectNumber, long generation, long offset)
+    {
+        string location = $"xref entry for object {objectNumber} {generation} R";
+        if (offset <= 0 || offset >= raw.Length)
+            return new ValidationFinding("PDF004", ValidationSeverity.Error, location,
+                $"The cross-reference entry points at byte offset {offset}, which is outside the "
+                + $"{raw.Length}-byte file. Object {objectNumber} is unreachable; viewers will have "
+                + "to scan the whole file to repair the document.");
+
+        int at = (int)offset;
+        var match = ObjectHeaderPattern.Match(raw, at, Math.Min(48, raw.Length - at));
+        bool pointsAtHeader = match.Success && match.Index == at
+            && long.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture) == objectNumber;
+        if (pointsAtHeader) return null;
+
+        return new ValidationFinding("PDF004", ValidationSeverity.Error, location,
+            $"The cross-reference entry points at byte offset {offset}, but the bytes there are "
+            + $"\"{Printable(raw.Substring(at, Math.Min(24, raw.Length - at)))}\" instead of "
+            + $"\"{objectNumber} {generation} obj\". The offset table does not match the objects "
+            + "that were written.");
+    }
+
+    // --------------------------------------------------------------- stream lengths
+
+    /// <summary>
+    /// Verifies that every stream's declared <c>/Length</c> lands exactly on its
+    /// <c>endstream</c> keyword. Parsers repair a wrong length by scanning, so this defect is
+    /// invisible to any check that goes through a parser — but strict consumers trust /Length
+    /// and read garbage.
+    /// </summary>
+    private static void CheckStreamLengths(string raw, List<ValidationFinding> findings)
+    {
+        int pos = 0;
+        int reported = 0;
+        while (reported < MaxXrefFindings)
+        {
+            int keyword = raw.IndexOf("stream", pos, StringComparison.Ordinal);
+            if (keyword < 0) return;
+            if (!IsStreamKeyword(raw, keyword))
+            {
+                // "endstream", or the word inside a name such as /application#2foctet-stream.
+                pos = keyword + "stream".Length;
+                continue;
+            }
+
+            int dataStart = keyword + "stream".Length;
+            if (dataStart < raw.Length && raw[dataStart] == '\r') dataStart++;
+            if (dataStart < raw.Length && raw[dataStart] == '\n') dataStart++;
+
+            var (objectId, declared) = LookBackForLength(raw, keyword);
+            if (declared is null)
+            {
+                // Indirect /Length: nothing to compare against, resynchronise past the data.
+                pos = NextEndstream(raw, dataStart);
+                continue;
+            }
+
+            int expected = dataStart + declared.Value;
+            if (EndstreamStartsAt(raw, expected, out int after))
+            {
+                pos = after;
+                continue;
+            }
+
+            int actual = raw.IndexOf("endstream", dataStart, StringComparison.Ordinal);
+            string effect = actual - dataStart > declared.Value ? "a truncated" : "an over-long";
+            findings.Add(new ValidationFinding("PDF031", ValidationSeverity.Error, objectId,
+                actual < 0
+                    ? $"The stream declares /Length {declared} but no 'endstream' keyword follows "
+                      + $"its data (which begins at byte offset {dataStart}). The stream is unterminated."
+                    : $"The stream declares /Length {declared}, but its 'endstream' keyword is at "
+                      + $"byte offset {actual}, i.e. {actual - dataStart} bytes after the data begins "
+                      + $"(expected {declared}). A viewer that trusts /Length will read "
+                      + effect + " stream."));
+            reported++;
+            pos = actual < 0 ? raw.Length : actual + "endstream".Length;
+        }
+    }
+
+    /// <summary>
+    /// True when the <c>stream</c> at this offset really opens stream data: the specification
+    /// requires it to close a dictionary and be followed by a line break, which rules out
+    /// <c>endstream</c> and the word appearing inside a name or inside stream data.
+    /// </summary>
+    private static bool IsStreamKeyword(string raw, int at)
+    {
+        int after = at + "stream".Length;
+        if (after >= raw.Length || (raw[after] != '\r' && raw[after] != '\n')) return false;
+        int before = at;
+        while (before > 0 && char.IsWhiteSpace(raw[before - 1])) before--;
+        return before >= 2 && raw[before - 1] == '>' && raw[before - 2] == '>';
+    }
+
+    private static bool EndstreamStartsAt(string raw, int expected, out int after)
+    {
+        after = 0;
+        if (expected < 0 || expected > raw.Length) return false;
+        int p = expected;
+        if (p < raw.Length && raw[p] == '\r') p++;
+        if (p < raw.Length && raw[p] == '\n') p++;
+        if (!raw.AsSpan(Math.Min(p, raw.Length)).StartsWith("endstream")) return false;
+        after = p + "endstream".Length;
+        return true;
+    }
+
+    private static int NextEndstream(string raw, int from)
+    {
+        int at = raw.IndexOf("endstream", from, StringComparison.Ordinal);
+        return at < 0 ? raw.Length : at + "endstream".Length;
+    }
+
+    /// <summary>
+    /// Finds the <c>/Length</c> and the owning object header immediately preceding a
+    /// <c>stream</c> keyword. Returns a null length when it is an indirect reference.
+    /// </summary>
+    private static (string ObjectId, int? Length) LookBackForLength(string raw, int keyword)
+    {
+        const int window = 3000;
+        int from = Math.Max(0, keyword - window);
+        string dictionary = raw[from..keyword];
+
+        string objectId = "stream at byte offset " + keyword;
+        var headers = ObjectHeaderPattern.Matches(dictionary);
+        if (headers.Count > 0)
+        {
+            var last = headers[^1];
+            objectId = $"object {last.Groups[1].Value} {last.Groups[2].Value} R";
+        }
+
+        var lengths = LengthPattern.Matches(dictionary);
+        if (lengths.Count == 0) return (objectId, null);
+        var length = lengths[^1];
+        if (length.Groups[2].Success) return (objectId, null); // /Length is an indirect reference
+        return int.TryParse(length.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+            ? (objectId, value)
+            : (objectId, null);
+    }
+
+    // --------------------------------------------------------------- parsed-document checks
+
+    private static void CheckWithParser(byte[] pdf, string? password, List<ValidationFinding> findings)
+    {
+        PdfDocument document;
+        try
+        {
+            document = PdfIo.OpenReadOnly(pdf, password);
+        }
+        catch (Exception ex)
+        {
+            findings.Add(new ValidationFinding("PDF010", ValidationSeverity.Error, "whole document",
+                $"The exported bytes cannot be parsed as a PDF: {ex.Message}. Nothing downstream "
+                + "of this point could be checked — fix this before looking at any other finding."));
+            return;
+        }
+
+        try
+        {
+            CheckRepairedXref(document, findings);
+            var catalog = CheckCatalog(document, findings);
+            // The page tree is walked directly rather than through PdfDocument.GetPage: iText
+            // trusts /Count, so on a document whose count is wrong it throws instead of
+            // reporting — and reporting is this class's whole job.
+            var pages = catalog is null ? new List<PdfDictionary>() : CollectPages(catalog, findings);
+            CheckStreamsDecode(document, findings);
+            CheckAcroForm(document, pages, findings);
+        }
+        catch (Exception ex)
+        {
+            findings.Add(new ValidationFinding("PDF010", ValidationSeverity.Error, "whole document",
+                $"Validation stopped: the document threw while being inspected ({ex.GetType().Name}: "
+                + $"{ex.Message}). The remaining checks could not run."));
+        }
+        finally
+        {
+            document.Close();
+        }
+    }
+
+    private static void CheckRepairedXref(PdfDocument document, List<ValidationFinding> findings)
+    {
+        var reader = document.GetReader();
+        if (reader is null) return;
+        bool rebuilt = reader.HasRebuiltXref();
+        if (!rebuilt && !reader.HasFixedXref()) return;
+        findings.Add(new ValidationFinding("PDF005", ValidationSeverity.Warning, "cross-reference table",
+            (rebuilt
+                ? "The parser could not use the cross-reference table at all and rebuilt it by "
+                  + "scanning the whole file for object headers. "
+                : "The parser had to repair the cross-reference table while reading it. ")
+            + "The document still opens here, but the table as written is wrong and stricter "
+            + "consumers (and anything appending an incremental update) will break."));
+    }
+
+    /// <summary>
+    /// Returns the document catalog, or null when it is unusable. Note that iText repairs the
+    /// catalog reference while parsing (it will even stamp /Type /Catalog onto whatever the
+    /// trailer's /Root happens to name), so a /Root pointing at the wrong object surfaces here as
+    /// a catalog with no page tree rather than as a type mismatch — hence the wording.
+    /// </summary>
+    private static PdfDictionary? CheckCatalog(PdfDocument document, List<ValidationFinding> findings)
+    {
+        var root = document.GetCatalog().GetPdfObject();
+        if (root.Get(PdfName.Pages) is not null) return root;
+
+        findings.Add(new ValidationFinding("PDF011", ValidationSeverity.Error, "trailer /Root",
+            "The document catalog has no /Pages entry, so there is no page tree to render. Either "
+            + "the catalog was written without one, or the trailer's /Root names the wrong object "
+            + "— an object number that shifted during the rewrite is the usual cause."));
+        return null;
+    }
+
+    /// <summary>Walks the page tree, checking every page it reaches, and returns those pages.</summary>
+    private static List<PdfDictionary> CollectPages(PdfDictionary catalog, List<ValidationFinding> findings)
+    {
+        var pages = new List<PdfDictionary>();
+        Descend(catalog.GetAsDictionary(PdfName.Pages), pages, new HashSet<PdfDictionary>(), 0);
+
+        if (pages.Count == 0)
+        {
+            findings.Add(new ValidationFinding("PDF020", ValidationSeverity.Error, "page tree",
+                "No pages are reachable from the document catalog. An export that drops every "
+                + "page produces a file that opens to a blank error in most viewers."));
+            return pages;
+        }
+
+        int? declared = catalog.GetAsDictionary(PdfName.Pages)?.GetAsNumber(PdfName.Count)?.IntValue();
+        if (declared is not null && declared != pages.Count)
+            findings.Add(new ValidationFinding("PDF012", ValidationSeverity.Warning, "page tree /Count",
+                $"The page tree declares /Count {declared} but only {pages.Count} page(s) are "
+                + "reachable through its /Kids. Viewers that trust /Count show the wrong page "
+                + "count, and iText itself throws when asked for the missing pages."));
+
+        for (int i = 0; i < pages.Count; i++) CheckPage(pages[i], i + 1, findings);
+        return pages;
+    }
+
+    private static void Descend(PdfDictionary? node, List<PdfDictionary> pages,
+        HashSet<PdfDictionary> seen, int depth)
+    {
+        // The depth and cycle guards keep a corrupt (self-referencing) tree from hanging validation.
+        if (node is null || depth > 64 || !seen.Add(node)) return;
+        var kids = node.GetAsArray(PdfName.Kids);
+        if (kids is null)
+        {
+            pages.Add(node);
+            return;
+        }
+        for (int i = 0; i < kids.Size(); i++) Descend(kids.GetAsDictionary(i), pages, seen, depth + 1);
+    }
+
+    private static void CheckPage(PdfDictionary page, int number, List<ValidationFinding> findings)
+    {
+        string location = $"page {number}";
+        if (!PdfName.Page.Equals(page.GetAsName(PdfName.Type)))
+            findings.Add(new ValidationFinding("PDF022", ValidationSeverity.Warning, location,
+                "The page dictionary has no /Type /Page entry. It is required by the "
+                + "specification, and viewers that validate the page tree may skip the page."));
+
+        var box = InheritedMediaBox(page, 0);
+        if (box is null)
+        {
+            findings.Add(new ValidationFinding("PDF021", ValidationSeverity.Error, location,
+                "Neither the page nor any of its ancestors declares a /MediaBox, so the page has "
+                + "no defined size. Viewers fall back to their own default and the page renders at "
+                + "the wrong scale."));
+            return;
+        }
+
+        if (box.Size() != 4 || box.ToDoubleArray().Any(v => double.IsNaN(v) || double.IsInfinity(v)))
+        {
+            findings.Add(new ValidationFinding("PDF021", ValidationSeverity.Error, location,
+                $"The /MediaBox is not four finite numbers (it is {box}). The page rectangle "
+                + "cannot be computed."));
+            return;
+        }
+
+        var values = box.ToDoubleArray();
+        double width = Math.Abs(values[2] - values[0]);
+        double height = Math.Abs(values[3] - values[1]);
+        if (width <= 0 || height <= 0)
+            findings.Add(new ValidationFinding("PDF021", ValidationSeverity.Error, location,
+                $"The /MediaBox {box} has zero area ({width} x {height} points), so the page has no "
+                + "renderable surface. A rectangle was probably written with its corners in the "
+                + "wrong order or collapsed by a transform."));
+    }
+
+    private static PdfArray? InheritedMediaBox(PdfDictionary? page, int depth)
+    {
+        if (page is null || depth > 32) return null;
+        return page.GetAsArray(PdfName.MediaBox)
+            ?? InheritedMediaBox(page.GetAsDictionary(PdfName.Parent), depth + 1);
+    }
+
+    private static void CheckStreamsDecode(PdfDocument document, List<ValidationFinding> findings)
+    {
+        int count = document.GetNumberOfPdfObjects();
+        for (int number = 1; number < count; number++)
+        {
+            PdfObject? candidate;
+            try
+            {
+                candidate = document.GetPdfObject(number);
+            }
+            catch (Exception ex)
+            {
+                findings.Add(new ValidationFinding("PDF030", ValidationSeverity.Error,
+                    $"object {number} 0 R",
+                    $"The object could not be loaded: {ex.Message}. The cross-reference entry or "
+                    + "the object body written for it is corrupt."));
+                continue;
+            }
+            if (candidate is PdfStream stream) CheckStream(stream, number, findings);
+        }
+    }
+
+    private static void CheckStream(PdfStream stream, int number, List<ValidationFinding> findings)
+    {
+        string location = $"object {number} 0 R";
+        var filters = FilterNames(stream);
+        var unknown = filters.Where(f => !KnownFilters.Contains(f)).ToList();
+        if (unknown.Count > 0)
+        {
+            findings.Add(new ValidationFinding("PDF032", ValidationSeverity.Error, location,
+                $"The stream declares the filter(s) /{string.Join(", /", unknown)}, which are not "
+                + "defined by the PDF specification. No viewer can decode this stream — the filter "
+                + "name was written incorrectly."));
+            return; // decoding would only restate the same problem
+        }
+
+        string chain = filters.Count == 0 ? "no filter" : "/" + string.Join(" then /", filters);
+        string reason;
+        try
+        {
+            // iText is deliberately forgiving: a filter that gives up returns null, or in the
+            // Flate case hands back the undecoded bytes, so neither an exception nor a non-null
+            // result proves the stream round-trips. Flate — what every export path here writes —
+            // is therefore inflated strictly, the way a non-iText viewer would.
+            reason = stream.GetBytes(true) is null ? "the filter chain produced no output" : "";
+            if (reason.Length == 0 && filters.FirstOrDefault() is "FlateDecode" or "Fl")
+                reason = InflateFailure(stream.GetBytes(false)) ?? "";
+        }
+        catch (Exception ex)
+        {
+            reason = ex.Message;
+        }
+        if (reason.Length == 0) return;
+
+        findings.Add(new ValidationFinding("PDF030", ValidationSeverity.Error, location,
+            $"The stream ({chain}, {stream.GetLength()} bytes as written) does not decode: "
+            + $"{reason}. The data and the declared filter disagree — the bytes were written raw "
+            + "under a compressed filter, or the encoded data was truncated."));
+    }
+
+    /// <summary>
+    /// Inflates Flate data the strict way (zlib wrapper first, then bare deflate, which some
+    /// producers emit). Returns null when the data decompresses, or the reason it does not.
+    /// </summary>
+    private static string? InflateFailure(byte[]? data)
+    {
+        if (data is null || data.Length == 0) return null; // an empty stream is legal
+        if (TryInflate(data, zlib: true) || TryInflate(data, zlib: false)) return null;
+        return "the data is not valid Flate (zlib) compressed data";
+    }
+
+    private static bool TryInflate(byte[] data, bool zlib)
+    {
+        try
+        {
+            using var source = new MemoryStream(data);
+            using Stream decoder = zlib
+                ? new System.IO.Compression.ZLibStream(source, System.IO.Compression.CompressionMode.Decompress)
+                : new System.IO.Compression.DeflateStream(source, System.IO.Compression.CompressionMode.Decompress);
+            using var sink = new MemoryStream();
+            decoder.CopyTo(sink);
+            return true;
+        }
+        catch (InvalidDataException)
+        {
+            return false;
+        }
+    }
+
+    private static List<string> FilterNames(PdfStream stream) => stream.Get(PdfName.Filter) switch
+    {
+        PdfName single => new List<string> { single.GetValue() },
+        PdfArray many => many.OfType<PdfName>().Select(n => n.GetValue()).ToList(),
+        _ => new List<string>()
+    };
+
+    // --------------------------------------------------------------- AcroForm invariants
+
+    private static void CheckAcroForm(PdfDocument document, List<PdfDictionary> pages,
+        List<ValidationFinding> findings)
+    {
+        var form = PdfFormCreator.GetAcroForm(document, false);
+        if (form is null) return;
+
+        bool needAppearances = form.GetPdfObject().GetAsBool(PdfName.NeedAppearances) == true;
+        var onPages = new HashSet<PdfIndirectReference>();
+        foreach (var page in pages)
+        {
+            var annots = page.GetAsArray(PdfName.Annots);
+            if (annots is null) continue;
+            for (int i = 0; i < annots.Size(); i++)
+            {
+                // Get(i, false) hands back the reference itself when the entry is indirect (the
+                // normal case); a directly embedded annotation dictionary carries its own.
+                var entry = annots.Get(i, false);
+                if ((entry as PdfIndirectReference ?? entry?.GetIndirectReference()) is { } reference)
+                    onPages.Add(reference);
+            }
+        }
+
+        foreach (var entry in form.GetAllFormFields())
+        {
+            string name = entry.Key;
+            foreach (var widget in entry.Value.GetWidgets())
+            {
+                var dictionary = widget.GetPdfObject();
+                if (!needAppearances && dictionary.GetAsDictionary(PdfName.AP)?.Get(PdfName.N) is null)
+                    findings.Add(new ValidationFinding("PDF040", ValidationSeverity.Warning,
+                        $"form field '{name}'",
+                        "The field's widget has no normal appearance stream (/AP /N) and the form "
+                        + "does not set /NeedAppearances, so viewers that do not regenerate "
+                        + "appearances (Chrome's built-in viewer among them) draw the field blank. "
+                        + "Regenerate the appearance when writing the field value."));
+
+                var reference = dictionary.GetIndirectReference();
+                if (reference is not null && !onPages.Contains(reference))
+                    findings.Add(new ValidationFinding("PDF041", ValidationSeverity.Warning,
+                        $"form field '{name}'",
+                        "The field's widget annotation is not listed in any page's /Annots array, "
+                        + "so the field exists in the AcroForm but is invisible and cannot be "
+                        + "clicked. Add the widget to the page it belongs to."));
+            }
+        }
+    }
+
+    // --------------------------------------------------------------- small parsing helpers
+
+    private static void SkipWhitespace(string raw, ref int cursor)
+    {
+        while (cursor < raw.Length && char.IsWhiteSpace(raw[cursor])) cursor++;
+    }
+
+    private static long? ReadInteger(string raw, ref int cursor)
+    {
+        SkipWhitespace(raw, ref cursor);
+        int start = cursor;
+        while (cursor < raw.Length && char.IsAsciiDigit(raw[cursor])) cursor++;
+        if (cursor == start) return null;
+        return long.TryParse(raw.AsSpan(start, cursor - start), NumberStyles.Integer,
+            CultureInfo.InvariantCulture, out long value) ? value : null;
+    }
+
+    /// <summary>Renders a byte snippet for a log message, escaping anything unprintable.</summary>
+    private static string Printable(string snippet)
+    {
+        var builder = new StringBuilder(snippet.Length);
+        foreach (char c in snippet)
+            builder.Append(c is >= ' ' and <= '~' ? c : '.');
+        return builder.ToString();
+    }
+}

--- a/src/PdfEditor.Core/ValidationModels.cs
+++ b/src/PdfEditor.Core/ValidationModels.cs
@@ -1,0 +1,49 @@
+namespace PdfEditor.Core;
+
+/// <summary>How badly a validation finding affects the exported document.</summary>
+public enum ValidationSeverity
+{
+    /// <summary>Worth knowing, but nothing is wrong.</summary>
+    Info,
+
+    /// <summary>The file opens, but some viewers will render or behave differently than intended.</summary>
+    Warning,
+
+    /// <summary>The file is structurally broken; viewers may fail to open it or lose content.</summary>
+    Error
+}
+
+/// <summary>
+/// One problem found in an exported document. <paramref name="Code"/> is a stable identifier
+/// (e.g. <c>PDF031</c>) so regression suites can assert on a defect class without matching prose,
+/// <paramref name="Location"/> says exactly where to look (<c>object 4 0 R</c>, <c>page 2</c>,
+/// <c>trailer</c>, <c>byte offset 1234</c>), and <paramref name="Message"/> states what is wrong
+/// and what it means — enough to act on without opening a hex editor.
+/// </summary>
+public sealed record ValidationFinding(
+    string Code, ValidationSeverity Severity, string Location, string Message)
+{
+    public override string ToString() => $"{Severity.ToString().ToUpperInvariant()} {Code} [{Location}] {Message}";
+}
+
+/// <summary>
+/// The outcome of validating an exported document. <see cref="IsValid"/> is false only when at
+/// least one <see cref="ValidationSeverity.Error"/> was found; warnings describe fidelity risks
+/// that still open in every viewer.
+/// </summary>
+public sealed record ValidationReport(IReadOnlyList<ValidationFinding> Findings)
+{
+    public bool IsValid => ErrorCount == 0;
+
+    public int ErrorCount => Findings.Count(f => f.Severity == ValidationSeverity.Error);
+
+    public int WarningCount => Findings.Count(f => f.Severity == ValidationSeverity.Warning);
+
+    /// <summary>True when a finding with the given code was reported.</summary>
+    public bool Has(string code) => Findings.Any(f => f.Code == code);
+
+    /// <summary>The findings rendered one per line, ready to write to a log.</summary>
+    public string ToLogText() => Findings.Count == 0
+        ? "PDF export validation: no problems found."
+        : string.Join(Environment.NewLine, Findings.Select(f => f.ToString()));
+}

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -59,6 +59,7 @@ public static class MessageProcessor
         "form-fields" => FormFieldsAction(p),
         "fill-form" => FillFormAction(p),
         "add-form-field" => AddFormFieldAction(p),
+        "validate" => ValidateAction(p),
         "scan-safety" => ScanSafetyAction(p),
         "js-sources" => new { sources = PdfSafety.JavaScriptSources(Pdf(p), Password(p)) },
         "strip-active" => StripActiveAction(p),
@@ -236,6 +237,30 @@ public static class MessageProcessor
                 p["value"]?.GetValue<string>(), Password(p), script: script),
         };
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };
+    }
+
+    /// <summary>
+    /// Re-reads an exported document and reports what is structurally wrong with it. This is a
+    /// diagnostic: it never rewrites the document and never turns a successful export into a
+    /// failure — the caller decides what to do with the findings.
+    /// </summary>
+    private static object ValidateAction(JsonObject p)
+    {
+        var report = ExportValidator.Validate(Pdf(p), Password(p));
+        return new
+        {
+            valid = report.IsValid,
+            errorCount = report.ErrorCount,
+            warningCount = report.WarningCount,
+            findings = report.Findings.Select(f => new
+            {
+                code = f.Code,
+                severity = f.Severity.ToString().ToLowerInvariant(),
+                location = f.Location,
+                message = f.Message
+            }),
+            log = report.ToLogText()
+        };
     }
 
     private static object ScanSafetyAction(JsonObject p)

--- a/tests/PdfEditor.Core.Tests/CorruptPdfs.cs
+++ b/tests/PdfEditor.Core.Tests/CorruptPdfs.cs
@@ -1,0 +1,335 @@
+using System.Globalization;
+using System.Text;
+using iText.Forms;
+using iText.Forms.Fields;
+using iText.Kernel.Pdf;
+
+namespace PdfEditor.Tests;
+
+/// <summary>
+/// Builds deliberately malformed PDFs, byte for byte, so the export validator can be proven to
+/// actually flag each class of defect (a validator that says "valid" for everything is worse
+/// than none). Every fixture is generated in-repo — nothing is downloaded.
+/// <para>
+/// The documents are written by hand rather than through iText because iText refuses to emit a
+/// broken cross-reference table, a wrong <c>/Length</c>, or undecodable stream data: the whole
+/// point of these fixtures is the corruption a writer would never produce.
+/// </para>
+/// </summary>
+public static class CorruptPdfs
+{
+    /// <summary>How the raw writer should deviate from a well-formed file.</summary>
+    /// <param name="Header">First line of the file (a valid file starts with <c>%PDF-</c>).</param>
+    /// <param name="IncludeEof">When false the trailing <c>%%EOF</c> marker is omitted.</param>
+    /// <param name="StartXrefOverride">Replaces the byte offset written after <c>startxref</c>.</param>
+    /// <param name="ShiftXrefEntryForObject">
+    /// Object number whose cross-reference entry is written pointing off target, by
+    /// <paramref name="ShiftBy"/> bytes.
+    /// </param>
+    /// <param name="ShiftBy">How far off target that entry points.</param>
+    /// <param name="IncludeStartXref">When false the <c>startxref</c> keyword is omitted.</param>
+    /// <param name="SubsectionHeader">Overrides the first cross-reference subsection header.</param>
+    /// <param name="Trailer">Overrides the whole trailer dictionary.</param>
+    public sealed record Options(
+        string Header = "%PDF-1.7",
+        bool IncludeEof = true,
+        long? StartXrefOverride = null,
+        int? ShiftXrefEntryForObject = null,
+        long ShiftBy = 7,
+        bool IncludeStartXref = true,
+        string? SubsectionHeader = null,
+        string? Trailer = null);
+
+    /// <summary>An object body written verbatim between <c>N 0 obj</c> and <c>endobj</c>.</summary>
+    public static byte[] Obj(string body) => Encoding.Latin1.GetBytes(body);
+
+    /// <summary>
+    /// A stream object whose dictionary is written verbatim — so a test can declare a
+    /// <c>/Length</c> or <c>/Filter</c> that does not match <paramref name="data"/>.
+    /// </summary>
+    public static byte[] StreamObj(string dictionary, byte[] data)
+    {
+        using var buffer = new MemoryStream();
+        buffer.Write(Encoding.Latin1.GetBytes(dictionary + "\nstream\n"));
+        buffer.Write(data);
+        buffer.Write(Encoding.Latin1.GetBytes("\nendstream"));
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Assembles numbered objects into a classic (table-based) PDF, applying the requested
+    /// corruption. Object <c>i + 1</c> is <c>objects[i]</c>.
+    /// </summary>
+    public static byte[] Build(IReadOnlyList<byte[]> objects, Options? options = null)
+    {
+        var o = options ?? new Options();
+        using var buffer = new MemoryStream();
+        void Write(string s) => buffer.Write(Encoding.Latin1.GetBytes(s));
+
+        Write(o.Header + "\n%âãÏÓ\n");
+        var offsets = new long[objects.Count + 1];
+        for (int i = 0; i < objects.Count; i++)
+        {
+            offsets[i + 1] = buffer.Length;
+            Write($"{i + 1} 0 obj\n");
+            buffer.Write(objects[i]);
+            Write("\nendobj\n");
+        }
+
+        long xref = buffer.Length;
+        Write("xref\n" + (o.SubsectionHeader ?? $"0 {objects.Count + 1}") + "\n0000000000 65535 f \n");
+        for (int i = 1; i <= objects.Count; i++)
+        {
+            long offset = offsets[i];
+            // Shifted entries land somewhere other than the object's "N 0 obj" header.
+            if (o.ShiftXrefEntryForObject == i) offset += o.ShiftBy;
+            Write(offset.ToString(CultureInfo.InvariantCulture).PadLeft(10, '0') + " 00000 n \n");
+        }
+        Write("trailer\n" + (o.Trailer ?? $"<< /Size {objects.Count + 1} /Root 1 0 R >>") + "\n");
+        if (o.IncludeStartXref)
+            Write($"startxref\n{(o.StartXrefOverride ?? xref).ToString(CultureInfo.InvariantCulture)}\n");
+        if (o.IncludeEof) Write("%%EOF\n");
+        return buffer.ToArray();
+    }
+
+    private static readonly byte[] Content =
+        Encoding.Latin1.GetBytes("BT /F1 12 Tf 20 100 Td (Hello) Tj ET");
+
+    /// <summary>
+    /// The baseline objects of a small, entirely well-formed one-page document. Callers replace
+    /// individual entries to introduce exactly one defect.
+    /// </summary>
+    public static List<byte[]> BaselineObjects() =>
+    [
+        Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+        Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+            + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"),
+        StreamObj($"<< /Length {Content.Length} >>", Content),
+        Obj("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+    ];
+
+    /// <summary>A hand-written but entirely well-formed document — the control fixture.</summary>
+    public static byte[] WellFormed() => Build(BaselineObjects());
+
+    /// <summary>The file does not start with the <c>%PDF-</c> signature.</summary>
+    public static byte[] MissingHeader() =>
+        Build(BaselineObjects(), new Options(Header: "%XDF-1.7"));
+
+    /// <summary>The trailing <c>%%EOF</c> marker is missing (a truncated write).</summary>
+    public static byte[] MissingEof() =>
+        Build(BaselineObjects(), new Options(IncludeEof: false));
+
+    /// <summary><c>startxref</c> points past the end of the file.</summary>
+    public static byte[] StartXrefOutOfRange() =>
+        Build(BaselineObjects(), new Options(StartXrefOverride: 9_000_000));
+
+    /// <summary><c>startxref</c> points at bytes that are not a cross-reference section.</summary>
+    public static byte[] StartXrefNotAnXref() =>
+        Build(BaselineObjects(), new Options(StartXrefOverride: 12));
+
+    /// <summary>There is no <c>startxref</c> keyword at all.</summary>
+    public static byte[] MissingStartXref() =>
+        Build(BaselineObjects(), new Options(IncludeStartXref: false));
+
+    /// <summary>The <c>startxref</c> keyword is not followed by a number.</summary>
+    public static byte[] StartXrefWithoutOffset()
+    {
+        byte[] pdf = Build(BaselineObjects(), new Options(IncludeStartXref: false));
+        return [.. pdf, .. Encoding.Latin1.GetBytes("startxref\n%%EOF\n")];
+    }
+
+    /// <summary>The cross-reference table's subsection header is not two numbers.</summary>
+    public static byte[] MalformedXrefSubsection() =>
+        Build(BaselineObjects(), new Options(SubsectionHeader: "zero five"));
+
+    /// <summary>One cross-reference entry points a few bytes away from its object header.</summary>
+    public static byte[] ShiftedXrefEntry() =>
+        Build(BaselineObjects(), new Options(ShiftXrefEntryForObject: 3));
+
+    /// <summary>One cross-reference entry points past the end of the file.</summary>
+    public static byte[] XrefEntryPastEndOfFile() =>
+        Build(BaselineObjects(), new Options(ShiftXrefEntryForObject: 3, ShiftBy: 5_000_000));
+
+    /// <summary>Junk bytes precede the <c>%PDF-</c> signature.</summary>
+    public static byte[] HeaderNotAtStart() =>
+        Build(BaselineObjects(), new Options(Header: "junk before the signature\n%PDF-1.7"));
+
+    /// <summary>The content stream declares a <c>/Length</c> shorter than the data it holds.</summary>
+    public static byte[] WrongStreamLength()
+    {
+        var objects = BaselineObjects();
+        objects[3] = StreamObj("<< /Length 5 >>", Content);
+        return Build(objects);
+    }
+
+    /// <summary>The content stream is never closed by an <c>endstream</c> keyword.</summary>
+    public static byte[] UnterminatedStream()
+    {
+        var objects = BaselineObjects();
+        objects[3] = Obj($"<< /Length {Content.Length} >>\nstream\n" + Encoding.Latin1.GetString(Content));
+        return Build(objects);
+    }
+
+    /// <summary>
+    /// A well-formed document whose stream length is an indirect reference — legal, and the case
+    /// the byte-level length check has to skip rather than mis-report.
+    /// </summary>
+    public static byte[] IndirectStreamLength()
+    {
+        var objects = BaselineObjects();
+        objects[3] = StreamObj("<< /Length 6 0 R >>", Content);
+        objects.Add(Obj(Content.Length.ToString(CultureInfo.InvariantCulture)));
+        return Build(objects);
+    }
+
+    /// <summary>
+    /// A well-formed document whose content stream is hex-encoded through a filter <em>array</em>
+    /// — the array form of /Filter must validate as cleanly as the single-name form.
+    /// </summary>
+    public static byte[] HexEncodedContentStream()
+    {
+        var objects = BaselineObjects();
+        byte[] hex = Encoding.Latin1.GetBytes(Convert.ToHexString(Content) + ">");
+        objects[3] = StreamObj($"<< /Length {hex.Length} /Filter [/ASCIIHexDecode] >>", hex);
+        return Build(objects);
+    }
+
+    /// <summary>The content stream claims to be Flate-compressed but holds plain text.</summary>
+    public static byte[] UndecodableStream()
+    {
+        var objects = BaselineObjects();
+        objects[3] = StreamObj($"<< /Length {Content.Length} /Filter /FlateDecode >>", Content);
+        return Build(objects);
+    }
+
+    /// <summary>The content stream names a filter that does not exist in the PDF specification.</summary>
+    public static byte[] UnknownStreamFilter()
+    {
+        var objects = BaselineObjects();
+        objects[3] = StreamObj($"<< /Length {Content.Length} /Filter /SuperDecode >>", Content);
+        return Build(objects);
+    }
+
+    /// <summary>The page's <c>/MediaBox</c> has zero area, so the page has no renderable surface.</summary>
+    public static byte[] DegenerateMediaBox()
+    {
+        var objects = BaselineObjects();
+        objects[2] = Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 0] "
+            + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>");
+        return Build(objects);
+    }
+
+    /// <summary>The page's <c>/MediaBox</c> does not have four entries.</summary>
+    public static byte[] MediaBoxWithThreeNumbers()
+    {
+        var objects = BaselineObjects();
+        objects[2] = Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200] "
+            + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>");
+        return Build(objects);
+    }
+
+    /// <summary>
+    /// A well-formed PDF 1.5+ document that stores its objects in object streams behind a
+    /// cross-reference <em>stream</em> instead of a classic table — the layout iText produces in
+    /// full-compression mode, which the byte-level checks must not mistake for corruption.
+    /// </summary>
+    public static byte[] FullyCompressed(byte[] source)
+    {
+        using var output = new MemoryStream();
+        using (new PdfDocument(new PdfReader(new MemoryStream(source)),
+                   new PdfWriter(output, new WriterProperties().SetFullCompressionMode(true))))
+        {
+            // Rewriting is the point; nothing to change.
+        }
+        return output.ToArray();
+    }
+
+    /// <summary>Neither the page nor any ancestor carries a <c>/MediaBox</c>.</summary>
+    public static byte[] MissingMediaBox()
+    {
+        var objects = BaselineObjects();
+        objects[2] = Obj("<< /Type /Page /Parent 2 0 R "
+            + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>");
+        return Build(objects);
+    }
+
+    /// <summary>The page dictionary omits its required <c>/Type /Page</c> entry.</summary>
+    public static byte[] PageWithoutType()
+    {
+        var objects = BaselineObjects();
+        objects[2] = Obj("<< /Parent 2 0 R /MediaBox [0 0 200 200] "
+            + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>");
+        return Build(objects);
+    }
+
+    /// <summary>The page tree's <c>/Count</c> disagrees with the number of pages it actually holds.</summary>
+    public static byte[] PageCountMismatch()
+    {
+        var objects = BaselineObjects();
+        objects[1] = Obj("<< /Type /Pages /Kids [3 0 R] /Count 4 >>");
+        return Build(objects);
+    }
+
+    /// <summary>The page tree is empty: the export dropped every page.</summary>
+    public static byte[] NoPages()
+    {
+        var objects = BaselineObjects();
+        objects[1] = Obj("<< /Type /Pages /Kids [] /Count 0 >>");
+        return Build(objects);
+    }
+
+    /// <summary>The document catalog has no <c>/Pages</c> entry at all.</summary>
+    public static byte[] CatalogWithoutPageTree()
+    {
+        var objects = BaselineObjects();
+        objects[0] = Obj("<< /Type /Catalog >>");
+        return Build(objects);
+    }
+
+    /// <summary>The trailer's <c>/Root</c> resolves to a font, not a document catalog.</summary>
+    public static byte[] RootIsNotACatalog() =>
+        Build(BaselineObjects(), new Options(Trailer: "<< /Size 6 /Root 5 0 R >>"));
+
+    /// <summary>Bytes that are not a PDF at all — the parser cannot open them.</summary>
+    public static byte[] NotAPdf() => Encoding.Latin1.GetBytes("this is not a PDF file at all\n");
+
+    /// <summary>
+    /// A one-page document with a text field whose widget has had its normal appearance stream
+    /// (<c>/AP /N</c>) removed, without the document opting into <c>/NeedAppearances</c> — the
+    /// field renders blank in viewers that do not regenerate appearances themselves.
+    /// </summary>
+    public static byte[] FormFieldWithoutAppearance(byte[] source)
+    {
+        using var output = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfReader(new MemoryStream(source)), new PdfWriter(output)))
+        {
+            var form = PdfFormCreator.GetAcroForm(doc, false);
+            foreach (var field in form.GetAllFormFields().Values)
+                foreach (var widget in field.GetWidgets())
+                {
+                    widget.GetPdfObject().Remove(PdfName.AP);
+                    widget.GetPdfObject().SetModified();
+                }
+        }
+        return output.ToArray();
+    }
+
+    /// <summary>
+    /// A one-page document whose form-field widget is no longer listed in any page's
+    /// <c>/Annots</c> array, so the field exists but can never be clicked.
+    /// </summary>
+    public static byte[] FormFieldOrphanedFromPage(byte[] source)
+    {
+        using var output = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfReader(new MemoryStream(source)), new PdfWriter(output)))
+        {
+            for (int i = 1; i <= doc.GetNumberOfPages(); i++)
+            {
+                doc.GetPage(i).GetPdfObject().Remove(PdfName.Annots);
+                doc.GetPage(i).SetModified();
+            }
+        }
+        return output.ToArray();
+    }
+}

--- a/tests/PdfEditor.Core.Tests/ExportValidatorTests.cs
+++ b/tests/PdfEditor.Core.Tests/ExportValidatorTests.cs
@@ -1,0 +1,272 @@
+using PdfEditor.Core;
+
+namespace PdfEditor.Tests;
+
+/// <summary>
+/// Every defect class the export validator claims to detect is proven here against a
+/// deliberately corrupt document, and the well-formed control documents are proven to pass
+/// clean — so the suite fails loudly if the validator ever degrades into "everything is fine".
+/// </summary>
+public class ExportValidatorTests
+{
+    private static ValidationReport Validate(byte[] pdf) => ExportValidator.Validate(pdf);
+
+    private static void AssertFlags(byte[] pdf, string code, ValidationSeverity severity)
+    {
+        var report = Validate(pdf);
+        var finding = report.Findings.FirstOrDefault(f => f.Code == code);
+        Assert.True(finding != null,
+            $"expected finding {code}; got: {report.ToLogText()}");
+        Assert.Equal(severity, finding!.Severity);
+        // "Actionable" means the finding says where to look and what is wrong.
+        Assert.False(string.IsNullOrWhiteSpace(finding.Location));
+        Assert.True(finding.Message.Length > 20, $"message is not actionable: {finding.Message}");
+        if (severity == ValidationSeverity.Error) Assert.False(report.IsValid);
+    }
+
+    // ------------------------------------------------------- well-formed documents pass clean
+
+    public static TheoryData<string, byte[]> CleanDocuments() => new()
+    {
+        { "hand-written raw", CorruptPdfs.WellFormed() },
+        { "itext text page", TestPdfs.WithText(("Hello world", 72, 700, 14)) },
+        { "multi page", TestPdfs.MultiPage(3) },
+        { "raster image", TestPdfs.WithImage(100, 400, 120, 80) },
+        { "inline image", TestPdfs.WithInlineImage(100, 400, 120, 80) },
+        { "form xobject", TestPdfs.WithForm("inner", 100, 400, 120, 80) },
+        { "acroform text field", TestPdfs.WithTextField("name", "Jane") },
+        { "hidden data", TestPdfs.WithHiddenData() },
+        { "chrome-style ctm", TestPdfs.ChromeStyleLeftoverCtm() },
+        { "indirect stream length", CorruptPdfs.IndirectStreamLength() },
+        { "filter array", CorruptPdfs.HexEncodedContentStream() },
+        { "xref stream + object streams",
+            CorruptPdfs.FullyCompressed(TestPdfs.WithText(("compressed", 72, 700, 12))) },
+    };
+
+    [Theory]
+    [MemberData(nameof(CleanDocuments))]
+    public void WellFormedDocumentsReportNoErrors(string label, byte[] pdf)
+    {
+        var report = Validate(pdf);
+        Assert.True(report.IsValid, $"{label} should validate clean, got: {report.ToLogText()}");
+        Assert.Equal(0, report.ErrorCount);
+    }
+
+    [Fact]
+    public void CleanDocumentLogTextSaysSoExplicitly()
+    {
+        var report = Validate(TestPdfs.WithText(("Hello", 72, 700, 12)));
+        Assert.Empty(report.Findings);
+        Assert.Contains("no problems", report.ToLogText(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, report.WarningCount);
+        Assert.False(report.Has("PDF001"));
+    }
+
+    [Fact]
+    public void ExportedDocumentsFromTheEditingPipelineValidateClean()
+    {
+        byte[] source = TestPdfs.WithText(("Confidential total 12345", 72, 700, 14));
+        byte[] redacted = Redactor.Redact(source, new[] { new RectRegion(1, 70, 690, 300, 30) }).Pdf;
+        Assert.True(Validate(redacted).IsValid, Validate(redacted).ToLogText());
+
+        byte[] filled = FormTools.FillFields(TestPdfs.WithTextField("name"),
+            new Dictionary<string, string> { ["name"] = "Jane" }, flatten: true).Pdf;
+        Assert.True(Validate(filled).IsValid, Validate(filled).ToLogText());
+    }
+
+    // ------------------------------------------------------- file-level structure
+
+    [Fact]
+    public void FlagsMissingPdfHeader() =>
+        AssertFlags(CorruptPdfs.MissingHeader(), "PDF001", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsHeaderThatIsNotAtTheStartOfTheFile()
+    {
+        AssertFlags(CorruptPdfs.HeaderNotAtStart(), "PDF001", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.HeaderNotAtStart()).Findings.First(f => f.Code == "PDF001");
+        Assert.Contains("offset 26", finding.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlagsMissingEofMarker() =>
+        AssertFlags(CorruptPdfs.MissingEof(), "PDF002", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsMissingStartXrefKeyword() =>
+        AssertFlags(CorruptPdfs.MissingStartXref(), "PDF003", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsStartXrefWithNoOffsetAfterIt() =>
+        AssertFlags(CorruptPdfs.StartXrefWithoutOffset(), "PDF003", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsMalformedXrefSubsectionHeader() =>
+        AssertFlags(CorruptPdfs.MalformedXrefSubsection(), "PDF003", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsXrefEntryPointingPastEndOfFile()
+    {
+        AssertFlags(CorruptPdfs.XrefEntryPastEndOfFile(), "PDF004", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.XrefEntryPastEndOfFile()).Findings.First(f => f.Code == "PDF004");
+        Assert.Contains("outside", finding.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlagsStartXrefPointingPastEndOfFile() =>
+        AssertFlags(CorruptPdfs.StartXrefOutOfRange(), "PDF003", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsStartXrefPointingAtSomethingThatIsNotAnXref() =>
+        AssertFlags(CorruptPdfs.StartXrefNotAnXref(), "PDF003", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsXrefEntryThatDoesNotPointAtItsObject()
+    {
+        AssertFlags(CorruptPdfs.ShiftedXrefEntry(), "PDF004", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.ShiftedXrefEntry()).Findings.First(f => f.Code == "PDF004");
+        // The maintainer must be able to go straight to the entry and the offset it names.
+        Assert.Contains("3", finding.Location, StringComparison.Ordinal);
+        Assert.Contains("offset", finding.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FlagsWhenTheParserHadToRebuildTheXref() =>
+        AssertFlags(CorruptPdfs.StartXrefOutOfRange(), "PDF005", ValidationSeverity.Warning);
+
+    [Fact]
+    public void FlagsBytesThatAreNotAPdfAtAll()
+    {
+        AssertFlags(CorruptPdfs.NotAPdf(), "PDF010", ValidationSeverity.Error);
+        // A file that cannot be opened must not silently pass the remaining checks.
+        Assert.False(Validate(CorruptPdfs.NotAPdf()).IsValid);
+    }
+
+    [Fact]
+    public void FlagsEmptyOutput() =>
+        AssertFlags(Array.Empty<byte>(), "PDF001", ValidationSeverity.Error);
+
+    // ------------------------------------------------------- catalog and page tree
+
+    [Fact]
+    public void FlagsRootThatIsNotACatalog() =>
+        // iText stamps /Type /Catalog onto whatever /Root names while parsing, so this surfaces
+        // as "the catalog has no page tree" — the finding says so, and points at trailer /Root.
+        AssertFlags(CorruptPdfs.RootIsNotACatalog(), "PDF011", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsCatalogWithoutAPageTree() =>
+        AssertFlags(CorruptPdfs.CatalogWithoutPageTree(), "PDF011", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsDocumentWithNoPages() =>
+        AssertFlags(CorruptPdfs.NoPages(), "PDF020", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsPageTreeCountThatDisagreesWithTheActualPages() =>
+        AssertFlags(CorruptPdfs.PageCountMismatch(), "PDF012", ValidationSeverity.Warning);
+
+    [Fact]
+    public void FlagsMissingMediaBox() =>
+        AssertFlags(CorruptPdfs.MissingMediaBox(), "PDF021", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsDegenerateMediaBox()
+    {
+        AssertFlags(CorruptPdfs.DegenerateMediaBox(), "PDF021", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.DegenerateMediaBox()).Findings.First(f => f.Code == "PDF021");
+        Assert.Contains("page 1", finding.Location, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FlagsMediaBoxThatIsNotFourNumbers() =>
+        AssertFlags(CorruptPdfs.MediaBoxWithThreeNumbers(), "PDF021", ValidationSeverity.Error);
+
+    [Fact]
+    public void FlagsPageDictionaryWithoutTypePage() =>
+        AssertFlags(CorruptPdfs.PageWithoutType(), "PDF022", ValidationSeverity.Warning);
+
+    // ------------------------------------------------------- streams
+
+    [Fact]
+    public void FlagsStreamWhoseDeclaredLengthIsWrong()
+    {
+        AssertFlags(CorruptPdfs.WrongStreamLength(), "PDF031", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.WrongStreamLength()).Findings.First(f => f.Code == "PDF031");
+        Assert.Contains("5", finding.Message, StringComparison.Ordinal);       // the declared length
+        Assert.Contains("endstream", finding.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlagsStreamThatIsNeverTerminated()
+    {
+        AssertFlags(CorruptPdfs.UnterminatedStream(), "PDF031", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.UnterminatedStream()).Findings.First(f => f.Code == "PDF031");
+        Assert.Contains("unterminated", finding.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FlagsStreamThatFailsToDecode()
+    {
+        AssertFlags(CorruptPdfs.UndecodableStream(), "PDF030", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.UndecodableStream()).Findings.First(f => f.Code == "PDF030");
+        Assert.Contains("FlateDecode", finding.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlagsUnknownStreamFilter()
+    {
+        AssertFlags(CorruptPdfs.UnknownStreamFilter(), "PDF032", ValidationSeverity.Error);
+        var finding = Validate(CorruptPdfs.UnknownStreamFilter()).Findings.First(f => f.Code == "PDF032");
+        Assert.Contains("SuperDecode", finding.Message, StringComparison.Ordinal);
+    }
+
+    // ------------------------------------------------------- AcroForm invariants
+
+    [Fact]
+    public void FlagsFormFieldWithoutAnAppearanceStream() =>
+        AssertFlags(CorruptPdfs.FormFieldWithoutAppearance(TestPdfs.WithTextField("name", "Jane")),
+            "PDF040", ValidationSeverity.Warning);
+
+    [Fact]
+    public void FlagsFormFieldWidgetMissingFromEveryPage() =>
+        AssertFlags(CorruptPdfs.FormFieldOrphanedFromPage(TestPdfs.WithTextField("name", "Jane")),
+            "PDF041", ValidationSeverity.Warning);
+
+    [Fact]
+    public void DoesNotFlagAFormFieldThatIsCorrectlyAttachedToItsPage()
+    {
+        // The negative case for PDF040/PDF041: a field added the right way, widget on the page
+        // with a generated appearance, must produce no form findings at all.
+        byte[] pdf = FormTools.AddTextField(TestPdfs.WithText(("form", 72, 700, 12)), 1,
+            new RectRegion(1, 100, 500, 200, 24), "fullName", "Jane").Pdf;
+        var report = Validate(pdf);
+        Assert.False(report.Has("PDF040"), report.ToLogText());
+        Assert.False(report.Has("PDF041"), report.ToLogText());
+        Assert.True(report.IsValid, report.ToLogText());
+    }
+
+    // ------------------------------------------------------- reporting surface
+
+    [Fact]
+    public void LogTextListsSeverityCodeAndLocationForEveryFinding()
+    {
+        var report = Validate(CorruptPdfs.UndecodableStream());
+        string log = report.ToLogText();
+        foreach (var finding in report.Findings)
+        {
+            Assert.Contains(finding.Code, log, StringComparison.Ordinal);
+            Assert.Contains(finding.Location, log, StringComparison.Ordinal);
+            Assert.Contains(finding.Severity.ToString().ToUpperInvariant(), log, StringComparison.Ordinal);
+        }
+        Assert.True(report.ErrorCount >= 1);
+    }
+
+    [Fact]
+    public void ValidatesEncryptedDocumentsWithTheirPassword()
+    {
+        byte[] encrypted = Encryptor.Encrypt(TestPdfs.WithText(("secret", 72, 700, 12)), "pw", "owner");
+        var report = ExportValidator.Validate(encrypted, "pw");
+        Assert.True(report.IsValid, report.ToLogText());
+    }
+}

--- a/tests/PdfEditor.NativeHost.Tests/ValidateActionTests.cs
+++ b/tests/PdfEditor.NativeHost.Tests/ValidateActionTests.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace PdfEditor.NativeHost.Tests;
+
+/// <summary>
+/// Covers the <c>validate</c> action — the thin dispatcher wrapper around
+/// <c>PdfEditor.Core.ExportValidator</c>.
+/// </summary>
+public class ValidateActionTests
+{
+    private static JsonObject Handle(object payload)
+    {
+        string request = JsonSerializer.Serialize(new { id = "v1", action = "validate", payload });
+        var frame = Assert.Single(MessageProcessor.Handle(request));
+        return JsonNode.Parse(frame)!.AsObject();
+    }
+
+    [Fact]
+    public void CleanDocumentReportsValidWithNoFindings()
+    {
+        var response = Handle(new { pdf = TestPdf.Base64(TestPdf.OnePage()) });
+        Assert.True(response["ok"]!.GetValue<bool>());
+        var result = response["result"]!;
+        Assert.True(result["valid"]!.GetValue<bool>());
+        Assert.Equal(0, result["errorCount"]!.GetValue<int>());
+        Assert.Empty(result["findings"]!.AsArray());
+    }
+
+    [Fact]
+    public void CorruptDocumentReportsActionableFindings()
+    {
+        // A PDF whose trailing %%EOF marker was cut off: still base64-clean input, broken output.
+        byte[] good = TestPdf.OnePage();
+        string text = Encoding.Latin1.GetString(good);
+        byte[] truncated = Encoding.Latin1.GetBytes(text[..text.LastIndexOf("%%EOF", StringComparison.Ordinal)]);
+
+        var result = Handle(new { pdf = Convert.ToBase64String(truncated) })["result"]!;
+        Assert.False(result["valid"]!.GetValue<bool>());
+        Assert.True(result["errorCount"]!.GetValue<int>() >= 1);
+
+        var finding = result["findings"]!.AsArray()
+            .First(f => f!["code"]!.GetValue<string>() == "PDF002");
+        Assert.Equal("error", finding!["severity"]!.GetValue<string>());
+        Assert.False(string.IsNullOrWhiteSpace(finding["location"]!.GetValue<string>()));
+        Assert.Contains("%%EOF", finding["message"]!.GetValue<string>(), StringComparison.Ordinal);
+        Assert.Contains("PDF002", result["log"]!.GetValue<string>(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnreadableBytesAreReportedRatherThanThrown()
+    {
+        var response = Handle(new { pdf = Convert.ToBase64String(Encoding.UTF8.GetBytes("not a pdf")) });
+        // The action must answer with a report, not an error frame — validation never fails a save.
+        Assert.True(response["ok"]!.GetValue<bool>());
+        Assert.False(response["result"]!["valid"]!.GetValue<bool>());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #52. Adds a reusable validator that checks an exported PDF's structural sanity and reports **actionable** findings — what is wrong and where — rather than a pass/fail bit.

Built API-first because ACTION_PLAN.md has #53 (golden-file corpus) and #54 (fuzzing) building on it; the CLI/host surface is a thin wrapper, not the home of the logic.

```csharp
public static ValidationReport Validate(byte[] pdf, string? password = null)
```

- `ValidationModels.cs` — `ValidationSeverity`, `ValidationFinding(Code, Severity, Location, Message)`, `ValidationReport` (`IsValid`, `ErrorCount`, `WarningCount`, `Has(code)`, `ToLogText()`).
- `MessageProcessor.cs` — a `validate` action, ~20 lines of serialisation.

**Checks:** `PDF001` header · `PDF002` `%%EOF` · `PDF003` `startxref` · `PDF004` per-entry xref offsets · `PDF005` parser had to repair the xref · `PDF010` unparsable · `PDF011` catalog/`/Root` · `PDF012` `/Count` mismatch · `PDF020` no pages · `PDF021` `/MediaBox` · `PDF022` `/Type /Page` · `PDF030` decode failure · `PDF031` `/Length` vs `endstream` · `PDF032` unknown filter · `PDF040` missing `/AP /N` · `PDF041` widget not on any page.

## The load-bearing design point: parsers lie
A validator built on iText alone would have reported "valid" for four of the corrupt fixtures. Verified empirically that iText rebuilds a broken xref, repairs a wrong `/Length` by scanning, stamps `/Type /Catalog` onto whatever `/Root` names, and hands back *undecoded* bytes for a Flate stream that will not inflate.

So header, `%%EOF`, `startxref`, xref entries and `/Length` are checked against the **raw bytes**, and Flate is inflated strictly via `ZLibStream`/`DeflateStream`.

## Proving the negative
Tests were written first against a stub returning an empty report, and **19 of 31 failed** at that point. With the full fixture set in place, re-stubbing `Validate` to always report clean fails **28 of 44** Core tests (plus 2 of 3 host tests); the 16 that still pass are the clean-document controls, which must pass either way by construction. Independently reproduced before opening this PR.

Clean controls deliberately include the awkward-but-valid cases: a full-compression document (xref stream + object streams), an indirect `/Length`, a `/Filter` array, an encrypted document, and real redaction/flattening output. That caught one false positive — `stream` inside the name `/application#2foctet-stream` was being read as a stream keyword.

## Test plan
- [x] `dotnet build PdfEditor.sln --configuration Release` — 0 errors (3 warnings, pre-existing on `main`)
- [x] `dotnet test --configuration Release --filter "Category!=Performance"` — **427/427** (Core 272, NativeHost 121, Integration 17, Perf 17); base on current `main` is 380, so +47
- [x] `node --test extension/test/formScript.test.mjs` — **14/14**
- [x] Playwright e2e — **67/67**
- [x] `scripts/coverage.sh 90` — 94.3% overall, `ExportValidator` 95.8%

Fixtures live in a new `tests/PdfEditor.Core.Tests/CorruptPdfs.cs`; `TestPdfs.cs` is untouched. All fixtures are generated in-repo — there is no network access, so nothing is downloaded.

## Deliberately deferred
- **No post-save hook and no extension UI.** `Validate` never throws and never rewrites, so it is safe to wire into a save — but nothing calls it there yet, so this PR cannot regress saving. Wiring it in is a follow-up decision about whether findings warn or block.
- Cross-reference **streams** get parser-level validation only; per-entry offset verification covers classic tables. `/Prev` chains are not walked.
- `RootIsNotACatalog` surfaces as `PDF011` ("the catalog has no `/Pages`") rather than a type mismatch, because iText mutates the object before the validator sees it. The defect is still caught and the message names `trailer /Root`; a byte-level `/Root` type check would be needed for a more precise message.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_