### PR TITLE
Update the agent docs with what actually goes wrong

### DIFF
--- a/.claude/agents/issue-resolver.md
+++ b/.claude/agents/issue-resolver.md
@@ -1,6 +1,6 @@
 ---
 name: issue-resolver
-description: Picks up a single GitHub issue from this repo's backlog (see ACTION_PLAN.md), implements a scoped fix on a correctly-named branch, and opens a draft PR. Use when asked to work on a specific issue number from the backlog, e.g. "use issue-resolver on #18" or "pick up the next Tier 0 issue".
+description: Picks up a single GitHub issue from this repo's backlog (see ACTION_PLAN.md), implements a scoped fix on a correctly-named branch, pushes it, and hands back a ready-to-file PR body (it cannot open the PR itself — no GitHub API access). Use when asked to work on a specific issue number from the backlog, e.g. "use issue-resolver on #18" or "pick up the next Tier 0 issue".
 tools: Read, Edit, Write, Glob, Grep, Bash
 model: inherit
 ---
@@ -9,14 +9,39 @@ You resolve exactly one GitHub issue (or one tightly-coupled pair, if the task
 explicitly names both) from this repository's backlog. Do not expand scope beyond
 what's needed for that issue.
 
+## Environment facts you will otherwise learn the hard way
+
+- **You cannot open a pull request.** The GitHub API is not reachable from a subagent
+  session: there is no `gh`, and `/repos/...` endpoints return 403 *"GitHub access is
+  not enabled for this session"*. Push your branch, then **write the full PR body to a
+  file and report its path** so the calling session can open the PR. Do not report the
+  work as finished-and-filed when only the branch exists. (This has silently stranded three
+  agent runs so far — finished work, pushed branch, no PR.)
+- **You cannot fetch the live issue** for the same reason. Work from the brief you were
+  given plus `ACTION_PLAN.md`, and say explicitly in your report that you could not read
+  the issue body/comments, so a reviewer knows what you might not have seen.
+- **There is no network access.** Test fixtures must be generated in-repo — see
+  `tests/PdfEditor.Core.Tests/TestPdfs.cs` and `e2e/helpers/pdf.js`. Nothing can be
+  downloaded, so "a corpus of real-world PDFs" has to mean synthetic ones you construct.
+- **`e2e/node_modules` may not exist in your worktree.** Run `npm ci --ignore-scripts`
+  in `e2e/` before Playwright. Chromium is pre-installed: use
+  `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`, never `playwright install`.
+- **Tesseract is required for the OCR tests to do anything.** Every OCR test begins
+  `if (!OcrTool.CanOcr) return;`, so without the binary they pass while executing
+  nothing. `sudo apt-get install -y tesseract-ocr tesseract-ocr-eng` if you are touching
+  OCR.
+
 ## Before writing code
 
 1. Read `ACTION_PLAN.md` to find the issue's tier, its stated dependencies, and
    which other issues it's grouped with. If the issue depends on work that isn't
    merged yet (check `git log`/open PRs), stop and report the blocker instead of
    working around it.
-2. Fetch the live issue (title, body, comments) — don't rely solely on the summary
-   in ACTION_PLAN.md, which may be stale.
+2. The live issue is **not** fetchable from here, so the brief you were given is your
+   only source for the issue text. ACTION_PLAN.md's summaries may be stale, and most
+   issues in this backlog are a single sentence — so where the brief leaves scope
+   genuinely open, decide, state your interpretation explicitly in the PR body, and
+   flag anything a reviewer might reasonably have wanted differently.
 3. Reproduce the bug or confirm the missing behavior before changing code. For UI/
    rendering issues, actually run the app if a run/dev-server skill is available;
    don't assume a fix works from reading code alone.
@@ -28,17 +53,77 @@ what's needed for that issue.
   unrelated code, don't fix unrelated bugs you notice along the way (file a note
   instead), and don't add speculative configuration options beyond what the issue
   asks for.
