### PR TITLE
Fuzz/regression suite for decompression + parser robustness (#54)

### DIFF
--- a/src/PdfEditor.Core/ContentStreamEditor.cs
+++ b/src/PdfEditor.Core/ContentStreamEditor.cs
@@ -49,11 +49,13 @@ internal sealed class ContentStreamEditor : PdfCanvasProcessor
     public void EditPage(PdfPage page)
     {
         var resources = page.GetResources();
-        byte[] content = page.GetContentBytes();
+        PdfStructureGuard.EnsureFormXObjectsTerminate(page);
+        byte[] content = null!;
+        PdfIo.Guarded("decoding the page content stream", () => content = page.GetContentBytes());
         var newStream = (PdfStream)new PdfStream().MakeIndirect(_document);
         _canvas = new PdfCanvas(newStream, resources, _document);
         _editResources = resources;
-        ProcessContent(content, resources);
+        PdfIo.Guarded("rewriting the page content stream", () => ProcessContent(content, resources));
         page.GetPdfObject().Put(PdfName.Contents, newStream);
         page.GetPdfObject().SetModified();
     }
@@ -61,11 +63,12 @@ internal sealed class ContentStreamEditor : PdfCanvasProcessor
     /// <summary>Rewrites the raw content of a form XObject stream in place.</summary>
     public void EditFormStream(PdfStream formStream, PdfResources resources)
     {
-        byte[] content = formStream.GetBytes();
+        byte[] content = null!;
+        PdfIo.Guarded("decoding a form XObject stream", () => content = formStream.GetBytes());
         var scratch = new PdfStream();
         _canvas = new PdfCanvas(scratch, resources, _document);
         _editResources = resources;
-        ProcessContent(content, resources);
+        PdfIo.Guarded("rewriting a form XObject stream", () => ProcessContent(content, resources));
         formStream.SetData(_canvas.GetContentStream().GetBytes(false));
     }
 

--- a/src/PdfEditor.Core/Encryptor.cs
+++ b/src/PdfEditor.Core/Encryptor.cs
@@ -45,8 +45,11 @@ public static class Encryptor
     {
         try
         {
-            using var doc = new PdfDocument(new PdfReader(new MemoryStream(pdf)));
-            return false;
+            PdfDocument? doc = null;
+            // Guarded for the same reason as PdfIo.Open: a catalog that is not a dictionary makes
+            // iText's constructor throw a bare InvalidCastException, which tells a caller nothing.
+            PdfIo.Guarded("opening the document", () => doc = new PdfDocument(new PdfReader(new MemoryStream(pdf))));
+            using (doc) return false;
         }
         catch (BadPasswordException)
         {

--- a/src/PdfEditor.Core/PageRenderer.cs
+++ b/src/PdfEditor.Core/PageRenderer.cs
@@ -20,8 +20,14 @@ public static class PageRenderer
             password: password,
             options: new RenderOptions(Dpi: dpi, WithAnnotations: true, WithFormFill: true));
 #pragma warning restore CA1416
-        using var image = SKImage.FromBitmap(bitmap);
-        using var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
+        // A malformed document (e.g. a page tree that loops back on itself) can make PDFium hand
+        // back a bitmap with no pixels, and Skia then returns null rather than throwing. Without
+        // these checks the caller sees a bare NullReferenceException instead of being told the
+        // page could not be rendered.
+        using var image = SKImage.FromBitmap(bitmap)
+            ?? throw new InvalidDataException($"Page {page} could not be rendered: the document is malformed.");
+        using var encoded = image.Encode(SKEncodedImageFormat.Png, 100)
+            ?? throw new InvalidDataException($"Page {page} could not be encoded as PNG.");
         return encoded.ToArray();
     }
 }

--- a/src/PdfEditor.Core/PdfIo.cs
+++ b/src/PdfEditor.Core/PdfIo.cs
@@ -12,7 +12,9 @@ internal static class PdfIo
             readerProperties.SetPassword(System.Text.Encoding.UTF8.GetBytes(password));
         var reader = new PdfReader(new MemoryStream(pdf), readerProperties);
         reader.SetUnethicalReading(true);
-        return new PdfDocument(reader, new PdfWriter(output));
+        PdfDocument? doc = null;
+        Guarded("opening the document", () => doc = new GuardedPdfDocument(reader, new PdfWriter(output)));
+        return doc!;
     }
 
     public static PdfDocument OpenReadOnly(byte[] pdf, string? password = null)
@@ -22,6 +24,55 @@ internal static class PdfIo
             readerProperties.SetPassword(System.Text.Encoding.UTF8.GetBytes(password));
         var reader = new PdfReader(new MemoryStream(pdf), readerProperties);
         reader.SetUnethicalReading(true);