-- Add or update tests that would fail without your fix. If the issue is in a
-  subsystem covered by the golden-file or fuzz regression suites (#53/#54), extend
-  those rather than writing a one-off test.
-- Run the existing test suite before committing.
+- **Add tests, then prove they fail without your fix.** Run each new test against the
+  unfixed code, watch it fail, and quote that failure in your report. This is not
+  ceremony — this repository has shipped a bug behind an assertion that passed
+  trivially (`expect(row).toBeVisible()` on a row that CSS made permanently visible),
+  and an entire regression suite that silently no-oped in CI because a binary was
+  missing. A test you have never seen fail is not evidence of anything.
+- For a validator, parser or other detector, also demonstrate the **negative case**:
+  stub the implementation out and confirm the suite goes red. A detector that reports
+  "fine" for everything passes its own tests perfectly.
+- If the issue is in a subsystem covered by the golden-file or fuzz regression suites
+  (#53/#54), extend those rather than writing a one-off test.
+- Run the full suite before committing (see below).
+
+## Verification baseline
+
+Run all four and report **exact counts**, so a silently-skipped suite is visible:
+
+```
+dotnet build PdfEditor.sln --configuration Release
+dotnet test --configuration Release --filter "Category!=Performance"
+node --test extension/test/formScript.test.mjs
+cd e2e && PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers npx playwright test tests/viewer.spec.js
+```
+
+Baseline on `main` at the time of writing — state your new totals against these, and
+re-check them yourself, since they move with every merge:
+
+| Suite | Count |
+| --- | --- |
+| `dotnet test` (`Category!=Performance`) | **380** — Core 228, NativeHost 118, Integration 17, Perf 17 |
+| `formScript.test.mjs` | **14** |
+| Playwright e2e | **67** |
+| Build | 0 errors, 3 warnings (all pre-existing on `main`) |
+
+Gates that will fail your PR:
+
+- `ci.yml` runs `scripts/coverage.sh 90` — **90% line coverage** overall.
+- SonarQube Cloud fails a PR under **80% coverage on new code** and over **3%
+  duplication on new code**. Both have bitten PRs in this repo: coverage because the
+  opencover report is C#-only (so `.py`/`.ps1`/`.sh`/JS are excluded in
+  `sonarqube.yml` — check the exclusion list before assuming a language is measured),
+  and duplication because a ~15-line helper was copied into two scripts.
+- Sonar findings are published to GitHub code scanning as SARIF and appear as inline
+  PR annotations. Read them; they have caught real defects, including a client-side
+  XSS.
+
+## Repository pitfalls worth knowing
+
+- **`extension/src/`: never assign interpolated `innerHTML`.** Document-derived data
+  (field names, filenames, URLs) reaches the UI, and the viewer is an extension page
+  with `chrome.*` privileges. Use `textContent`/`createElement`. A real XSS shipped
+  here because untrusted text was passed to a generic `toast()` helper whose
+  `innerHTML` was two calls away. See #74.
+- **`viewer.css` has a bare `label { display: block }` rule.** Author `display` beats
+  the UA stylesheet's `[hidden] { display: none }`, so the `hidden` attribute is inert
+  on any element a rule like that matches. There is now a global
+  `[hidden] { display: none !important }` — do not remove it.
+- **Bare `catch {}` blocks in `viewer.js` swallow render/host failures** and present
+  them as blank pages or empty panels. See #72 before adding another.
+- **`loadDocument()` distinguishes a fresh open from an edit/undo reload** via the
+  `freshOpen` flag (`fileName != null`). Panel/state resets belong behind that guard,
+  or you will close the panel the user is working in.
 
 ## Finishing
 
 - Commit with a message describing why, not just what.
-- Push to `origin/<branch-name>`.
-- Open a **draft** PR titled after the issue, with `Fixes #<number>` in the body,
-  a summary of the change, and a test plan. Check for a PR template first.
+- Push to `origin/<branch-name>` (`git push -u origin <branch-name>`).
+- **You cannot open the PR yourself** (see Environment facts). Write the complete
+  draft-PR body — title, `Fixes #<number>`, summary, test plan with exact counts, and
+  the `_Generated by [Claude Code](https://claude.ai/code)_` footer — to a file, and
+  report that path plus the branch name. There is no PR template in this repo.
 - If you could not fully resolve the issue (needs a product decision, blocked on
   another unmerged issue, etc.), do not open a PR claiming completion — instead
   report back exactly what's blocking it.

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -8,6 +8,27 @@ other enhancements, and (4) larger feature/quality investments.
 
 _Generated 2026-07-28. Source: 40 open issues (#17–#56) on `zanattamichael/chromium-pdf-editor`._
 
+## Progress
+
+**Tier 0 is complete.** #18 + #22 (PR #59), #20 + #21 (PR #68), #24 (PR #67) are all merged.
+
+**Tier 2 is in flight:** #52 (PR #75) and #54 (PR #76) are open for review; #53 is
+sequenced after #52 so it can assert with that validator rather than reinventing one.
+
+Issues raised by this work, not in the original 40: **#72** (bare `catch {}` hides
+render failures), **#74** (ban interpolated `innerHTML` in `extension/src`). A
+client-side XSS found by the new code scanning was fixed in #73.
+
+Two corrections to the sequencing below, learned in practice:
+
+- **#52 should come before #53 and #54, not alongside them.** It produces the
+  structural validator both of the others want as their assertion oracle.
+- **"A corpus of tricky real-world PDFs" (#53) has to mean synthetic ones.** There is
+  no network access in the working environment, and real-world files carry licensing
+  questions. `tests/PdfEditor.Core.Tests/CorruptPdfs.cs` (from #52) and
+  `tests/PdfEditor.Core.Tests/Fuzz/RawPdf.cs` (from #54) already construct malformed
+  and awkward-but-valid documents byte by byte; #53 should build on those.
+
 ## Tier 0 — Critical correctness bugs (fix first)
 
 These break core, everyday functionality and should be fixed before new features are

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -28,10 +28,16 @@ depend on them being correct.
 3. #24 links menu stale state (independent, can run in parallel with 1–2)
 4. #23 highlight click-and-drag (independent, can run in parallel)
 
-### Phase 2 — Safety net (can parallelize across sessions)
-5. #53 golden-file regression suite
-6. #54 fuzz/regression testing
-7. #52 export pipeline validation
+### Phase 2 — Safety net (partly parallel; #52 first)
+5. **#52 export pipeline validation — do this first.** It yields the structural
+   validator that #53 and #54 both want as their assertion oracle; running it last
+   means the other two invent their own. *(PR #75, open.)*
+6. #54 fuzz/regression testing — independent of #52, can run concurrently with it.
+   *(PR #76, open.)*
+7. #53 golden-file regression suite — after #52, so it asserts with the validator.
+   Note the corpus must be **generated in-repo**: no network access, and real-world
+   PDFs carry licensing questions. Build on `CorruptPdfs.cs` (#52) and
+   `Fuzz/RawPdf.cs` (#54).
 8. #19 async link parser + loading indicator
 9. #56 SonarCube cleanup — split into 2–3 sub-PRs by rule category (bugs, code
    smells, security hotspots); run as background/low-priority sessions since it's
@@ -76,10 +82,20 @@ For each issue:
 1. Start a session (or spawn a subagent — see `issue-resolver` below) with a prompt
    that includes: the issue number/title/body, the relevant ACTION_PLAN.md tier
    context, and the target branch name.
-2. The session should: reproduce the bug/confirm the gap, implement the fix, add/
-   update tests, run the existing test suite, commit, push, and open a draft PR
-   linking the issue (`Fixes #<n>`).
-3. Human review gate: PRs from Phase 1 and Phase 6 (security-sensitive) get a manual
+2. The session should: reproduce the bug/confirm the gap, implement the fix, add
+   tests **and confirm they fail without it**, run the full suite, commit and push.
+3. **Opening the PR is the calling session's job.** A subagent has no GitHub API
+   access — `gh` is absent and `/repos/...` returns 403 — so it can push a branch but
+   cannot file the PR. Have it write the PR body to a file and report the path; three
+   agent runs in one session ended with finished work and no PR because of this.
+4. Before opening the PR, **rebase the branch onto current `main`** and re-run the
+   suites. Agent branches go stale quickly when several land in a session, and a
+   diff against a moved `main` shows other people's merges as deletions.
+5. **Verify the agent's central claim yourself** rather than relaying it. For a fix,
+   that means reverting it and watching the new test fail; for a detector, stubbing it
+   out and watching the suite go red. Both Phase 2 agents' headline claims held up
+   under that check — but the check is what makes the claim worth repeating.
+6. Human review gate: PRs from Phase 1 and Phase 6 (security-sensitive) get a manual
    review before merge; later phases can use lighter review if CI is green and the
    regression suite (Phase 2) passes.
 


### PR DESCRIPTION
## Summary
Five agent runs in one session surfaced constraints and traps the docs didn't mention — several costing a full run each. This writes them down.

## `.claude/agents/issue-resolver.md`

**The expensive one: a subagent has no GitHub API access.** No `gh`, and `/repos/...` returns 403. It can push a branch but cannot open a PR, and cannot read the live issue. **Three runs finished their work and stranded it on a pushed branch with no PR**, because the doc told them to file one. The frontmatter and the "fetch the live issue" step said the same impossible thing and are corrected too — instructions an agent cannot follow are worse than none.

Also added: no network (fixtures must be generated in-repo), `e2e/node_modules` may be absent in a worktree, Chromium is pre-installed at `PLAYWRIGHT_BROWSERS_PATH`, and **tesseract must be installed or every OCR test silently no-ops**.

**Test discipline, stated as the point rather than a footnote.** Run each new test against the unfixed code and watch it fail. This repo has shipped a bug behind an assertion that passed trivially (`toBeVisible()` on a row CSS made permanently visible), and a regression suite that no-oped in CI because a binary was missing. For a detector, stub it out and confirm the suite goes red — one that reports "fine" for everything passes its own tests perfectly.

**Verification baseline and the gates that actually fail a PR:** 380 / 14 / 67; `scripts/coverage.sh 90`; Sonar's 80%-on-new-code and 3%-duplication. Both Sonar gates have failed PRs here for reasons unrelated to code quality — a C#-only coverage report being asked to account for Python, and a 15-line helper copied into two files.

**Four repository traps that each cost real debugging:** the bare `label { display: block }` that makes `[hidden]` inert, the swallowing `catch {}` blocks (#72), the `freshOpen` guard, and the `innerHTML` XSS route (#74).

## `AGENT_PLAN.md`
- Phase 2 reordered: **#52 first**, since it produces the validator #53 and #54 both want as their oracle. #53 after it, with the corpus noted as necessarily synthetic.
- The per-issue loop now says the **calling session** opens the PR, **rebases onto current `main`** first, and **independently verifies the agent's central claim** rather than relaying it. Agent branches go stale fast when several land in one session — a diff against a moved `main` shows other people's merges as deletions.

## `ACTION_PLAN.md`
Tier 0 recorded complete (#18, #20, #21, #22, #24); Tier 2 in flight (#75, #76); the two issues this work raised (#72, #74) noted, with the sequencing corrections.

## Verification
Docs-only — no code, no tests affected. Every factual claim was checked against `origin/main` rather than written from memory:

| Claim | Checked |
| --- | --- |
| `[hidden] { display: none !important }` exists | `viewer.css:17` |
| bare `label { display: block }` still present | `viewer.css:425` |
| `freshOpen` guard | `viewer.js:218-224` |
| coverage gate is 90 | `ci.yml:24` |
| OCR tests early-return without tesseract | 6 occurrences in `OcrToolTests.cs` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_