-        return new PdfDocument(reader);
+        PdfDocument? doc = null;
+        Guarded("opening the document", () => doc = new GuardedPdfDocument(reader));
+        return doc!;
+    }
+
+    /// <summary>
+    /// Runs a step that feeds raw document bytes into the underlying PDF library and converts the
+    /// library's <em>defect-class</em> exceptions into a typed, message-bearing failure.
+    /// <para>
+    /// Content-stream decoding is the one place where a hostile document reliably drives iText off
+    /// the rails: a truncated Flate stream leaves a number where an operator should be
+    /// (<see cref="InvalidCastException"/>), a corrupt LZW stream dereferences a null dictionary
+    /// entry (<see cref="NullReferenceException"/>), a RunLength stream that promises more bytes
+    /// than it carries walks off its buffer (<see cref="IndexOutOfRangeException"/>). Those escape
+    /// as "Object reference not set to an instance of an object", which tells a caller nothing and
+    /// is indistinguishable from a genuine bug in this engine. Translating them here means every
+    /// malformed-input failure reaches the host as a recoverable, explicable one; the original is
+    /// kept as the inner exception so a real defect is still diagnosable from the stack trace.
+    /// </para>
+    /// </summary>
+    public static void Guarded(string what, Action step)
+    {
+        try
+        {
+            step();
+        }
+        catch (Exception ex) when (ex is NullReferenceException or IndexOutOfRangeException
+                                       or InvalidCastException or KeyNotFoundException)
+        {
+            throw new InvalidDataException(
+                $"This PDF could not be read: {what} failed because the document is malformed or " +
+                $"corrupt ({ex.GetType().Name}).", ex);
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="PdfDocument"/> whose close/save step is <see cref="Guarded"/> too. Closing is
+    /// not a formality: it re-walks the page tree and serialises every object, so a document whose
+    /// <c>/Count</c> lies about the number of kids throws a bare
+    /// <see cref="NullReferenceException"/> out of <c>Dispose</c> — from inside a <c>using</c>, at
+    /// the end of an operation that had otherwise succeeded. Overriding <see cref="Close"/> covers
+    /// every caller at once, because <c>Dispose</c> is implemented in terms of it.
+    /// </summary>
+    private sealed class GuardedPdfDocument : PdfDocument
+    {
+        public GuardedPdfDocument(PdfReader reader) : base(reader) { }
+
+        public GuardedPdfDocument(PdfReader reader, PdfWriter writer) : base(reader, writer) { }
+
+        public override void Close() => Guarded("saving the document", base.Close);
     }
 }

--- a/src/PdfEditor.Core/PdfStructureGuard.cs
+++ b/src/PdfEditor.Core/PdfStructureGuard.cs
@@ -1,0 +1,58 @@
+using iText.Kernel.Pdf;
+
+namespace PdfEditor.Core;
+
+/// <summary>
+/// Structural pre-checks that must run before a page's content is handed to iText's content
+/// processor, for the failures iText itself does not defend against.
+/// </summary>
+internal static class PdfStructureGuard
+{
+    /// <summary>Deepest legitimate form-XObject nesting. Real documents use a handful of levels.</summary>
+    private const int MaxFormNesting = 32;
+
+    /// <summary>Upper bound on nodes inspected, so a wide (rather than deep) graph cannot stall the walk.</summary>
+    private const int MaxFormsInspected = 4096;
+
+    /// <summary>
+    /// Rejects a page whose form-XObject graph does not terminate.
+    /// <para>
+    /// <c>PdfCanvasProcessor</c> follows every <c>/Do</c> into the referenced form XObject and
+    /// processes its content recursively, with no cycle check and no depth limit. A document
+    /// containing a form XObject that lists itself in its own <c>/Resources /XObject</c> therefore
+    /// drives it into infinite recursion — and a <see cref="StackOverflowException"/> cannot be
+    /// caught on .NET, so the whole host process dies. That is a one-file denial of service against
+    /// anyone who opens a hostile PDF, and it has to be prevented rather than handled.
+    /// </para>
+    /// </summary>
+    public static void EnsureFormXObjectsTerminate(PdfPage page)
+    {
+        var onPath = new HashSet<PdfObject>(ReferenceEqualityComparer.Instance);
+        int budget = MaxFormsInspected;
+        Walk(page.GetResources()?.GetResource(PdfName.XObject), onPath, 0, ref budget);
+    }
+
+    private static void Walk(PdfDictionary? xobjects, HashSet<PdfObject> onPath, int depth, ref int budget)
+    {
+        if (xobjects == null || budget <= 0) return;
+        if (depth > MaxFormNesting)
+            throw new InvalidDataException(
+                $"This PDF could not be read: its form XObjects nest more than {MaxFormNesting} " +
+                "levels deep, which no legitimate document does.");
+
+        foreach (var key in xobjects.KeySet().ToList())
+        {
+            if (--budget <= 0) return;
+            var form = xobjects.GetAsStream(key);
+            if (form == null || !PdfName.Form.Equals(form.GetAsName(PdfName.Subtype))) continue;
+
+            if (!onPath.Add(form))
+                throw new InvalidDataException(
+                    "This PDF could not be read: a form XObject draws itself, so its content never " +
+                    "terminates. The document is malformed or deliberately hostile.");
+            Walk(form.GetAsDictionary(PdfName.Resources)?.GetAsDictionary(PdfName.XObject),
+                onPath, depth + 1, ref budget);
+            onPath.Remove(form);
+        }
+    }
+}

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -142,7 +142,12 @@ public static class TextTools
         {
             var strategy = new RegexBasedLocationExtractionStrategy(
                 System.Text.RegularExpressions.Regex.Escape(phrase));
-            new PdfCanvasProcessor(strategy).ProcessPageContent(doc.GetPage(p));
+            int page = p;
+            PdfIo.Guarded($"searching page {page}", () =>
+            {
+                PdfStructureGuard.EnsureFormXObjectsTerminate(doc.GetPage(page));
+                new PdfCanvasProcessor(strategy).ProcessPageContent(doc.GetPage(page));
+            });
             foreach (var location in strategy.GetResultantLocations())
             {
                 var r = location.GetRectangle();
@@ -220,7 +225,11 @@ public static class TextTools
         using var doc = PdfIo.OpenReadOnly(pdf, password);
         if (page < 1 || page > doc.GetNumberOfPages()) return Array.Empty<TextSpan>();
         var spans = new List<TextSpan>();
-        new PdfCanvasProcessor(new SpanListener(spans)).ProcessPageContent(doc.GetPage(page));
+        PdfIo.Guarded($"reading the text layout of page {page}", () =>
+        {
+            PdfStructureGuard.EnsureFormXObjectsTerminate(doc.GetPage(page));
+            new PdfCanvasProcessor(new SpanListener(spans)).ProcessPageContent(doc.GetPage(page));
+        });
         return spans;
     }
 
@@ -254,7 +263,11 @@ public static class TextTools
     {
         var chunks = new List<Chunk>();
         var listener = new ChunkListener(chunks);
-        new PdfCanvasProcessor(listener).ProcessPageContent(doc.GetPage(pageNumber));
+        PdfIo.Guarded($"extracting text from page {pageNumber}", () =>
+        {
+            PdfStructureGuard.EnsureFormXObjectsTerminate(doc.GetPage(pageNumber));
+            new PdfCanvasProcessor(listener).ProcessPageContent(doc.GetPage(pageNumber));
+        });
         return chunks;
     }
 

--- a/tests/PdfEditor.Core.Tests/Fuzz/FuzzCorpus.cs
+++ b/tests/PdfEditor.Core.Tests/Fuzz/FuzzCorpus.cs
@@ -1,0 +1,422 @@
+using System.Globalization;
+using System.Text;
+using SkiaSharp;
+
+namespace PdfEditor.Tests.Fuzz;
+
+/// <summary>One named input in the fuzz corpus.</summary>
+internal sealed record FuzzCase(string Name, byte[] Bytes);
+
+/// <summary>
+/// The seed corpus and the mutator. Everything here is generated in-repo and is fully
+/// deterministic: the same commit produces byte-identical inputs on every machine, and the
+/// mutation stream is driven by <see cref="FuzzHarness.CorpusSeed"/> alone, so a failing case
+/// named in a CI log can be reproduced locally by re-running the same test.
+/// </summary>
+internal static class FuzzCorpus
+{
+    private static readonly byte[] Payload = Encoding.ASCII.GetBytes(
+        "BT /F1 24 Tf 40 500 Td (Fuzz corpus payload text) Tj ET\n" +
+        "0 0 1 rg 40 40 320 200 re f\n");
+
+    /// <summary>
+    /// 8 MiB of highly compressible zeros: a classic decompression bomb once deflated down to a
+    /// few hundred bytes. Large enough that an unbounded expansion is unmistakable, small enough
+    /// that a *bounded* expansion still finishes inside the CI budget.
+    /// </summary>
+    private const int BombSize = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// Streams whose declared filter and actual bytes disagree in every way the issue calls out:
+    /// truncated, corrupt, wrong <c>/Length</c>, mismatched filter chains, and a bomb.
+    /// </summary>
+    public static IReadOnlyList<FuzzCase> FilterCases { get; } = BuildFilterCases();
+
+    /// <summary>Documents whose *structure* is broken: xref, offsets, page tree, required keys.</summary>
+    public static IReadOnlyList<FuzzCase> StructureCases { get; } = BuildStructureCases();
+
+    /// <summary>
+    /// The base documents the mutator chews on. Real, valid PDFs — so a mutation lands in a
+    /// plausible place rather than producing obvious garbage that the reader rejects at byte 1.
+    /// <para>
+    /// They are all written by <see cref="RawPdf"/> (or by <see cref="TestPdfs.ChromeStyleLeftoverCtm"/>,
+    /// which is likewise hand-written) rather than by iText, because <em>iText's output is not
+    /// reproducible</em>: it stamps a timestamp-derived <c>/ID</c> and <c>/ModDate</c> into every
+    /// file, so two calls in the same process already differ. Seeding a fuzzer with those would
+    /// make every failure a one-off that cannot be reproduced from the recorded seed.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<FuzzCase> MutationSeeds { get; } = new[]
+    {
+        new FuzzCase("seed-plain", RawPdf.ContentStreamDoc("", Payload)),
+        new FuzzCase("seed-flate", RawPdf.ContentStreamDoc("/Filter /FlateDecode", RawPdf.Deflate(Payload))),
+        new FuzzCase("seed-multipage", RawPdf.MultiPageDoc(3)),
+        new FuzzCase("seed-chrome", TestPdfs.ChromeStyleLeftoverCtm()),
+    };
+
+    private static List<FuzzCase> BuildFilterCases()
+    {
+        byte[] flate = RawPdf.Deflate(Payload);
+        byte[] corruptFlate = (byte[])flate.Clone();
+        for (int i = 4; i < corruptFlate.Length; i += 3) corruptFlate[i] ^= 0x5A;
+
+        byte[] bomb = RawPdf.Deflate(new byte[BombSize]);
+        byte[] jpeg = Jpeg();
+        byte[] corruptJpeg = (byte[])jpeg.Clone();
+        for (int i = 20; i < corruptJpeg.Length; i += 7) corruptJpeg[i] ^= 0xFF;
+
+        var cases = new List<FuzzCase>
+        {
+            // --- FlateDecode ---------------------------------------------------------------
+            new("flate-valid", RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate)),
+            new("flate-truncated-half",
+                RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate[..(flate.Length / 2)])),
+            new("flate-truncated-header", RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate[..2])),
+            new("flate-corrupt-body", RawPdf.ContentStreamDoc("/Filter /FlateDecode", corruptFlate)),
+            new("flate-empty", RawPdf.ContentStreamDoc("/Filter /FlateDecode", Array.Empty<byte>())),
+            new("flate-length-too-short",
+                RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate, declaredLength: 5)),
+            new("flate-length-too-long",
+                RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate, declaredLength: flate.Length + 4096)),
+            new("flate-length-negative",
+                RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate, declaredLength: -17)),
+            new("flate-length-indirect-missing",
+                RawPdf.Build(new[]
+                {
+                    RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                    RawPdf.Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+                    RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] /Contents 4 0 R >>"),
+                    Concat(Encoding.ASCII.GetBytes("<< /Length 99 0 R /Filter /FlateDecode >>\nstream\n"),
+                        flate, Encoding.ASCII.GetBytes("\nendstream")),
+                }, "/Root 1 0 R")),
+            new("flate-no-endstream",
+                RawPdf.ContentStreamDoc("/Filter /FlateDecode", flate, omitEndstream: true)),
+            new("flate-bomb-8mib", RawPdf.ContentStreamDoc("/Filter /FlateDecode", bomb)),
+            new("flate-bomb-as-image",
+                RawPdf.ImageDoc("/Filter /FlateDecode", bomb, 4096, 4096)),
+
+            // --- ASCIIHexDecode ------------------------------------------------------------
+            new("asciihex-valid", RawPdf.ContentStreamDoc("/Filter /ASCIIHexDecode", RawPdf.AsciiHex(Payload))),
+            new("asciihex-odd-digits",
+                RawPdf.ContentStreamDoc("/Filter /ASCIIHexDecode", Encoding.ASCII.GetBytes("48656C6C6F2>"))),
+            new("asciihex-invalid-chars",
+                RawPdf.ContentStreamDoc("/Filter /ASCIIHexDecode", Encoding.ASCII.GetBytes("zzQQ!!##%%^^>"))),
+            new("asciihex-no-eod",
+                RawPdf.ContentStreamDoc("/Filter /ASCIIHexDecode", Encoding.ASCII.GetBytes("4142434445"))),
+
+            // --- ASCII85Decode -------------------------------------------------------------
+            new("ascii85-valid", RawPdf.ContentStreamDoc("/Filter /ASCII85Decode", RawPdf.Ascii85(Payload))),
+            new("ascii85-invalid-chars",
+                RawPdf.ContentStreamDoc("/Filter /ASCII85Decode", Encoding.ASCII.GetBytes("~~~vw~>"))),
+            new("ascii85-truncated-group",
+                RawPdf.ContentStreamDoc("/Filter /ASCII85Decode",
+                    RawPdf.Ascii85(Payload)[..17])),
+            new("ascii85-no-eod",
+                RawPdf.ContentStreamDoc("/Filter /ASCII85Decode", Encoding.ASCII.GetBytes("87cURD]i,\"Ebo80"))),
+            new("ascii85-z-inside-group",
+                RawPdf.ContentStreamDoc("/Filter /ASCII85Decode", Encoding.ASCII.GetBytes("87zcURD~>"))),
+            new("ascii85-overflow-group",
+                RawPdf.ContentStreamDoc("/Filter /ASCII85Decode", Encoding.ASCII.GetBytes("uuuuu~>"))),
+
+            // --- LZWDecode -----------------------------------------------------------------
+            // No valid LZW encoder is needed here: every LZW case in the issue is a *broken* one.
+            new("lzw-garbage",
+                RawPdf.ContentStreamDoc("/Filter /LZWDecode", Payload)),
+            new("lzw-truncated",
+                RawPdf.ContentStreamDoc("/Filter /LZWDecode", new byte[] { 0x80, 0x0B, 0x60 })),
+            new("lzw-all-ones",
+                RawPdf.ContentStreamDoc("/Filter /LZWDecode", Enumerable.Repeat((byte)0xFF, 512).ToArray())),
+            new("lzw-early-change-zero",
+                RawPdf.ContentStreamDoc("/Filter /LZWDecode /DecodeParms << /EarlyChange 0 >>", Payload)),
+
+            // --- RunLengthDecode -----------------------------------------------------------
+            new("runlength-valid",
+                RawPdf.ContentStreamDoc("/Filter /RunLengthDecode", RawPdf.RunLength(Payload))),
+            new("runlength-truncated-literal",
+                RawPdf.ContentStreamDoc("/Filter /RunLengthDecode", new byte[] { 100, 65, 66, 67 })),
+            new("runlength-no-eod",
+                RawPdf.ContentStreamDoc("/Filter /RunLengthDecode",
+                    RawPdf.RunLength(Payload)[..^1])),
+            new("runlength-trailing-run-byte",
+                RawPdf.ContentStreamDoc("/Filter /RunLengthDecode", new byte[] { 250 })),
+
+            // --- DCTDecode -----------------------------------------------------------------
+            new("dct-valid", RawPdf.ImageDoc("/Filter /DCTDecode", jpeg, 32, 32)),
+            new("dct-truncated", RawPdf.ImageDoc("/Filter /DCTDecode", jpeg[..(jpeg.Length / 3)], 32, 32)),
+            new("dct-corrupt-scan", RawPdf.ImageDoc("/Filter /DCTDecode", corruptJpeg, 32, 32)),
+            new("dct-not-a-jpeg", RawPdf.ImageDoc("/Filter /DCTDecode", Payload, 32, 32)),
+            new("dct-dimensions-lie", RawPdf.ImageDoc("/Filter /DCTDecode", jpeg, 30000, 30000)),
+
+            // --- Filter chains and nonsense filters ----------------------------------------
+            new("chain-a85-flate-mismatch",
+                RawPdf.ContentStreamDoc("/Filter [/ASCII85Decode /FlateDecode]", flate)),
+            new("chain-flate-declared-twice",
+                RawPdf.ContentStreamDoc("/Filter [/FlateDecode /FlateDecode]", flate)),
+            new("chain-a85-then-flate-valid",
+                RawPdf.ContentStreamDoc("/Filter [/ASCII85Decode /FlateDecode]", RawPdf.Ascii85(flate))),
+            new("filter-unknown-name",
+                RawPdf.ContentStreamDoc("/Filter /NoSuchDecode", Payload)),
+            new("filter-is-a-number",
+                RawPdf.ContentStreamDoc("/Filter 42", Payload)),
+            new("filter-self-recursive-chain",
+                RawPdf.ContentStreamDoc(
+                    "/Filter [/FlateDecode /FlateDecode /FlateDecode /FlateDecode /FlateDecode]", flate)),
+            new("crypt-filter-without-encryption",
+                RawPdf.ContentStreamDoc("/Filter /Crypt", Payload)),
+        };
+        return cases;
+    }
+
+    private static List<FuzzCase> BuildStructureCases()
+    {
+        byte[][] good =
+        {
+            RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+            RawPdf.Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] /Contents 4 0 R >>"),
+            RawPdf.StreamObj("", Payload),
+        };
+
+        var cases = new List<FuzzCase>();
+        foreach (var damage in Enum.GetValues<XrefDamage>())
+            cases.Add(new FuzzCase("xref-" + damage, RawPdf.Build(good, "/Root 1 0 R", damage)));
+
+        cases.AddRange(new FuzzCase[]
+        {
+            new("trailer-no-root", RawPdf.Build(good, "")),
+            new("trailer-root-missing-object", RawPdf.Build(good, "/Root 77 0 R")),
+            new("trailer-root-is-a-string", RawPdf.Build(good, "/Root (not a dictionary)")),
+
+            new("pagetree-cycle-self", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [2 0 R] /Count 1 >>"),
+            }, "/Root 1 0 R")),
+            new("pagetree-cycle-two-node", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+                RawPdf.Obj("<< /Type /Pages /Parent 2 0 R /Kids [2 0 R] /Count 1 >>"),
+            }, "/Root 1 0 R")),
+            new("pagetree-parent-cycle", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 /Parent 3 0 R >>"),
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] >>"),
+            }, "/Root 1 0 R")),
+            new("pagetree-count-lies", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [3 0 R] /Count 100000 >>"),
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] >>"),
+            }, "/Root 1 0 R")),
+            new("pagetree-empty-kids", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [] /Count 0 >>"),
+            }, "/Root 1 0 R")),
+            new("pagetree-kid-is-missing-object", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [64 0 R] /Count 1 >>"),
+            }, "/Root 1 0 R")),
+
+            new("page-no-mediabox", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /Contents 4 0 R >>"),
+                good[3],
+            }, "/Root 1 0 R")),
+            new("page-mediabox-degenerate", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 0 0] /Contents 4 0 R >>"),
+                good[3],
+            }, "/Root 1 0 R")),
+            new("page-mediabox-nonsense", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [(a) (b) /c << >>] /Contents 4 0 R >>"),
+                good[3],
+            }, "/Root 1 0 R")),
+            new("page-mediabox-astronomical", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 1e30 1e30] /Contents 4 0 R >>"),
+                good[3],
+            }, "/Root 1 0 R")),
+            new("page-contents-missing-object", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] /Contents 88 0 R >>"),
+            }, "/Root 1 0 R")),
+            new("page-contents-is-a-dictionary", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] /Contents << /a 1 >> >>"),
+            }, "/Root 1 0 R")),
+            new("page-contents-points-at-itself", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] /Contents 3 0 R >>"),
+            }, "/Root 1 0 R")),
+            new("page-resources-cycle", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] " +
+                           "/Resources << /XObject << /Im1 5 0 R >> >> /Contents 4 0 R >>"),
+                RawPdf.StreamObj("", Encoding.ASCII.GetBytes("q /Im1 Do Q\n")),
+                RawPdf.StreamObj("/Type /XObject /Subtype /Form /BBox [0 0 10 10] " +
+                                 "/Resources << /XObject << /Im1 5 0 R >> >>",
+                    Encoding.ASCII.GetBytes("q /Im1 Do Q\n")),
+            }, "/Root 1 0 R")),
+            new("form-xobject-nesting-200", RawPdf.DeeplyNestedForms(200)),
+            new("form-xobject-nesting-4", RawPdf.DeeplyNestedForms(4)),
+            new("page-type-is-wrong", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Bogus /Parent 2 0 R /MediaBox [0 0 400 600] /Contents 4 0 R >>"),
+                good[3],
+            }, "/Root 1 0 R")),
+
+            new("object-numbering-mismatch", RawPdf.Build(new[]
+            {
+                RawPdf.Obj("<< /Type /Catalog /Pages 9 0 R >>"),
+                RawPdf.Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] >>"),
+            }, "/Root 1 0 R")),
+            new("deeply-nested-arrays", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] /Contents 4 0 R /Junk " +
+                           new string('[', 400) + new string(']', 400) + " >>"),
+                good[3],
+            }, "/Root 1 0 R")),
+            new("dictionary-unterminated", RawPdf.Build(new[]
+            {
+                good[0], good[1],
+                RawPdf.Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600"),
+            }, "/Root 1 0 R")),
+            new("no-eof-marker",
+                RawPdf.Build(good, "/Root 1 0 R")[..^6]),
+            new("header-only", Encoding.ASCII.GetBytes("%PDF-1.7\n")),
+            new("empty", Array.Empty<byte>()),
+        });
+        return cases;
+    }
+
+    /// <summary>
+    /// Produces <paramref name="count"/> deterministic mutations of <paramref name="seed"/>. The
+    /// PRNG is seeded from <see cref="FuzzHarness.CorpusSeed"/> combined with the seed document's
+    /// name, so each document's mutation stream is independent yet perfectly reproducible, and
+    /// adding a new seed document never renumbers the existing ones' cases.
+    /// </summary>
+    public static IEnumerable<FuzzCase> Mutate(FuzzCase seed, int count)
+    {
+        var rng = new Random(FuzzHarness.CorpusSeed ^ StableHash(seed.Name));
+        for (int i = 0; i < count; i++)
+        {
+            var bytes = (byte[])seed.Bytes.Clone();
+            string kind = ApplyMutation(rng, ref bytes);
+            yield return new FuzzCase(
+                string.Create(CultureInfo.InvariantCulture, $"{seed.Name}-{i:D3}-{kind}"), bytes);
+        }
+    }
+
+    /// <summary>Applies one random mutation in place (or replaces the array) and names it.</summary>
+    private static string ApplyMutation(Random rng, ref byte[] bytes)
+    {
+        if (bytes.Length < 32) return "noop";
+        switch (rng.Next(7))
+        {
+            case 0: // single bit flip
+                {
+                    int at = rng.Next(bytes.Length);
+                    bytes[at] ^= (byte)(1 << rng.Next(8));
+                    return "bitflip";
+                }
+            case 1: // splat a random byte over a short run
+                {
+                    int at = rng.Next(bytes.Length);
+                    int len = Math.Min(bytes.Length - at, 1 + rng.Next(16));
+                    byte value = (byte)rng.Next(256);
+                    for (int i = 0; i < len; i++) bytes[at + i] = value;
+                    return "splat";
+                }
+            case 2: // truncate
+                bytes = bytes[..(1 + rng.Next(bytes.Length - 1))];
+                return "truncate";
+            case 3: // delete an interior chunk (shifts every later offset — murder on the xref)
+                {
+                    int at = rng.Next(bytes.Length - 1);
+                    int len = Math.Min(bytes.Length - at, 1 + rng.Next(64));
+                    bytes = bytes[..at].Concat(bytes[(at + len)..]).ToArray();
+                    return "delete";
+                }
+            case 4: // insert random bytes
+                {
+                    int at = rng.Next(bytes.Length);
+                    var inserted = new byte[1 + rng.Next(32)];
+                    rng.NextBytes(inserted);
+                    bytes = bytes[..at].Concat(inserted).Concat(bytes[at..]).ToArray();
+                    return "insert";
+                }
+            case 5: // scramble an ASCII digit run: turns xref offsets and /Length values into lies
+                {
+                    int at = FindDigit(rng, bytes);
+                    if (at < 0) goto case 0;
+                    for (int i = at; i < bytes.Length && bytes[i] is >= (byte)'0' and <= (byte)'9'; i++)
+                        bytes[i] = (byte)('0' + rng.Next(10));
+                    return "digits";
+                }
+            default: // swap two equal-sized chunks
+                {
+                    int len = 1 + rng.Next(32);
+                    if (bytes.Length < 2 * len) goto case 0;
+                    int a = rng.Next(bytes.Length - 2 * len);
+                    int b = a + len + rng.Next(bytes.Length - a - 2 * len);
+                    for (int i = 0; i < len; i++)
+                        (bytes[a + i], bytes[b + i]) = (bytes[b + i], bytes[a + i]);
+                    return "swap";
+                }
+        }
+    }
+
+    /// <summary>Finds an ASCII digit at or after a random position; -1 when there is none.</summary>
+    private static int FindDigit(Random rng, byte[] bytes)
+    {
+        int start = rng.Next(bytes.Length);
+        for (int i = start; i < bytes.Length; i++)
+            if (bytes[i] is >= (byte)'0' and <= (byte)'9') return i;
+        return -1;
+    }
+
+    /// <summary>
+    /// A hash that does not vary between runs or frameworks — <see cref="string.GetHashCode()"/>
+    /// is randomised per process and would make the corpus irreproducible.
+    /// </summary>
+    private static int StableHash(string text)
+    {
+        int hash = 17;
+        foreach (char c in text) hash = unchecked(hash * 31 + c);
+        return hash;
+    }
+
+    /// <summary>A tiny, deterministic baseline JPEG for the DCTDecode cases.</summary>
+    private static byte[] Jpeg()
+    {
+        using var bitmap = new SKBitmap(32, 32);
+        for (int y = 0; y < 32; y++)
+            for (int x = 0; x < 32; x++)
+                bitmap.SetPixel(x, y, new SKColor((byte)(x * 8), (byte)(y * 8), 128));
+        using var image = SKImage.FromBitmap(bitmap);
+        return image.Encode(SKEncodedImageFormat.Jpeg, 80).ToArray();
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var output = new MemoryStream();
+        foreach (var part in parts) output.Write(part);
+        return output.ToArray();
+    }
+}

--- a/tests/PdfEditor.Core.Tests/Fuzz/FuzzHarness.cs
+++ b/tests/PdfEditor.Core.Tests/Fuzz/FuzzHarness.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PdfEditor.Tests.Fuzz;
+
+/// <summary>What running one operation over one hostile input produced.</summary>
+internal enum FuzzOutcome
+{
+    /// <summary>The operation ran to completion. Tolerating malformed input is allowed.</summary>
+    Completed,
+    /// <summary>The operation refused the input with a recoverable, typed exception.</summary>
+    Rejected,
+}
+
+/// <summary>The verdict for a single fuzz case, used by the tests to summarise a run.</summary>
+internal sealed record FuzzResult(string Case, FuzzOutcome Outcome, string? ExceptionType, double Milliseconds);
+
+/// <summary>
+/// Thrown when a fuzz case violates the robustness contract. Carries the offending bytes so the
+/// failure is reproducible from the test artifacts, not just from the seed.
+/// </summary>
+internal sealed class FuzzContractViolationException : Exception
+{
+    public FuzzContractViolationException(string message) : base(message) { }
+}
+
+/// <summary>
+/// The enforcement half of the fuzzing suite. Every case runs through <see cref="Run"/>, which
+/// holds the parser to a single explicit contract:
+/// <list type="bullet">
+///   <item>it may succeed, or</item>
+///   <item>it may fail with a <em>recoverable</em> exception carrying a non-empty message,</item>
+/// </list>
+/// and nothing else. Specifically it may not
+/// <list type="bullet">
+///   <item>hang — every case runs on its own thread under a wall-clock budget and the budget's
+///     expiry is a test failure, not a stalled CI job;</item>
+///   <item>fail with a defect-class exception (<see cref="NullReferenceException"/>,
+///     <see cref="IndexOutOfRangeException"/>, <see cref="KeyNotFoundException"/>, …) — those are
+///     unhandled crashes that happen to be catchable on .NET, and they mean the parser walked off
+///     the end of something rather than validating it;</item>
+///   <item>allocate without bound — the per-case allocation budget catches decompression bombs.</item>
+/// </list>
+/// Every violation writes the exact input bytes to <see cref="ArtifactDirectory"/> and names both
+/// the file and the corpus seed in the failure message, so a red run is always reproducible.
+/// <para>
+/// Known limitation: a <see cref="StackOverflowException"/> is process-fatal on .NET and cannot be
+/// intercepted here — an input that sends the engine into unbounded recursion aborts the whole test
+/// run instead of failing one case. That is still a loud, unmissable failure (the run reports
+/// "Test Run Aborted" and the recursive stack is printed), and it is exactly how the
+/// self-referential form XObject that <c>PdfStructureGuard</c> now rejects was found.
+/// </para>
+/// </summary>
+internal static class FuzzHarness
+{
+    /// <summary>
+    /// The fixed PRNG seed for the whole mutation corpus. Printed in every failure message; change
+    /// it only deliberately, because changing it changes every generated input.
+    /// </summary>
+    public const int CorpusSeed = 0x5EED54;
+
+    /// <summary>Wall-clock budget for one operation over one input. Exceeding it fails the test.</summary>
+    public static readonly TimeSpan CaseBudget = TimeSpan.FromSeconds(
+        double.TryParse(Environment.GetEnvironmentVariable("PDFEDITOR_FUZZ_CASE_SECONDS"),
+            CultureInfo.InvariantCulture, out double s) && s > 0 ? s : 20);
+
+    /// <summary>
+    /// Managed-allocation budget for one operation over one input (512 MiB). A parser that streams
+    /// or rejects a decompression bomb stays far below it; one that materialises the bomb does not.
+    /// </summary>
+    public const long AllocationBudgetBytes = 512L * 1024 * 1024;
+
+    /// <summary>Where offending inputs are dumped. Emitted next to the test binary so CI can collect it.</summary>
+    public static string ArtifactDirectory { get; } = Path.Combine(
+        Path.GetDirectoryName(typeof(FuzzHarness).Assembly.Location) ?? ".", "fuzz-artifacts");
+
+    /// <summary>
+    /// Exception types that mean "this code has a defect", not "this input was rejected". They are
+    /// what a parser throws when it walks off the end of a buffer, dereferences a dictionary entry
+    /// that was not there, or casts an object it never checked — i.e. an unhandled crash that .NET
+    /// happens to make catchable. A caller cannot distinguish one of these from a genuine bug in
+    /// the engine, and "Object reference not set to an instance of an object" is not an error
+    /// message a user can act on.
+    /// <para>
+    /// A deny-list rather than an allow-list, because the engine legitimately surfaces typed
+    /// failures from several libraries (iText's <c>PdfException</c>, PDFtoImage's
+    /// <c>PdfInvalidFormatException</c>, …) and new ones must not silently count as violations.
+    /// </para>
+    /// </summary>
+    private static readonly Type[] DefectClassExceptions =
+    {
+        typeof(NullReferenceException),
+        typeof(IndexOutOfRangeException),
+        typeof(InvalidCastException),
+        typeof(KeyNotFoundException),
+        typeof(DivideByZeroException),
+        typeof(NotImplementedException),
+        typeof(AccessViolationException),
+        typeof(OutOfMemoryException),
+        typeof(StackOverflowException),
+        typeof(System.Runtime.InteropServices.SEHException),
+        typeof(BadImageFormatException),
+    };
+
+    /// <summary>
+    /// Bare, meaningless exception types. Throwing <c>new Exception("…")</c> from a parser gives a
+    /// caller nothing to branch on, so it is treated as a violation just like a defect class.
+    /// </summary>
+    private static readonly Type[] UntypedExceptions =
+    {
+        typeof(Exception), typeof(SystemException), typeof(ApplicationException),
+    };
+
+    private static bool IsRecoverable(Exception ex) =>
+        !DefectClassExceptions.Any(t => t.IsInstanceOfType(ex)) &&
+        !UntypedExceptions.Contains(ex.GetType());
+
+    /// <summary>
+    /// Runs <paramref name="operation"/> over <paramref name="input"/> under the full contract and
+    /// returns what happened. Throws <see cref="FuzzContractViolationException"/> — never the
+    /// operation's own exception — when the contract is broken.
+    /// </summary>
+    public static FuzzResult Run(string caseName, byte[] input, Action<byte[]> operation)
+        => RunWithBudget(caseName, input, operation, CaseBudget);
+
+    /// <summary>
+    /// <see cref="Run"/> with an explicit time budget. Exposed so the harness's own tests can prove
+    /// the timeout fires without making the suite wait the full production budget.
+    /// </summary>
+    public static FuzzResult RunWithBudget(string caseName, byte[] input, Action<byte[]> operation,
+        TimeSpan budget)
+    {
+        Exception? thrown = null;
+        long allocated = 0;
+        var clock = Stopwatch.StartNew();
+
+        // A dedicated thread, not the thread pool: a hung case must not starve the pool, and
+        // Join(timeout) is the only way to put a hard wall-clock bound around code that may loop
+        // forever. .NET cannot abort a runaway thread, so the thread is a background thread and is
+        // deliberately abandoned on timeout — the process still exits when the run finishes.
+        var worker = new Thread(() =>
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            try { operation(input); }
+            catch (Exception ex) { thrown = ex; }
+            finally { allocated = GC.GetAllocatedBytesForCurrentThread() - before; }
+        })
+        { IsBackground = true, Name = "fuzz:" + caseName };
+
+        worker.Start();
+        bool finished = worker.Join(budget);
+        clock.Stop();
+
+        if (!finished)
+            throw Violation(caseName, input,
+                $"did not finish within {budget.TotalSeconds:F1}s — a hang, not a handled failure");
+
+        if (thrown != null)
+        {
+            var ex = Unwrap(thrown);
+            if (!IsRecoverable(ex))
+                throw Violation(caseName, input,
+                    $"threw {ex.GetType().FullName} — a defect-class exception, not a handled rejection " +
+                    "(the engine walked off the end of something instead of validating it)." +
+                    Environment.NewLine + ex);
+            if (string.IsNullOrWhiteSpace(ex.Message))
+                throw Violation(caseName, input, $"threw {ex.GetType().FullName} with an empty message");
+        }
+
+        if (allocated > AllocationBudgetBytes)
+            throw Violation(caseName, input,
+                $"allocated {allocated / (1024 * 1024)} MiB, over the " +
+                $"{AllocationBudgetBytes / (1024 * 1024)} MiB budget — unbounded expansion");
+
+        return thrown == null
+            ? new FuzzResult(caseName, FuzzOutcome.Completed, null, clock.Elapsed.TotalMilliseconds)
+            : new FuzzResult(caseName, FuzzOutcome.Rejected, Unwrap(thrown).GetType().Name,
+                clock.Elapsed.TotalMilliseconds);
+    }
+
+    /// <summary>Unwraps the reflection/aggregate wrappers so the real failure is judged.</summary>
+    private static Exception Unwrap(Exception ex) => ex switch
+    {
+        TargetInvocationException { InnerException: { } inner } => Unwrap(inner),
+        AggregateException { InnerExceptions.Count: 1 } agg => Unwrap(agg.InnerExceptions[0]),
+        _ => ex,
+    };
+
+    /// <summary>Dumps the offending input and builds the failure message that points at it.</summary>
+    private static FuzzContractViolationException Violation(string caseName, byte[] input, string what)
+    {
+        string path = DumpArtifact(caseName, input);
+        return new FuzzContractViolationException(
+            $"Fuzz case '{caseName}' {what}." + Environment.NewLine +
+            $"Corpus seed: 0x{CorpusSeed:X} (reproducible). Input: {input.Length} bytes, " +
+            $"sha256 {Convert.ToHexString(SHA256.HashData(input))[..16]}." + Environment.NewLine +
+            $"Offending bytes written to: {path}");
+    }
+
+    /// <summary>Writes the input beside the test binary; never lets an I/O problem mask the failure.</summary>
+    private static string DumpArtifact(string caseName, byte[] input)
+    {
+        try
+        {
+            Directory.CreateDirectory(ArtifactDirectory);
+            var safe = new StringBuilder(caseName.Length);
+            foreach (char c in caseName)
+                safe.Append(char.IsLetterOrDigit(c) || c is '-' or '_' or '.' ? c : '_');
+            string path = Path.Combine(ArtifactDirectory, safe + ".pdf");
+            File.WriteAllBytes(path, input);
+            return path;
+        }
+        catch (IOException ex) { return "<could not write artifact: " + ex.Message + ">"; }
+        catch (UnauthorizedAccessException ex) { return "<could not write artifact: " + ex.Message + ">"; }
+    }
+}

--- a/tests/PdfEditor.Core.Tests/Fuzz/FuzzHarnessSelfTests.cs
+++ b/tests/PdfEditor.Core.Tests/Fuzz/FuzzHarnessSelfTests.cs
@@ -1,0 +1,141 @@
+using System.Text;
+
+namespace PdfEditor.Tests.Fuzz;
+
+/// <summary>
+/// Proves the fuzz harness has teeth. A fuzzing suite that passes because it silently fails to
+/// exercise anything is worse than no suite at all, so each of the three failure modes the harness
+/// claims to catch — hangs, defect-class exceptions, unbounded allocation — is demonstrated here
+/// against a deliberately broken operation. If any of these tests stops failing the harness has
+/// gone blind, and <see cref="ParserFuzzTests"/> is no longer meaningful.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA2201:Do not raise reserved exception types",
+    Justification = "Raising the reserved defect-class exceptions on purpose is the whole point: " +
+                    "these tests prove the harness rejects exactly those, and no substitute type would.")]
+public class FuzzHarnessSelfTests
+{
+    private static readonly byte[] Input = Encoding.ASCII.GetBytes("%PDF-1.7\nnot a real document\n");
+
+    [Fact]
+    public void Harness_CatchesAHang()
+    {
+        var stop = new ManualResetEventSlim();
+        try
+        {
+            var ex = Assert.Throws<FuzzContractViolationException>(() =>
+                FuzzHarness.RunWithBudget("selftest-hang", Input, _ => stop.Wait(),
+                    TimeSpan.FromMilliseconds(250)));
+            Assert.Contains("a hang, not a handled failure", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            stop.Set(); // release the abandoned worker thread
+        }
+    }
+
+    [Fact]
+    public void Harness_CatchesADefectClassException()
+    {
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-nre", Input, _ => throw new NullReferenceException("boom")));
+        Assert.Contains("defect-class exception", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(NullReferenceException), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(typeof(IndexOutOfRangeException))]
+    [InlineData(typeof(KeyNotFoundException))]
+    [InlineData(typeof(InvalidCastException))]
+    [InlineData(typeof(DivideByZeroException))]
+    public void Harness_RejectsEveryDefectClassException(Type defect)
+    {
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-defect", Input,
+                _ => throw (Exception)Activator.CreateInstance(defect)!));
+        Assert.Contains("defect-class exception", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A bare <c>Exception</c> is untyped: the caller cannot branch on it, so it fails too.</summary>
+    [Fact]
+    public void Harness_RejectsAnUntypedException()
+    {
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-untyped", Input, _ => throw new Exception("something went wrong")));
+        Assert.Contains("not a handled rejection", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Harness_CatchesUnboundedAllocation()
+    {
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-bomb", Input, _ =>
+            {
+                // ~640 MiB of managed allocation, past the 512 MiB budget, without ever holding
+                // more than one buffer alive — exactly what a streaming decompression bomb looks like.
+                for (int i = 0; i < 10; i++) GC.KeepAlive(new byte[64 * 1024 * 1024]);
+            }));
+        Assert.Contains("unbounded expansion", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Harness_CatchesAnEmptyExceptionMessage()
+    {
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-silent", Input, _ => throw new SilentException()));
+        Assert.Contains("empty message", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Harness_AcceptsARecoverableRejection()
+    {
+        var result = FuzzHarness.Run("selftest-ok", Input,
+            _ => throw new InvalidOperationException("that is not a PDF"));
+        Assert.Equal(FuzzOutcome.Rejected, result.Outcome);
+        Assert.Equal(nameof(InvalidOperationException), result.ExceptionType);
+    }
+
+    [Fact]
+    public void Harness_AcceptsSuccess()
+    {
+        var result = FuzzHarness.Run("selftest-success", Input, _ => { });
+        Assert.Equal(FuzzOutcome.Completed, result.Outcome);
+        Assert.Null(result.ExceptionType);
+    }
+
+    [Fact]
+    public void Harness_UnwrapsWrappedExceptions()
+    {
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-wrapped", Input,
+                _ => throw new AggregateException(new NullReferenceException("inner boom"))));
+        Assert.Contains(nameof(NullReferenceException), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Harness_TreatsITextExceptionsAsHandledRejections()
+    {
+        var result = FuzzHarness.Run("selftest-itext", Input,
+            _ => throw new iText.Kernel.Exceptions.PdfException("trailer not found"));
+        Assert.Equal(FuzzOutcome.Rejected, result.Outcome);
+    }
+
+    /// <summary>Writes the offending bytes so a CI failure can be reproduced from the artifact.</summary>
+    [Fact]
+    public void Harness_DumpsTheOffendingInputAsAnArtifact()
+    {
+        byte[] distinctive = Encoding.ASCII.GetBytes("%PDF-1.7 artifact-dump-probe");
+        var ex = Assert.Throws<FuzzContractViolationException>(() =>
+            FuzzHarness.Run("selftest-artifact", distinctive, _ => throw new NullReferenceException("boom")));
+
+        string path = Path.Combine(FuzzHarness.ArtifactDirectory, "selftest-artifact.pdf");
+        Assert.Contains(path, ex.Message, StringComparison.Ordinal);
+        Assert.Equal(distinctive, File.ReadAllBytes(path));
+        Assert.Contains($"Corpus seed: 0x{FuzzHarness.CorpusSeed:X}", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Recoverable by type, but useless to a caller — the harness must still reject it.</summary>
+    private sealed class SilentException : InvalidOperationException
+    {
+        public SilentException() : base("") { }
+    }
+}

--- a/tests/PdfEditor.Core.Tests/Fuzz/ParserFuzzTests.cs
+++ b/tests/PdfEditor.Core.Tests/Fuzz/ParserFuzzTests.cs
@@ -1,0 +1,277 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using PdfEditor.Core;
+
+namespace PdfEditor.Tests.Fuzz;
+
+/// <summary>
+/// Fuzz/regression suite for the decompression and parsing paths (issue #54).
+/// <para>
+/// The engine is a library that a browser extension hands untrusted files to, so the only
+/// acceptable reaction to a malformed document is a <em>handled</em> one: a clean result, or a
+/// recoverable exception the native host can turn into an error envelope. A hang, a decompression
+/// bomb, or a <see cref="NullReferenceException"/> from deep inside a parser are all failures.
+/// <see cref="FuzzHarness"/> enforces exactly that, with a wall-clock budget per case so a hang
+/// surfaces as a red test rather than a stalled CI job.
+/// </para>
+/// <para>
+/// The corpus is generated in-repo from a fixed seed, so a failure names a case that can be
+/// re-run verbatim, and the offending bytes are dumped to <c>fuzz-artifacts/</c>.
+/// </para>
+/// </summary>
+public class ParserFuzzTests
+{
+    /// <summary>
+    /// Mutations generated per seed document. Kept small enough that the whole suite is a
+    /// few seconds; <c>PDFEDITOR_FUZZ_MUTATIONS</c> raises it for a deeper (e.g. nightly) run
+    /// without making the default CI pass slow.
+    /// </summary>
+    private static readonly int MutationsPerSeed =
+        int.TryParse(Environment.GetEnvironmentVariable("PDFEDITOR_FUZZ_MUTATIONS"),
+            CultureInfo.InvariantCulture, out int n) && n > 0 ? n : 40;
+
+    private static readonly RectRegion Region = new(1, 20, 20, 120, 40);
+
+    /// <summary>
+    /// The entry points a hostile document reaches. Read-only inspection, rendering, text
+    /// extraction and redaction between them cover the xref/object parser, the stream filters,
+    /// the image decoders and the content-stream tokeniser.
+    /// </summary>
+    private static readonly (string Name, Action<byte[]> Run)[] Operations =
+    {
+        ("GetInfo", pdf => PdfInspector.GetInfo(pdf)),
+        ("RenderPagePng", pdf => PageRenderer.RenderPagePng(pdf, 1, 72)),
+        ("FindText", pdf => TextTools.FindText(pdf, "payload")),
+        ("Redact", pdf => Redactor.Redact(pdf, new[] { Region })),
+        ("SafetyScan", pdf => PdfSafety.Scan(pdf)),
+    };
+
+    /// <summary>Inspection and text extraction only — the cheap pair used for the bulk mutation sweep.</summary>
+    private static readonly (string Name, Action<byte[]> Run)[] CheapOperations =
+    {
+        ("GetInfo", pdf => PdfInspector.GetInfo(pdf)),
+        ("FindText", pdf => TextTools.FindText(pdf, "payload")),
+    };
+
+    [Fact]
+    public void ContentStreamFilters_MalformedStreams_FailHandled()
+    {
+        var results = RunCorpus(FuzzCorpus.FilterCases, Operations);
+        AssertParserWasActuallyExercised(results, minimumRejections: 20);
+    }
+
+    [Fact]
+    public void DocumentStructure_Malformed_FailsHandled()
+    {
+        var results = RunCorpus(FuzzCorpus.StructureCases, Operations);
+        AssertParserWasActuallyExercised(results, minimumRejections: 20);
+    }
+
+    [Fact]
+    public void MutatedValidDocuments_FailHandled()
+    {
+        var cases = FuzzCorpus.MutationSeeds.SelectMany(seed => FuzzCorpus.Mutate(seed, MutationsPerSeed)).ToList();
+        Assert.Equal(FuzzCorpus.MutationSeeds.Count * MutationsPerSeed, cases.Count);
+
+        var results = RunCorpus(cases, CheapOperations);
+        AssertParserWasActuallyExercised(results, minimumRejections: 20);
+    }
+
+    /// <summary>
+    /// The mutation stream must be a pure function of <see cref="FuzzHarness.CorpusSeed"/>: if it
+    /// were not, a CI failure could not be reproduced locally and the artifacts would be useless.
+    /// </summary>
+    [Fact]
+    public void Mutations_AreDeterministic_AcrossRuns()
+    {
+        var seed = FuzzCorpus.MutationSeeds[0];
+        var first = FuzzCorpus.Mutate(seed, 12).ToList();
+        var second = FuzzCorpus.Mutate(seed, 12).ToList();
+
+        Assert.Equal(12, first.Count);
+        for (int i = 0; i < first.Count; i++)
+        {
+            Assert.Equal(first[i].Name, second[i].Name);
+            Assert.Equal(first[i].Bytes, second[i].Bytes);
+        }
+        // ...and it must actually change the bytes, or the "fuzzing" is just re-parsing a good file.
+        Assert.Contains(first, c => !c.Bytes.SequenceEqual(seed.Bytes));
+    }
+
+    /// <summary>
+    /// The structure and mutation corpora contain nothing but hand-written bytes, so their
+    /// contents are pinned: if this hash moves without the corpus being deliberately edited,
+    /// something has crept in that varies between runs or machines (an iText-produced document, a
+    /// timestamp, an unseeded PRNG) and every future failure would be irreproducible.
+    /// </summary>
+    [Fact]
+    public void Corpus_IsBitForBitReproducible()
+    {
+        const string expected = "A5561E31E730D16F626165C17362E6B57E3AC97D000F41ED25B244BB7603ED78";
+        string actual = HashOf(FuzzCorpus.StructureCases
+            .Concat(FuzzCorpus.MutationSeeds.SelectMany(s => FuzzCorpus.Mutate(s, 40))));
+
+        Assert.True(expected == actual,
+            $"The pinned corpus hash changed: expected {expected}, got {actual}. If you edited the " +
+            "corpus on purpose, update the constant. If you did not, the corpus has become " +
+            "non-reproducible and its failures can no longer be reproduced from the recorded seed.");
+    }
+
+    private static string HashOf(IEnumerable<FuzzCase> cases)
+    {
+        using var sha = SHA256.Create();
+        foreach (var c in cases)
+        {
+            byte[] name = Encoding.UTF8.GetBytes(c.Name);
+            sha.TransformBlock(name, 0, name.Length, null, 0);
+            sha.TransformBlock(c.Bytes, 0, c.Bytes.Length, null, 0);
+        }
+        sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        return Convert.ToHexString(sha.Hash!);
+    }
+
+    /// <summary>
+    /// Regression test for the robustness bug this fuzzing campaign found. Every one of these
+    /// inputs used to escape the engine as a bare <see cref="NullReferenceException"/>,
+    /// <see cref="IndexOutOfRangeException"/> or <see cref="InvalidCastException"/> from inside
+    /// iText's filter decoders and canvas processor — a failure the host could only report as
+    /// "Object reference not set to an instance of an object". They must now surface as a typed
+    /// failure that says the document is malformed, with the original preserved for diagnosis.
+    /// </summary>
+    [Theory]
+    [InlineData("flate-truncated-half")]      // was InvalidCastException
+    [InlineData("flate-length-indirect-missing")] // was NullReferenceException
+    [InlineData("lzw-truncated")]             // was InvalidCastException
+    [InlineData("lzw-all-ones")]              // was NullReferenceException
+    [InlineData("runlength-truncated-literal")] // was IndexOutOfRangeException
+    public void MalformedFilters_SurfaceAsTypedFailures_NotDefectExceptions(string caseName)
+    {
+        byte[] pdf = FuzzCorpus.FilterCases.Single(c => c.Name == caseName).Bytes;
+
+        foreach (var op in new Action[]
+                 {
+                     () => TextTools.FindText(pdf, "payload"),
+                     () => Redactor.Redact(pdf, new[] { Region }),
+                 })
+        {
+            var ex = Assert.Throws<InvalidDataException>(op);
+            Assert.Contains("malformed or corrupt", ex.Message, StringComparison.Ordinal);
+            Assert.NotNull(ex.InnerException); // the original defect is kept for diagnosis
+        }
+    }
+
+    /// <summary>
+    /// Regression test for the most serious finding of this campaign: a form XObject that lists
+    /// itself in its own <c>/Resources /XObject</c> sent iText's content processor into unbounded
+    /// recursion, and the resulting <see cref="StackOverflowException"/> is uncatchable on .NET —
+    /// it killed the whole test host ("Test Run Aborted") and would equally kill the native host
+    /// process of anyone who opened such a file. It must now be refused up front.
+    /// </summary>
+    [Fact]
+    public void SelfReferentialFormXObject_IsRefused_RatherThanCrashingTheProcess()
+    {
+        byte[] pdf = FuzzCorpus.StructureCases.Single(c => c.Name == "page-resources-cycle").Bytes;
+
+        var find = Assert.Throws<InvalidDataException>(() => TextTools.FindText(pdf, "payload"));
+        Assert.Contains("draws itself", find.Message, StringComparison.Ordinal);
+        var redact = Assert.Throws<InvalidDataException>(() => Redactor.Redact(pdf, new[] { Region }));
+        Assert.Contains("draws itself", redact.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The acyclic-but-unbounded variant of the same crash: 200 levels of form XObject, each
+    /// drawing the next. Refused; a plausible four-level document still works.
+    /// </summary>
+    [Fact]
+    public void AbsurdlyDeepFormNesting_IsRefused_ButPlausibleNestingStillWorks()
+    {
+        byte[] tooDeep = FuzzCorpus.StructureCases.Single(c => c.Name == "form-xobject-nesting-200").Bytes;
+        var ex = Assert.Throws<InvalidDataException>(() => TextTools.FindText(tooDeep, "payload"));
+        Assert.Contains("levels deep", ex.Message, StringComparison.Ordinal);
+
+        byte[] reasonable = FuzzCorpus.StructureCases.Single(c => c.Name == "form-xobject-nesting-4").Bytes;
+        Assert.Empty(TextTools.FindText(reasonable, "payload"));
+    }
+
+    /// <summary>
+    /// A catalog whose <c>/Root</c> is a string used to escape as a bare
+    /// <see cref="InvalidCastException"/> from iText's document constructor, on every entry point
+    /// at once. Opening a document is now guarded, so the failure explains itself.
+    /// </summary>
+    [Fact]
+    public void CatalogThatIsNotADictionary_IsRefusedWithAnExplicableError()
+    {
+        byte[] pdf = FuzzCorpus.StructureCases.Single(c => c.Name == "trailer-root-is-a-string").Bytes;
+        var ex = Assert.Throws<InvalidDataException>(() => PdfInspector.GetInfo(pdf));
+        Assert.Contains("malformed or corrupt", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The decompression bomb deserves its own named test: 8 MiB of zeros in a few hundred bytes
+    /// of Flate. Whatever the engine does with it, it must stay inside the time and allocation
+    /// budgets rather than expanding without bound.
+    /// </summary>
+    [Fact]
+    public void DecompressionBomb_StaysWithinBudget()
+    {
+        var bombs = FuzzCorpus.FilterCases.Where(c => c.Name.Contains("bomb", StringComparison.Ordinal)).ToList();
+        Assert.NotEmpty(bombs);
+        var results = RunCorpus(bombs, Operations);
+        Assert.NotEmpty(results);
+    }
+
+    /// <summary>Runs every operation over every case, collecting *all* violations before failing.</summary>
+    private static List<FuzzResult> RunCorpus(
+        IReadOnlyList<FuzzCase> cases, (string Name, Action<byte[]> Run)[] operations)
+    {
+        var results = new List<FuzzResult>();
+        var violations = new List<string>();
+
+        foreach (var fuzzCase in cases)
+        {
+            foreach (var (opName, run) in operations)
+            {
+                string label = fuzzCase.Name + "." + opName;
+                try
+                {
+                    results.Add(FuzzHarness.Run(label, fuzzCase.Bytes, run));
+                }
+                catch (FuzzContractViolationException ex)
+                {
+                    violations.Add(ex.Message);
+                    if (violations.Count >= 10) goto done; // enough evidence; keep the log readable
+                }
+            }
+        }
+    done:
+        if (violations.Count > 0)
+        {
+            var report = new StringBuilder()
+                .Append(violations.Count)
+                .Append(" fuzz case(s) violated the robustness contract (")
+                .Append(results.Count)
+                .AppendLine(" ran cleanly before this point):")
+                .AppendLine();
+            foreach (string v in violations) report.AppendLine(v).AppendLine();
+            Assert.Fail(report.ToString());
+        }
+        return results;
+    }
+
+    /// <summary>
+    /// Guards against the worst failure mode a fuzz suite has: passing because it never really
+    /// reached the code under test. A corpus of deliberately broken documents that the engine
+    /// *never* rejects means the inputs stopped being hostile (or the operations stopped running),
+    /// and the suite has quietly become decoration.
+    /// </summary>
+    private static void AssertParserWasActuallyExercised(IReadOnlyList<FuzzResult> results, int minimumRejections)
+    {
+        Assert.NotEmpty(results);
+        int rejected = results.Count(r => r.Outcome == FuzzOutcome.Rejected);
+        Assert.True(rejected >= minimumRejections,
+            $"Only {rejected} of {results.Count} fuzz runs were rejected by the engine (expected at " +
+            $"least {minimumRejections}). Either the corpus is no longer hostile or the operations " +
+            "are no longer reaching the parser — in both cases this suite is no longer testing anything.");
+    }
+}

--- a/tests/PdfEditor.Core.Tests/Fuzz/RawPdf.cs
+++ b/tests/PdfEditor.Core.Tests/Fuzz/RawPdf.cs
@@ -1,0 +1,260 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+
+namespace PdfEditor.Tests.Fuzz;
+
+/// <summary>How the cross-reference machinery of a generated file should be damaged.</summary>
+internal enum XrefDamage
+{
+    /// <summary>A correct xref table and trailer.</summary>
+    None,
+    /// <summary>Every entry points at byte 0.</summary>
+    ZeroOffsets,
+    /// <summary>Every entry is off by a few bytes, so objects start mid-token.</summary>
+    ShiftedOffsets,
+    /// <summary>Every entry points past the end of the file.</summary>
+    OffsetsPastEof,
+    /// <summary><c>startxref</c> names an offset far beyond the file.</summary>
+    GarbageStartxref,
+    /// <summary>The xref table and trailer are omitted entirely.</summary>
+    NoXref,
+    /// <summary>The trailer dictionary is cut off mid-token.</summary>
+    TruncatedTrailer,
+    /// <summary>The trailer's <c>/Size</c> disagrees wildly with the object count.</summary>
+    WrongSize,
+}
+
+/// <summary>
+/// A byte-level PDF writer. Unlike <see cref="TestPdfs"/> (which drives iText and therefore can
+/// only ever produce *valid* documents) this emits exactly the bytes it is told to, so a test can
+/// declare a wrong <c>/Length</c>, a cyclic page tree, or a filter that does not match its payload.
+/// Everything it produces is deterministic — no timestamps, no random object ids.
+/// </summary>
+internal static class RawPdf
+{
+    private const string Header = "%PDF-1.7\n%âãÏÓ\n";
+
+    /// <summary>Encodes an object body written as text (Latin-1, i.e. one byte per char).</summary>
+    public static byte[] Obj(string body) => Encoding.Latin1.GetBytes(body);
+
+    /// <summary>
+    /// Builds a stream object body: <c>&lt;&lt; /Length n <paramref name="dictEntries"/> &gt;&gt;</c>
+    /// followed by the raw <paramref name="data"/>. <paramref name="declaredLength"/> overrides the
+    /// <c>/Length</c> actually written, which is how the wrong-length cases are produced.
+    /// </summary>
+    public static byte[] StreamObj(string dictEntries, byte[] data, int? declaredLength = null,
+        bool omitEndstream = false)
+    {
+        var buffer = new MemoryStream();
+        Append(buffer, string.Create(CultureInfo.InvariantCulture,
+            $"<< /Length {declaredLength ?? data.Length} {dictEntries} >>\nstream\n"));
+        buffer.Write(data);
+        Append(buffer, omitEndstream ? "\n" : "\nendstream");
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Assembles <paramref name="objects"/> (object 1 first) into a complete file, appending the
+    /// given <paramref name="trailerEntries"/> to the trailer dictionary and damaging the xref
+    /// section as requested.
+    /// </summary>
+    public static byte[] Build(IReadOnlyList<byte[]> objects, string trailerEntries,
+        XrefDamage damage = XrefDamage.None)
+    {
+        var file = new MemoryStream();
+        Append(file, Header);
+
+        var offsets = new List<long>();
+        for (int i = 0; i < objects.Count; i++)
+        {
+            offsets.Add(file.Length);
+            Append(file, string.Create(CultureInfo.InvariantCulture, $"{i + 1} 0 obj\n"));
+            file.Write(objects[i]);
+            Append(file, "\nendobj\n");
+        }
+
+        if (damage == XrefDamage.NoXref)
+        {
+            Append(file, "%%EOF\n");
+            return file.ToArray();
+        }
+
+        long xrefOffset = file.Length;
+        int size = objects.Count + 1;
+        Append(file, string.Create(CultureInfo.InvariantCulture, $"xref\n0 {size}\n0000000000 65535 f \n"));
+        foreach (long offset in offsets)
+        {
+            long written = damage switch
+            {
+                XrefDamage.ZeroOffsets => 0,
+                XrefDamage.ShiftedOffsets => offset + 3,
+                XrefDamage.OffsetsPastEof => offset + 900_000,
+                _ => offset,
+            };
+            Append(file, written.ToString(CultureInfo.InvariantCulture).PadLeft(10, '0') + " 00000 n \n");
+        }
+
+        int declaredSize = damage == XrefDamage.WrongSize ? 999_999 : size;
+        string trailer = string.Create(CultureInfo.InvariantCulture,
+            $"trailer\n<< /Size {declaredSize} {trailerEntries} >>\n");
+        if (damage == XrefDamage.TruncatedTrailer)
+        {
+            Append(file, "trailer\n<< /Size ");
+            return file.ToArray();
+        }
+
+        Append(file, trailer);
+        long startxref = damage == XrefDamage.GarbageStartxref ? xrefOffset + 500_000 : xrefOffset;
+        Append(file, string.Create(CultureInfo.InvariantCulture, $"startxref\n{startxref}\n%%EOF\n"));
+        return file.ToArray();
+    }
+
+    /// <summary>
+    /// A one-page document whose content stream carries <paramref name="data"/> under
+    /// <paramref name="filterEntries"/> (e.g. <c>"/Filter /FlateDecode"</c>). The rest of the
+    /// document — catalog, page tree, font resource — is structurally valid, so anything that goes
+    /// wrong is attributable to the stream.
+    /// </summary>
+    public static byte[] ContentStreamDoc(string filterEntries, byte[] data, int? declaredLength = null,
+        bool omitEndstream = false, XrefDamage damage = XrefDamage.None)
+        => Build(new[]
+        {
+            Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+            Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] " +
+                "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"),
+            StreamObj(filterEntries, data, declaredLength, omitEndstream),
+            Obj("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+        }, "/Root 1 0 R", damage);
+
+    /// <summary>
+    /// A one-page document that draws a <paramref name="width"/>×<paramref name="height"/> image
+    /// XObject whose bytes are <paramref name="data"/> under <paramref name="filterEntries"/> —
+    /// the vehicle for the DCTDecode (JPEG) cases.
+    /// </summary>
+    public static byte[] ImageDoc(string filterEntries, byte[] data, int width, int height)
+    {
+        byte[] content = Encoding.ASCII.GetBytes("q 200 0 0 200 40 40 cm /Im1 Do Q\n");
+        return Build(new[]
+        {
+            Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+            Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] " +
+                "/Resources << /XObject << /Im1 5 0 R >> >> /Contents 4 0 R >>"),
+            StreamObj("", content),
+            StreamObj(string.Create(CultureInfo.InvariantCulture,
+                $"/Type /XObject /Subtype /Image /Width {width} /Height {height} " +
+                $"/ColorSpace /DeviceRGB /BitsPerComponent 8 {filterEntries}"), data),
+        }, "/Root 1 0 R");
+    }
+
+    /// <summary>
+    /// A valid <paramref name="pages"/>-page document, each page carrying its own uncompressed
+    /// content stream. Byte-for-byte reproducible — unlike anything iText writes, which stamps a
+    /// timestamp-derived <c>/ID</c> and <c>/ModDate</c> into every file.
+    /// </summary>
+    public static byte[] MultiPageDoc(int pages)
+    {
+        var kids = new StringBuilder();
+        for (int p = 0; p < pages; p++)
+            kids.Append(CultureInfo.InvariantCulture, $"{3 + 2 * p} 0 R ");
+
+        var objects = new List<byte[]>
+        {
+            Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+            Obj(string.Create(CultureInfo.InvariantCulture,
+                $"<< /Type /Pages /Kids [{kids.ToString().TrimEnd()}] /Count {pages} >>")),
+        };
+        for (int p = 0; p < pages; p++)
+        {
+            objects.Add(Obj(string.Create(CultureInfo.InvariantCulture,
+                $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] " +
+                $"/Resources << /Font << /F1 {3 + 2 * pages} 0 R >> >> /Contents {4 + 2 * p} 0 R >>")));
+            objects.Add(StreamObj("", Encoding.ASCII.GetBytes(string.Create(CultureInfo.InvariantCulture,
+                $"BT /F1 18 Tf 40 500 Td (Page {p + 1} payload) Tj ET\n0.2 0.4 0.9 rg 40 40 300 120 re f\n"))));
+        }
+        objects.Add(Obj("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"));
+        return Build(objects, "/Root 1 0 R");
+    }
+
+    /// <summary>
+    /// A page whose form XObjects are nested <paramref name="depth"/> levels deep, each drawing the
+    /// next with <c>Do</c>. Acyclic, but arbitrarily deep — the other way to drive a recursive
+    /// content processor off the end of the stack.
+    /// </summary>
+    public static byte[] DeeplyNestedForms(int depth)
+    {
+        byte[] draw = Encoding.ASCII.GetBytes("q /Nested Do Q\n");
+        var objects = new List<byte[]>
+        {
+            Obj("<< /Type /Catalog /Pages 2 0 R >>"),
+            Obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+            Obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] " +
+                "/Resources << /XObject << /Nested 5 0 R >> >> /Contents 4 0 R >>"),
+            StreamObj("", draw),
+        };
+        for (int level = 0; level < depth; level++)
+        {
+            bool last = level == depth - 1;
+            string resources = last
+                ? ""
+                : string.Create(CultureInfo.InvariantCulture,
+                    $"/Resources << /XObject << /Nested {6 + level} 0 R >> >>");
+            objects.Add(StreamObj(
+                $"/Type /XObject /Subtype /Form /BBox [0 0 100 100] {resources}",
+                last ? Encoding.ASCII.GetBytes("0 0 1 rg 0 0 50 50 re f\n") : draw));
+        }
+        return Build(objects, "/Root 1 0 R");
+    }
+
+    /// <summary>zlib-compresses <paramref name="data"/> — the encoding FlateDecode expects.</summary>
+    public static byte[] Deflate(byte[] data)
+    {
+        var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+            zlib.Write(data);
+        return output.ToArray();
+    }
+
+    /// <summary>Encodes <paramref name="data"/> the way a RunLengthDecode stream expects.</summary>
+    public static byte[] RunLength(byte[] data)
+    {
+        var output = new MemoryStream();
+        int i = 0;
+        while (i < data.Length)
+        {
+            int run = Math.Min(data.Length - i, 127);
+            output.WriteByte((byte)(run - 1));
+            output.Write(data, i, run);
+            i += run;
+        }
+        output.WriteByte(128); // EOD
+        return output.ToArray();
+    }
+
+    /// <summary>Encodes <paramref name="data"/> as ASCIIHexDecode input, EOD marker included.</summary>
+    public static byte[] AsciiHex(byte[] data)
+        => Encoding.ASCII.GetBytes(Convert.ToHexString(data) + ">");
+
+    /// <summary>Encodes <paramref name="data"/> as ASCII85Decode input, EOD marker included.</summary>
+    public static byte[] Ascii85(byte[] data)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < data.Length; i += 4)
+        {
+            int remaining = Math.Min(4, data.Length - i);
+            uint block = 0;
+            for (int j = 0; j < 4; j++)
+                block = (block << 8) | (j < remaining ? data[i + j] : 0u);
+            if (block == 0 && remaining == 4) { sb.Append('z'); continue; }
+            var group = new char[5];
+            for (int j = 4; j >= 0; j--) { group[j] = (char)('!' + (int)(block % 85)); block /= 85; }
+            sb.Append(group, 0, remaining + 1);
+        }
+        return Encoding.ASCII.GetBytes(sb.Append("~>").ToString());
+    }
+
+    private static void Append(MemoryStream stream, string text)
+        => stream.Write(Encoding.Latin1.GetBytes(text));
+}


### PR DESCRIPTION
## Summary
Fixes #54. Adds a deterministic, in-repo fuzz suite for content-stream decoding/filters and malformed document structure — **and fixes the five real robustness bugs it found**, including one that kills the process outright.

## The serious one
A **self-referential form XObject** causes unbounded recursion in iText's `PdfCanvasProcessor` and throws `StackOverflowException`, which .NET makes **uncatchable and process-fatal**. On a hostile file this takes down the native host, not just the operation. Reproduced by removing the new guard: the test run doesn't fail, it **aborts**.

```
at iText...PdfCanvasProcessor+FormXObjectDoHandler.HandleXObject(...)
at iText...PdfCanvasProcessor.DisplayXObject(...)
   … unbounded …
Test Run Aborted.
```

New `src/PdfEditor.Core/PdfStructureGuard.cs` refuses cycles, depth > 32, and runaway node counts *before* content processing.

## Everything else it found

| Finding | Symptom | Fix |
|---|---|---|
| Self-referential form XObject | Uncatchable `StackOverflowException`, kills the process | `PdfStructureGuard` cycle/depth/node-budget check |
| Truncated Flate / corrupt LZW / short RunLength | bare `InvalidCastException` / `NullReferenceException` / `IndexOutOfRangeException` from iText decoders | `PdfIo.Guarded(...)` at 3 `TextTools` + 2 `ContentStreamEditor` sites |
| `/Root` not a dictionary | `InvalidCastException` from `PdfDocument..ctor` on *every* entry point | guarded `PdfIo.Open`/`OpenReadOnly`/`Encryptor.IsEncrypted` |
| Page tree `/Count` lies | `NullReferenceException` from `Dispose`, *after* the operation succeeded | `GuardedPdfDocument` overriding `Close()` — covers all callers at once |
| Cyclic page tree + render | `NullReferenceException` — PDFium returns an empty bitmap and `SKImage.FromBitmap` returns null | null checks in `PageRenderer` |

All four non-crash cases now surface as `InvalidDataException` naming what failed, with the original as `InnerException`.

## How the harness enforces its contract
The contract is that malformed input produces a *handled* failure — never a crash, hang, or unbounded memory growth. Merely "didn't throw" is not a pass.

- **Hangs fail, they don't stall.** Every case runs on its own thread under `Join(budget)` (20s, `PDFEDITOR_FUZZ_CASE_SECONDS` to override). Without this a hang presents as CI hanging rather than a red test.
- **Deny-list of defect-class exceptions** — `NullReference`, `IndexOutOfRange`, `InvalidCast`, `KeyNotFound`, `DivideByZero`, `OutOfMemory`, `SEHException` — plus bare `Exception`/`SystemException` and empty messages.
- **Allocation budget** (512 MiB/case) catches decompression bombs.
- **Reproducible failures**: offending bytes dumped to `fuzz-artifacts/<case>.pdf`, with seed + sha256 printed.

Corpus: ~90 hand-built cases (Flate/ASCIIHex/ASCII85/LZW/RunLength/DCT — truncated, corrupt, wrong `/Length`, bombs, mismatched chains; xref/offset/page-tree/required-key/cycle damage) plus a fixed-seed mutator over 4 seed documents × 40 mutations.

**Determinism note:** iText's output is *not* reproducible — it stamps a timestamp-derived `/ID` and `/ModDate`, so the same call differs between two invocations in one process. Seed documents are therefore hand-written bytes, and `Corpus_IsBitForBitReproducible` pins a SHA-256 over the structure+mutation corpus. The DCT cases use a SkiaSharp-encoded JPEG and are deliberately excluded from that hash, since a SkiaSharp bump could change it.

## Proving the harness isn't decorative
1. It was **red on first run** — the five bugs above are what it found.
2. **Regression demo**: removing `PdfStructureGuard` aborts the run with a stack overflow (output above). Independently reproduced before opening this PR.
3. **14 permanent self-tests** (`FuzzHarnessSelfTests`) keep it honest in CI: a real hang, each defect-class exception, an untyped `Exception`, an empty message, unbounded allocation, artifact dumping, wrapper unwrapping.

## Test plan
- [x] `dotnet build PdfEditor.sln --configuration Release` — 0 errors (3 warnings, pre-existing on `main`)
- [x] `dotnet test --configuration Release --filter "Category!=Performance"` — **408/408** (Core 256, NativeHost 118, Integration 17, Perf 17); base on current `main` is 380, so +28
- [x] Fuzz suite alone — **28 tests, ~13 s**. Fast enough that it needs no separate category; deepen with `PDFEDITOR_FUZZ_MUTATIONS`
- [x] `node --test extension/test/formScript.test.mjs` — **14/14**
- [x] Playwright e2e — **67/67**
- [x] `scripts/coverage.sh 90` — 94.2%; `PdfIo` 100%, `PdfStructureGuard` 100%, `PageRenderer` 100%, `ContentStreamEditor` 97.3%, `TextTools` 98.8%

`TestPdfs.cs` is untouched — all fixtures live in the new `tests/PdfEditor.Core.Tests/Fuzz/` folder.

## Known limits
- **`StackOverflowException` stays outside the harness's reach** — it is process-fatal on .NET and cannot be caught. The mitigation is that the engine must prevent unbounded recursion, which is what `PdfStructureGuard` now does. Documented in the harness XML docs.
- The `PdfIo.Guarded` translation covers the content-processing and open/close boundary. Other entry points (`Merger`, `PageTools`, `FormTools`, `Signer`, `Sanitizer`, `ImageTools`) are not yet in the fuzz operation list and may still leak defect-class exceptions. Extending it is cheap and likely to find more — kept out here to bound both runtime and the size of this diff. **Worth a follow-up issue.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_