### PR TITLE
Surface failures in a new activity console instead of swallowing them (#72, #74)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
         # `tesseract` binary is absent, so without this they pass without executing anything --
         # leaving OcrTool.cs at 0% coverage on new code and the regressions unguarded in CI.
         run: sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+      - name: Extension unit tests
+        # These had never run in CI, so extension/test/ was effectively unenforced.
+        run: node --test "extension/test/**/*.test.mjs"
+      - name: No interpolated innerHTML under extension/src (#74)
+        # A dedicated step as well as a node --test case, so the failure message points straight
+        # at the offending file:line rather than at an assertion.
+        run: node scripts/check-innerhtml.mjs
       - name: Build
         run: dotnet build --configuration Release
       - name: Test with coverage (gated at 90% line coverage)

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -60,6 +60,15 @@ jobs:
       # really being scanned. begin/build/test/end is the .NET-specific flow that actually
       # runs the C# analyzers, with coverage imported from the same test run.
       - name: Begin SonarQube analysis
+        # sonar.coverage.exclusions must list every language the imported report cannot measure.
+        # That report is opencover from `dotnet test`, so it covers C# only: .py/.mjs/.ps1/.sh and
+        # the extension/e2e JavaScript would otherwise each count as 0% covered on new code and
+        # fail the gate. `.mjs` is separate from the `extension/**/*.js` entry because the glob
+        # matches on the literal extension -- a .mjs file is not a .js file to Sonar.
+        #
+        # Keep comments HERE, above the folded scalar. A `#` line inside the `>` block below is
+        # not a YAML comment: it is folded into the command, and the shell then treats it as a
+        # comment and silently discards everything after it -- which dropped this whole setting.
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
@@ -70,9 +79,6 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.exclusions="**/bin/**,**/obj/**,**/node_modules/**,coverage-report/**,coverage-results/**,coverage-sonar/**,dist/**,e2e/test-results/**,e2e/playwright-report/**"
           /d:sonar.cs.opencover.reportsPaths="coverage-sonar/**/coverage.opencover.xml"
-          # `**/*.mjs` for the same reason as `**/*.py`: the imported coverage report is C#-only
-          # (opencover from `dotnet test`), so any language it cannot measure must be excluded or
-          # it counts as 0% covered on new code. The .mjs files are covered by `node --test`.
           /d:sonar.coverage.exclusions="**/*.css,**/*.html,**/*.yml,**/*.yaml,**/*.ps1,**/*.sh,**/*.py,**/*.mjs,extension/**/*.js,e2e/**/*.js"
       - name: Build
         run: dotnet build --configuration Release

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -70,7 +70,10 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.exclusions="**/bin/**,**/obj/**,**/node_modules/**,coverage-report/**,coverage-results/**,coverage-sonar/**,dist/**,e2e/test-results/**,e2e/playwright-report/**"
           /d:sonar.cs.opencover.reportsPaths="coverage-sonar/**/coverage.opencover.xml"
-          /d:sonar.coverage.exclusions="**/*.css,**/*.html,**/*.yml,**/*.yaml,**/*.ps1,**/*.sh,**/*.py,extension/**/*.js,e2e/**/*.js"
+          # `**/*.mjs` for the same reason as `**/*.py`: the imported coverage report is C#-only
+          # (opencover from `dotnet test`), so any language it cannot measure must be excluded or
+          # it counts as 0% covered on new code. The .mjs files are covered by `node --test`.
+          /d:sonar.coverage.exclusions="**/*.css,**/*.html,**/*.yml,**/*.yaml,**/*.ps1,**/*.sh,**/*.py,**/*.mjs,extension/**/*.js,e2e/**/*.js"
       - name: Build
         run: dotnet build --configuration Release
       - name: Test with coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,21 @@ If you touch `PdfEditor.Core` or `PdfEditor.NativeHost`, add or update unit test
 the matching project. If you touch the extension ↔ host wire protocol, add a case to
 `PdfEditor.IntegrationTests` too.
 
+The extension's own unit tests are plain `node --test`, and CI runs them:
+
+```bash
+node --test "extension/test/**/*.test.mjs"
+node scripts/check-innerhtml.mjs   # also run as one of the tests above
+```
+
+### Never assign interpolated `innerHTML` in `extension/src/`
+
+The viewer renders text that comes straight out of the document being edited — form
+field names, file names, link URLs, host error strings — on an extension page with
+`chrome.*` privileges. Build nodes with `createElement`/`textContent`. Clearing a
+container with `innerHTML = ''` and assigning a static string literal are both fine;
+anything interpolated is not, and `scripts/check-innerhtml.mjs` fails CI on it.
+
 ### Golden-file regression suite
 
 `tests/PdfEditor.Core.Tests/Golden/` runs a corpus of deliberately awkward documents

--- a/e2e/helpers/hostgate.js
+++ b/e2e/helpers/hostgate.js
@@ -11,18 +11,23 @@
  * In the page, `window.__hostGate` exposes:
  *   hold(actions)   — start holding responses for these actions (replaces the current set)
  *   fail(actions)   — answer these actions with an error instead of forwarding them
+ *   failWith(text)  — set the message the injected error carries. The viewer surfaces host error
+ *                    strings verbatim (status line, activity console), and a hostile document can
+ *                    influence them, so a test needs to be able to choose that text.
  *   stopHolding()   — let *new* requests through; already-parked responses stay parked
  *   release()       — deliver every parked response, in arrival order
  *   heldCount()     — how many responses are currently parked
  */
-async function installHostGate(page, { hold = [], fail = [] } = {}) {
-  await page.addInitScript(([heldActions, failedActions]) => {
+async function installHostGate(page, { hold = [], fail = [], failMessage } = {}) {
+  await page.addInitScript(([heldActions, failedActions, failedMessage]) => {
     const gate = {
       held: new Set(heldActions),
       failed: new Set(failedActions),
+      message: failedMessage,
       parked: [],
       hold(actions) { gate.held = new Set(actions); },
       fail(actions) { gate.failed = new Set(actions); },
+      failWith(text) { gate.message = text; },
       stopHolding() { gate.held = new Set(); },
       release() {
         const queued = gate.parked.splice(0);
@@ -56,7 +61,7 @@ async function installHostGate(page, { hold = [], fail = [] } = {}) {
     };
 
     const answerWithFailure = (listeners, id) => setTimeout(
-      () => notify(listeners, { id, ok: false, result: { error: 'injected host failure' } }), 0);
+      () => notify(listeners, { id, ok: false, result: { error: gate.message } }), 0);
 
     const connect = chrome.runtime.connectNative.bind(chrome.runtime);
     chrome.runtime.connectNative = (name) => {
@@ -79,7 +84,7 @@ async function installHostGate(page, { hold = [], fail = [] } = {}) {
         disconnect: () => port.disconnect(),
       };
     };
-  }, [hold, fail]);
+  }, [hold, fail, failMessage ?? 'injected host failure']);
 }
 
 module.exports = { installHostGate };

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1745,6 +1745,144 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  // ------------------------------------------------------- activity console (#72)
+
+  /** Opens a viewer with the host gate installed, loads `file`, and returns the page. */
+  async function openGatedViewerWith(file, gateOptions) {
+    const page = await ext.context.newPage();
+    await installHostGate(page, gateOptions);
+    await page.goto(ext.viewerUrl);
+    const chooser = page.waitForEvent('filechooser');
+    await page.click('#btn-open-empty');
+    await (await chooser).setFiles(file);
+    await expect(page.locator(pageImageSel(1))).toHaveAttribute('src', /data:image\/png/);
+    return page;
+  }
+
+  /**
+   * Opens the activity console from the Help menu. The pane's open/closed state is remembered in
+   * chrome.storage.local, which is shared by every page in this suite's one persistent profile —
+   * so a plain toggle would close it for whichever test ran after one that left it open.
+   */
+  async function openConsole(page) {
+    if (await page.locator('#console-pane').isHidden()) await ui(page, '#btn-console');
+    await expect(page.locator('#console-pane')).toBeVisible();
+  }
+
+  test('activity console: the Help menu opens a docked log of what the viewer did', async () => {
+    const page = await openViewerWith(fixture('console.pdf', [[{ text: 'Console test', x: 72, y: 700 }]]));
+
+    // Closed by default. Help is reachable straight away — unlike Read/Edit it is never disabled,
+    // because the console matters most before a document loads and while an open is failing.
+    await expect(page.locator('#console-pane')).toBeHidden();
+    await expect(page.locator('#menu-help-trigger')).toBeEnabled();
+    await openConsole(page);
+    await expect(page.locator('#btn-console')).toHaveAttribute('aria-pressed', 'true');
+
+    // The open we just performed is in it: the document open itself, and the host round-trips.
+    const log = page.locator('#console-log');
+    await expect(log.locator('.console-entry', { hasText: 'document opened' })).toHaveCount(1);
+    const renders = log.locator('.console-entry', { hasText: 'render' });
+    expect(await renders.count()).toBeGreaterThan(0);
+
+    // Round-trip time is the single most useful thing here, so every host entry carries one.
+    await expect(renders.first().locator('.console-detail')).toContainText(/\d+ ms/);
+    // Timestamped and levelled.
+    await expect(log.locator('.console-entry').first().locator('.console-time'))
+      .toContainText(/^\d\d:\d\d:\d\d\.\d\d\d$/);
+    await expect(log.locator('.console-entry').first().locator('.console-level'))
+      .toContainText(/^(info|warn|error)$/);
+
+    // A tool change is an action too...
+    await ui(page, '#tool-highlight');
+    const toolEntry = log.locator('.console-entry', { hasText: 'tool changed' });
+    await expect(toolEntry).toHaveCount(1);
+    await expect(toolEntry).toContainText('select → highlight');
+    // ...and logging it did not touch the shared status line.
+    await expect(page.locator('#status')).not.toContainText('tool changed');
+
+    // Clear discards what was there.
+    await page.locator('#console-clear').click();
+    await expect(log.locator('.console-entry', { hasText: 'document opened' })).toHaveCount(0);
+
+    // The pane's state survives a reload; the log itself deliberately does not.
+    await page.reload();
+    await expect(page.locator('#console-pane')).toBeVisible();
+    await expect(log.locator('.console-entry', { hasText: 'document opened' })).toHaveCount(0);
+
+    await page.locator('#console-close').click();
+    await expect(page.locator('#console-pane')).toBeHidden();
+    await page.close();
+  });
+
+  test('activity console: a forced host failure is logged instead of swallowed (#72)', async () => {
+    // `form-fields` is the case #72 names by hand: its bare `catch { state.formFields = []; }`
+    // turned any failure into the claim "this document has no fillable form fields".
+    const page = await openGatedViewerWith(
+      fixture('console-fail.pdf', [[{ text: 'Console failure test', x: 72, y: 700 }]]), { fail: ['form-fields'] });
+
+    await openConsole(page);
+    const log = page.locator('#console-log');
+    // Both halves: the raw round-trip failure, and what it cost the user.
+    const raw = log.locator('.console-entry', { hasText: 'form-fields failed' });
+    await expect(raw).toHaveCount(1);
+    await expect(raw).toContainText('injected host failure');
+    await expect(log.locator('.console-entry', { hasText: 'form fields could not be listed' }))
+      .toHaveCount(1);
+    await expect(log.locator('.console-entry.error').first()).toBeVisible();
+
+    // Additive, not a replacement: the failure never overwrote the shared status line.
+    await expect(page.locator('#status')).not.toContainText('form-fields');
+    await page.locator('#console-close').click();
+    await page.close();
+  });
+
+  test('activity console: untrusted entry text is rendered as text, never as HTML', async () => {
+    // Host error strings reach the console verbatim, and a hostile document can influence them.
+    // A console built with innerHTML would be a worse sink than the one #73 fixed.
+    const payload = '<img src=x onerror="window.__pwned = 1">';
+    const page = await openGatedViewerWith(fixture('console-xss.pdf', [[{ text: 'XSS test', x: 72, y: 700 }]]),
+      { fail: ['form-fields'], failMessage: payload });
+
+    await openConsole(page);
+    const log = page.locator('#console-log');
+    await expect(log.locator('.console-entry.error').first()).toBeVisible();
+    // The payload is shown, as text...
+    await expect(log).toContainText(payload);
+    // ...and produced no element and ran no script.
+    await expect(log.locator('img')).toHaveCount(0);
+    expect(await page.evaluate(() => window.__pwned)).toBeUndefined();
+    await page.locator('#console-close').click();
+    await page.close();
+  });
+
+  test('a page that keeps failing to render says so instead of staying blank (#72/#20)', async () => {
+    const page = await openGatedViewerWith(fixture('render-fail.pdf', [[{ text: 'Page one', x: 72, y: 700 }], [{ text: 'Page two', x: 72, y: 700 }]]), {});
+    // No placeholder on a healthy document.
+    await expect(page.locator('.page-error')).toHaveCount(0);
+
+    // Now every render fails. Zooming invalidates the render cache, so the page re-renders.
+    // Retrying on scroll stays deliberate: only repeated failures for a page get a placeholder,
+    // so a single hiccup during fast scrolling still just retries, silently.
+    await page.evaluate(() => window.__hostGate.fail(['render']));
+    await page.click('#btn-zoom-in');
+    await page.click('#btn-zoom-in');
+    await expect(page.locator('.page-error').first()).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('.page-error').first())
+      .toContainText('This page could not be rendered');
+
+    await openConsole(page);
+    await expect(page.locator('#console-log')
+      .locator('.console-entry', { hasText: 'did not render' }).first()).toBeVisible();
+
+    // Recovering clears the placeholder again — it is a state, not a permanent tombstone.
+    await page.evaluate(() => window.__hostGate.fail([]));
+    await page.click('#btn-zoom-out');
+    await expect(page.locator('.page-error')).toHaveCount(0, { timeout: 30000 });
+    await page.locator('#console-close').click();
+    await page.close();
+  });
+
   test('open-from-url: refuses a src param pointing at a private/internal host', async () => {
     const page = await ext.context.newPage();
     await page.goto(`${ext.viewerUrl}?src=${encodeURIComponent('http://169.254.169.254/latest/meta-data/doc.pdf')}`);

--- a/extension/src/activity-log.js
+++ b/extension/src/activity-log.js
@@ -1,0 +1,90 @@
+// In-memory activity log behind the viewer's activity console (Help ▸ Activity console).
+//
+// This is deliberately a *store* only: it holds entries, caps how many it retains, and knows how
+// to format one as plain text. Nothing here touches the DOM, so the rendering side (viewer.js)
+// stays free to build every entry with createElement/textContent — entries carry document-derived
+// text (error messages, file names, field names, URLs) and must never reach innerHTML (#74).
+
+/** Levels, in the order a reader cares about them. */
+export const LEVELS = ['info', 'warn', 'error'];
+
+/** Two digits, four for the year, three for milliseconds — no locale surprises across machines. */
+function pad(value, width) {
+  return String(value).padStart(width, '0');
+}
+
+/** `HH:MM:SS.mmm` in local time; the console is a session tool, so the date is noise. */
+export function formatTime(date) {
+  return `${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(date.getSeconds(), 2)}`
+    + `.${pad(date.getMilliseconds(), 3)}`;
+}
+
+/** One line of plain text for an entry — what "Copy all" writes to the clipboard. */
+export function formatEntry(entry) {
+  const level = entry.level.toUpperCase().padEnd(5, ' ');
+  const detail = entry.detail ? ` — ${entry.detail}` : '';
+  return `${formatTime(entry.time)}  ${level}  ${entry.message}${detail}`;
+}
+
+export const DEFAULT_CAPACITY = 500;
+
+export class ActivityLog {
+  #entries = [];
+  #capacity;
+  #seq = 0;
+  #dropped = 0;
+  #listeners = new Set();
+
+  constructor(capacity = DEFAULT_CAPACITY) {
+    // A session can run for hours and every host round-trip logs a line, so retention is capped
+    // and the oldest entries fall off the front rather than growing without bound.
+    this.#capacity = Math.max(1, capacity);
+  }
+
+  get capacity() { return this.#capacity; }
+
+  /** How many entries have been evicted by the cap since the last clear(). */
+  get dropped() { return this.#dropped; }
+
+  /** Live entries, oldest first. Treat as read-only. */
+  get entries() { return this.#entries; }
+
+  /**
+   * Records one entry. `level` is 'info' | 'warn' | 'error'; `message` is the headline (an action
+   * name, say) and `detail` the optional extra (an error message, a duration, a file name).
+   * Both may be attacker-controlled text — they are stored verbatim and never parsed.
+   */
+  add(level, message, detail = '') {
+    const entry = {
+      seq: ++this.#seq,
+      time: new Date(),
+      level: LEVELS.includes(level) ? level : 'info',
+      message: String(message),
+      detail: detail ? String(detail) : '',
+    };
+    this.#entries.push(entry);
+    while (this.#entries.length > this.#capacity) {
+      this.#entries.shift();
+      this.#dropped++;
+    }
+    for (const listener of this.#listeners) listener(entry);
+    return entry;
+  }
+
+  clear() {
+    this.#entries = [];
+    this.#dropped = 0;
+    for (const listener of this.#listeners) listener(null);
+  }
+
+  /** Subscribes to additions (called with the new entry) and clears (called with null). */
+  subscribe(listener) {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  /** The whole log as plain text, one entry per line. */
+  toText() {
+    return this.#entries.map(formatEntry).join('\n');
+  }
+}

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -211,6 +211,23 @@ button.danger:hover:not(:disabled) { background: #ef5443; }
 
 .page-image { display: block; width: 100%; height: 100%; }
 
+/* Shown only after a page has failed to render twice running for the same render (#72): a
+   transient hiccup during fast scrolling still just retries, silently. A blank white rectangle
+   is indistinguishable from an empty page, which is how the #20 rasteriser OOM presented. */
+.page-error {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+  background: #f5f2f2;
+  color: #7a1f1f;
+  font-size: 13px;
+}
+
 /* Per-page layer stacking (all absolute/inset:0 over the image). Pinned with explicit z-index so
    the order never depends on which layer's builder (some async) inserted last: text at the bottom,
    then link hotspots, then form-field markers, then the tool-drawing overlay on top. Without this,
@@ -584,6 +601,60 @@ textarea.code-editor:focus { outline: 1px solid var(--accent-2); }
 .tab.active { background: var(--accent-2); color: #fff; }
 
 #sign-pad { background: #fff; border-radius: 4px; touch-action: none; width: 100%; }
+
+/* -------------------------------------------------------- activity console */
+/* Docked at the bottom of the window, above the status bar. Styled after the JavaScript code
+   editor (textarea.code-editor above): monospace on a near-black surface, scrollable. It is
+   additive — it never writes to #status, so a toast can't be clobbered by a log entry. */
+#console-pane {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  height: 30vh;
+  min-height: 120px;
+  background: #1e1e24;
+  border-top: 1px solid #55555e;
+}
+
+#console-bar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--surface-2);
+  border-bottom: 1px solid #55555e;
+  font-size: 12px;
+}
+#console-bar .console-title { font-weight: 600; }
+#console-bar .console-spacer { flex: 1; }
+#console-bar button { padding: 2px 8px; font-size: 12px; }
+/* `label { display: block }` further down would otherwise stack the checkbox above its text. */
+#console-bar .console-option { display: inline-flex; align-items: center; gap: 4px; color: var(--muted); }
+#console-bar .console-option input { width: auto; margin: 0; }
+#console-count { color: var(--muted); }
+
+#console-log {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 6px 8px;
+  font: 12.5px/1.5 ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  color: #e6e6ec;
+  word-break: break-word;
+  tab-size: 2;
+}
+#console-log:focus-visible { outline: 1px solid var(--accent-2); }
+
+.console-entry { display: flex; gap: 8px; align-items: baseline; }
+.console-time { flex: none; color: #7f7f8c; }
+.console-level { flex: none; width: 40px; text-transform: uppercase; font-size: 11px; color: #6fa8f5; }
+.console-message { flex: 1; min-width: 0; white-space: pre-wrap; }
+.console-detail { color: var(--muted); }
+.console-entry.warn, .console-entry.warn .console-level { color: #ffcf70; }
+.console-entry.error, .console-entry.error .console-level { color: #ff8f86; }
+.console-entry.warn .console-detail, .console-entry.error .console-detail { color: inherit; }
+.console-empty { color: var(--muted); }
 
 /* -------------------------------------------------------------- statusbar */
 #statusbar {

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -64,6 +64,17 @@
       </div>
     </div>
 
+    <!-- Help. Unlike Read/Edit this is never disabled: the activity console is at its most
+         useful before a document loads, and while an open is failing. -->
+    <div class="menu-group" id="menu-help">
+      <button class="menu-trigger" id="menu-help-trigger" aria-haspopup="true"
+        aria-expanded="false" title="Help">❔ Help ▾</button>
+      <div class="menu-panel" role="menu">
+        <button id="btn-console" class="menu-item" role="menuitem"
+          aria-pressed="false" title="Show a log of actions, timings and errors">🧾 Activity console</button>
+      </div>
+    </div>
+
     <!-- Navigation + zoom (pushed to the right) -->
     <fieldset class="group" id="nav" aria-label="Navigation">
       <button id="btn-prev" title="Previous page" disabled>◀</button>
@@ -273,6 +284,23 @@
       </div>
     </aside>
   </main>
+
+  <!-- Activity console (Help ▸ Activity console): a dockable log of every host action, its
+       round-trip time, and every failure — including ones that are otherwise recovered from
+       silently (#72). Entries are built with createElement/textContent only; they carry
+       document-derived text and must never be interpolated into HTML (#74). -->
+  <section id="console-pane" aria-label="Activity console" hidden>
+    <div id="console-bar">
+      <span class="console-title">🧾 Activity console</span>
+      <span id="console-count" class="muted"></span>
+      <span class="console-spacer"></span>
+      <label class="console-option"><input id="console-autoscroll" type="checkbox" checked /> Auto-scroll</label>
+      <button id="console-copy" title="Copy the whole log to the clipboard">Copy all</button>
+      <button id="console-clear" title="Discard every entry">Clear</button>
+      <button id="console-close" title="Hide the console">✕</button>
+    </div>
+    <div id="console-log" tabindex="0" role="log" aria-label="Activity log"></div>
+  </section>
 
   <footer id="statusbar">
     <span id="status"></span>

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -3,8 +3,31 @@
 
 import { HostClient, bytesToBase64, base64ToBytes } from './host-client.js';
 import { runFormScript } from './formScript.js';
+import { ActivityLog, formatTime } from './activity-log.js';
 
 const host = new HostClient();
+
+// Everything the viewer does gets recorded here and shown by Help ▸ Activity console. The point
+// (#72) is that a failure the UI recovers from — a page that renders blank, a forms panel that
+// says "no fields" because listing them threw — still leaves a trace someone can read.
+const activity = new ActivityLog();
+
+// Every host round-trip is timed and logged: the action name and its duration, which is the one
+// number worth having when the editor feels slow, plus the error when it fails. Wrapping `call`
+// once here means no call site can forget, and no failure can be swallowed before it is recorded.
+const rawHostCall = host.call.bind(host);
+host.call = async (action, payload = {}) => {
+  const started = performance.now();
+  const elapsed = () => `${Math.round(performance.now() - started)} ms`;
+  try {
+    const result = await rawHostCall(action, payload);
+    activity.add('info', action, elapsed());
+    return result;
+  } catch (e) {
+    activity.add('error', `${action} failed`, `${e?.message ?? e} (after ${elapsed()})`);
+    throw e;
+  }
+};
 
 // URL/link handling: a document with links shows a warning badge, links are disabled (stripped on
 // save) by default, and the 🔗 Links panel lists every URL (the "source") so the user can review
@@ -78,6 +101,7 @@ function setWorkingPdf(bytes, base64) {
   thumbCache.clear();
   spanCache.clear();
   inkByPage.clear();  // uncommitted freehand strokes belong to the old document
+  pageRenderFailures.clear(); // a new document's pages have not failed yet
   prefetchToken++; // cancel any in-flight prefetch for the previous document
 }
 
@@ -147,7 +171,132 @@ function toast(text) {
 
 function fail(err) {
   console.error(err);
+  activity.add('error', 'error', err?.message ?? String(err));
   setStatus(`⚠ ${err.message ?? err}`);
+}
+
+// -------------------------------------------------------- activity console
+// A dockable log at the bottom of the window. It is strictly additive: it never touches #status,
+// so a toast can't be clobbered by a log entry the way placeField()'s once was.
+
+const CONSOLE_OPEN_KEY = 'activityConsoleOpen';
+let consoleRenderedSeq = 0;   // seq of the newest entry that is in the DOM
+let consoleFlushQueued = false;
+
+function consoleOpen() { return !$('console-pane').hidden; }
+
+/**
+ * One row, built entirely from nodes. Messages and details carry document-derived text — host
+ * error strings, file names, form-field names, link URLs — so this must never grow an innerHTML
+ * (#74); scripts/check-innerhtml.mjs enforces that.
+ */
+function consoleEntryEl(entry) {
+  const row = document.createElement('div');
+  row.className = `console-entry ${entry.level}`;
+  const time = document.createElement('span');
+  time.className = 'console-time';
+  time.textContent = formatTime(entry.time);
+  const level = document.createElement('span');
+  level.className = 'console-level';
+  level.textContent = entry.level;
+  const message = document.createElement('span');
+  message.className = 'console-message';
+  message.textContent = entry.message;
+  if (entry.detail) {
+    const detail = document.createElement('span');
+    detail.className = 'console-detail';
+    detail.textContent = ` — ${entry.detail}`;
+    message.appendChild(detail);
+  }
+  row.append(time, level, message);
+  return row;
+}
+
+/**
+ * Appends everything logged since the last flush in one batch on the next frame — and does
+ * nothing at all while the pane is closed, so rendering a link- or field-heavy page cannot pay
+ * for per-entry DOM work (#19). Opening the pane rebuilds from the store.
+ */
+function scheduleConsoleFlush() {
+  if (consoleFlushQueued || !consoleOpen()) return;
+  consoleFlushQueued = true;
+  requestAnimationFrame(flushConsole);
+}
+
+function flushConsole() {
+  consoleFlushQueued = false;
+  const logEl = $('console-log');
+  const pending = activity.entries.filter((e) => e.seq > consoleRenderedSeq);
+  if (pending.length > 0) {
+    const batch = document.createDocumentFragment();
+    for (const entry of pending) batch.appendChild(consoleEntryEl(entry));
+    logEl.appendChild(batch);
+    consoleRenderedSeq = pending[pending.length - 1].seq;
+    // The store caps what it retains; drop the rows it no longer holds so a long session's DOM
+    // stays bounded too.
+    while (logEl.childElementCount > activity.capacity) logEl.firstElementChild.remove();
+    if ($('console-autoscroll').checked) logEl.scrollTop = logEl.scrollHeight;
+  }
+  updateConsoleCount();
+}
+
+function updateConsoleCount() {
+  const total = activity.entries.length;
+  const dropped = activity.dropped;
+  $('console-count').textContent = total === 0
+    ? 'no entries yet'
+    : `${total} entr${total === 1 ? 'y' : 'ies'}${dropped > 0 ? `, oldest ${dropped} dropped` : ''}`;
+}
+
+function setConsoleOpen(open, persist = true) {
+  $('console-pane').hidden = !open;
+  $('btn-console').setAttribute('aria-pressed', String(open));
+  if (open) {
+    $('console-log').textContent = '';  // rebuild from the store, which kept logging while closed
+    consoleRenderedSeq = 0;
+    flushConsole();
+  }
+  // Remembering the pane's state is a one-key write; the log itself is deliberately not persisted.
+  if (persist) {
+    chrome.storage?.local?.set({ [CONSOLE_OPEN_KEY]: open })
+      ?.catch((e) => activity.add('warn', 'could not save the console state', e?.message ?? e));
+  }
+}
+
+async function copyConsole() {
+  try {
+    await navigator.clipboard.writeText(activity.toText());
+    toast('Activity log copied to the clipboard.');
+  } catch (e) {
+    fail(e);
+  }
+}
+
+function initConsole() {
+  activity.subscribe((entry) => {
+    if (entry === null) {
+      $('console-log').textContent = '';
+      consoleRenderedSeq = 0;
+      updateConsoleCount();
+      return;
+    }
+    scheduleConsoleFlush();
+  });
+  $('btn-console').addEventListener('click', () => setConsoleOpen(!consoleOpen()));
+  $('console-close').addEventListener('click', () => setConsoleOpen(false));
+  $('console-clear').addEventListener('click', () => activity.clear());
+  $('console-copy').addEventListener('click', copyConsole);
+  updateConsoleCount();
+}
+
+/** Restores the pane's last open/closed state (the log itself never persists). */
+async function restoreConsoleState() {
+  try {
+    const stored = await chrome.storage.local.get({ [CONSOLE_OPEN_KEY]: false });
+    if (stored[CONSOLE_OPEN_KEY]) setConsoleOpen(true, false);
+  } catch (e) {
+    activity.add('warn', 'could not read the console state', e?.message ?? e);
+  }
 }
 
 function pageSize(pageNum = state.page) {
@@ -308,7 +457,11 @@ async function refreshSignatures() {
       pdf: state.pdfB64, pdfPassword: state.password,
     });
     state.signatures = result.signatures ?? [];
-  } catch {
+  } catch (e) {
+    // Kept non-fatal — but "this document is unsigned" and "we could not tell" are different
+    // claims, and the badge only shows the first. Say which one this is (#72).
+    activity.add('warn', 'signatures could not be listed',
+      `${e?.message ?? e} — the document will be shown as unsigned`);
     state.signatures = [];
   }
 }
@@ -319,7 +472,11 @@ async function refreshSafety() {
     state.safety = await host.call('scan-safety', {
       pdf: state.pdfB64, pdfPassword: state.password,
     });
-  } catch {
+  } catch (e) {
+    // A failed scan is not a clean document: nothing gets badged, and the strip-on-save default
+    // has nothing to strip. That silence is exactly what #72 is about.
+    activity.add('warn', 'active-content scan failed',
+      `${e?.message ?? e} — embedded JavaScript and link URLs are unknown for this document`);
     state.safety = null;
   }
 }
@@ -373,8 +530,11 @@ function prefetchAround(centerPage, dpi) {
         if (renderCache.has(cacheKey(page, dpi))) continue;
         try {
           await renderToCache(page, dpi);
-        } catch {
-          /* a prefetch failure is never fatal — the page renders on demand instead */
+        } catch (e) {
+          // Never fatal — the page renders on demand instead. host.call already logged the error
+          // itself; this records which page it cost us, so a document that only ever fails to
+          // prefetch is distinguishable from one that never tried.
+          activity.add('info', `prefetch of page ${page} abandoned`, e?.message ?? e);
         }
         await new Promise((r) => setTimeout(r, 0)); // yield so the UI stays responsive
       }
@@ -460,6 +620,7 @@ async function renderPageEl(pageNum) {
   if (cached !== undefined) {
     pe.img.src = `data:image/png;base64,${cached}`;
     pe.renderedKey = key;
+    clearPageError(pe, pageNum);
     ensureTextLayer(pe, pageNum);
     buildLinkLayer(pe, pageNum); // a cached page still needs its overlays (re)built for this page
     buildFieldLayer(pe, pageNum);
@@ -470,12 +631,43 @@ async function renderPageEl(pageNum) {
     if (cacheKey(pageNum, currentDpi()) !== key || !pe.wrap.isConnected) return;
     pe.img.src = `data:image/png;base64,${png}`;
     pe.renderedKey = key;
+    clearPageError(pe, pageNum);
     ensureTextLayer(pe, pageNum);
     buildLinkLayer(pe, pageNum); // draw any link hotspots for this page
     buildFieldLayer(pe, pageNum); // outline any form fields for this page
-  } catch {
-    /* leave the placeholder blank; it renders again when it next scrolls into view */
+  } catch (e) {
+    // Retrying on scroll is deliberate, so this still doesn't throw and still leaves the
+    // placeholder in place. What changes (#72) is that the failure is no longer invisible: it is
+    // always logged, and a page that fails *twice running for the same render* is not a hiccup
+    // during fast scrolling — it gets a visible placeholder rather than the silent blank
+    // rectangle an out-of-memory rasteriser produced in #20.
+    const failures = (pageRenderFailures.get(pageNum) ?? 0) + 1;
+    pageRenderFailures.set(pageNum, failures);
+    const repeated = failures >= PAGE_ERROR_AFTER;
+    activity.add(repeated ? 'error' : 'warn', `page ${pageNum} did not render`,
+      `${e?.message ?? e}${repeated ? ' (repeated)' : ' — retrying when it scrolls back into view'}`);
+    if (repeated && pe.renderedKey !== key && pe.wrap.isConnected) showPageError(pe);
   }
+}
+
+// Consecutive render failures per page, cleared the moment one succeeds (and on a new document,
+// via setWorkingPdf). Keyed by page rather than by page element because zooming rebuilds every
+// element, and by page rather than by render key because the observer retries the same key.
+const pageRenderFailures = new Map();
+const PAGE_ERROR_AFTER = 2;
+
+/** Replaces a persistently blank page with something that says so. */
+function showPageError(pe) {
+  if (pe.wrap.querySelector('.page-error')) return;
+  const note = document.createElement('div');
+  note.className = 'page-error';
+  note.textContent = '⚠ This page could not be rendered. See Help ▸ Activity console for details.';
+  pe.wrap.insertBefore(note, pe.overlay);
+}
+
+function clearPageError(pe, pageNum) {
+  pageRenderFailures.delete(pageNum);
+  pe.wrap.querySelector('.page-error')?.remove();
 }
 
 // ------------------------------------------------------ selectable text layer
@@ -491,8 +683,12 @@ async function ensureTextLayer(pe, pageNum) {
       });
       spans = result.spans ?? [];
       spanCache.set(key, spans);
-    } catch {
-      return; // selection is a nicety; never block rendering on it
+    } catch (e) {
+      // Selection is a nicety; never block rendering on it. But "this page has no selectable
+      // text" and "we could not read its text" look identical on screen (#72).
+      activity.add('warn', `text layer unavailable on page ${pageNum}`,
+        `${e?.message ?? e} — text on this page cannot be selected or right-click edited`);
+      return;
     }
   }
   if (!pe.wrap.isConnected || pe.textKey === key) return;
@@ -634,8 +830,10 @@ async function renderThumb(pageNum) {
     t.img.src = `data:image/png;base64,${png}`;
     if (t.skeleton.parentNode) t.skeleton.replaceWith(t.img);
     t.renderedKey = key;
-  } catch {
-    /* leave the skeleton; it retries when it next scrolls into view */
+  } catch (e) {
+    // Leave the skeleton; it retries when it next scrolls into view. Logged so a rail that stays
+    // grey is traceable to the failure that caused it rather than looking like slow rendering.
+    activity.add('warn', `thumbnail for page ${pageNum} did not render`, e?.message ?? e);
   }
 }
 
@@ -763,7 +961,9 @@ function renderRedactList() {
   list.innerHTML = '';
   for (const [index, region] of state.regions.entries()) {
     const item = document.createElement('li');
-    item.innerHTML = `<span>#${index + 1} — page ${region.page}</span>`;
+    const label = document.createElement('span');
+    label.textContent = `#${index + 1} — page ${region.page}`;
+    item.appendChild(label);
     const remove = document.createElement('button');
     remove.textContent = '✕';
     remove.addEventListener('click', () => {
@@ -1108,6 +1308,7 @@ function hidePanels() {
 }
 
 function setTool(tool) {
+  if (state.tool !== tool) activity.add('info', 'tool changed', `${state.tool} → ${tool}`);
   if (state.tool === 'draw' && tool !== 'draw') clearDrawing(); // drop uncommitted strokes
   state.tool = tool;
   for (const button of document.querySelectorAll('.tool')) button.classList.remove('active');
@@ -1129,7 +1330,13 @@ function setTool(tool) {
 /** Small form dialog; resolves with {fieldId: value} or null when cancelled. */
 function promptDialog(title, fields, confirmLabel = 'OK') {
   return new Promise((resolve) => {
-    modal.innerHTML = `<h2>${title}</h2>`;
+    // The heading is built as a node, not interpolated HTML: every current caller passes a
+    // hardcoded title, but nothing in the signature says so, and the rule in
+    // scripts/check-innerhtml.mjs is only enforceable with no exemptions (#74).
+    modal.innerHTML = '';
+    const heading = document.createElement('h2');
+    heading.textContent = title;
+    modal.appendChild(heading);
     const inputs = {};
     for (const field of fields) {
       const label = document.createElement('label');
@@ -1388,7 +1595,13 @@ async function applyHighlight(region) {
       });
       spans = r.spans ?? [];
       spanCache.set(`${state.version}|${region.page}`, spans);
-    } catch { spans = []; }
+    } catch (e) {
+      // Falls back to highlighting the whole dragged box instead of snapping to words — a
+      // visibly different result, so record why (#72).
+      activity.add('warn', 'highlight could not snap to words',
+        `${e?.message ?? e} — highlighting the whole selected box instead`);
+      spans = [];
+    }
   }
   const covered = spans.filter((s) => rectsIntersect(s, region))
     .map((s) => ({ x: s.x, y: s.y, width: s.width, height: s.height }));
@@ -1868,7 +2081,9 @@ async function openFromBytes(bytes, name) {
     state.keepActiveContent = false; // re-arm the strip-on-save default for each new document
     state.keepLinks = false;
     state.urlVerdicts = [];
+    activity.add('info', 'opening document', `${name} (${bytes.length} bytes)`);
     await loadDocument(bytes, name);
+    activity.add('info', 'document opened', `${name} — ${state.info.pageCount} page(s)`);
     toast(`Opened ${name}.`);
   } catch (e) {
     fail(e);
@@ -1912,7 +2127,10 @@ function looksLikePdfUrl(rawUrl) {
     if (!/^https?:|^file:/.test(parsed.protocol)) return false;
     if (parsed.protocol !== 'file:' && isPrivateOrLocalHost(parsed.hostname)) return false;
     return parsed.pathname.toLowerCase().endsWith('.pdf');
-  } catch {
+  } catch (e) {
+    // Unparseable input is a rejection, not a crash — but record what was rejected and why, so a
+    // legitimate URL the viewer refuses can be diagnosed instead of guessed at (#72).
+    activity.add('warn', 'rejected the src parameter', `${rawUrl} — ${e?.message ?? e}`);
     return false;
   }
 }
@@ -1979,7 +2197,11 @@ async function showSafetyDialog() {
     pre.textContent = sources.length
       ? sources.map((src, i) => `/* — script ${i + 1} — */\n${src}`).join('\n\n')
       : (s.samples?.join('\n') || '(source unavailable)');
-  } catch {
+  } catch (e) {
+    // Falls back to the scan's samples. Worth recording: the dialog then shows a *partial* view
+    // of the active content it is warning about, which is not what it appears to be (#72).
+    activity.add('warn', 'full script sources unavailable',
+      `${e?.message ?? e} — showing the scan's samples instead`);
     pre.textContent = s.samples?.join('\n') || '(source unavailable)';
   }
 
@@ -2614,8 +2836,17 @@ async function refreshLinks() {
       if (link.stale()) return;
       state.urlVerdicts = scan.verdicts ?? [];
       drawLinks(); // phase 2: recolour by risk
-    } catch { /* colour falls back to "unknown" */ }
-  } catch { /* links are a nicety; never block on them */
+    } catch (e) {
+      // Every hotspot's colour falls back to "unknown" — which reads as "not yet rated", not as
+      // "rating failed". Say which it was (#72).
+      activity.add('warn', 'link rating failed',
+        `${e?.message ?? e} — links stay shown as unrated`);
+    }
+  } catch (e) {
+    // Links are a nicety; never block on them. But with no hotspots the document looks like it
+    // simply has none, which is the same class of silent lie as an empty forms panel (#72).
+    activity.add('warn', 'links could not be read',
+      `${e?.message ?? e} — the document will appear to contain no links`);
   } finally {
     // Clears on failure as well as on success — but only for the run that is still current, so a
     // superseded run cannot wipe the newer document's indicator.
@@ -2763,7 +2994,15 @@ async function refreshFormFields() {
   try {
     const result = await host.call('form-fields', { pdf: state.pdfB64, pdfPassword: state.password });
     state.formFields = result.fields ?? [];
-  } catch { state.formFields = []; }
+  } catch (e) {
+    // The named case in #72: an empty list makes the panel say "This document has no fillable
+    // form fields", which is a claim about the document, not about a failed call. The panel's
+    // behaviour is unchanged (there is nothing to fill either way) but the reason is now on
+    // record instead of being invented.
+    activity.add('error', 'form fields could not be listed',
+      `${e?.message ?? e} — the document will appear to have no fillable fields`);
+    state.formFields = [];
+  }
   drawFormFields();
 }
 
@@ -3022,7 +3261,9 @@ function printDocument() {
       frame.contentWindow.print();
       toast('Opening the browser print dialog…');
       cleanup();
-    } catch {
+    } catch (e) {
+      activity.add('warn', 'in-page printing was blocked',
+        `${e?.message ?? e} — opening the document in a new tab instead`);
       handled = false; // let the tab fallback take over
       openInTab();
     }
@@ -3036,6 +3277,7 @@ function printDocument() {
 
 async function save() {
   let bytes = state.pdf;
+  activity.add('info', 'saving document', state.fileName);
   const stripJs = state.safety?.javaScriptCount > 0 && !state.keepActiveContent;
   // URL scanning is off for now: leave link URLs untouched on save.
   const stripUrls = URL_SCANNING_ENABLED && state.safety?.urlCount > 0 && !state.keepLinks;
@@ -3064,18 +3306,25 @@ async function save() {
       const writable = await handle.createWritable();
       await writable.write(blob);
       await writable.close();
+      activity.add('info', 'document saved', handle.name);
       toast(`Saved ${handle.name}.`);
       return;
     }
   } catch (e) {
-    if (e.name === 'AbortError') return;
+    if (e.name === 'AbortError') {
+      activity.add('info', 'save cancelled', state.fileName);
+      return;
+    }
     // fall through to the downloads API
+    activity.add('warn', 'the save dialog failed',
+      `${e?.message ?? e} — falling back to the downloads API`);
   }
   chrome.downloads.download({
     url: URL.createObjectURL(blob),
     filename: suggested,
     saveAs: true,
   });
+  activity.add('info', 'document saved via downloads', suggested);
   toast('Saving via downloads…');
 }
 
@@ -3232,6 +3481,7 @@ function wire() {
   $('sign-cancel').addEventListener('click', () => { hidePanels(); setTool('select'); });
 
   initMenus();
+  initConsole();
   initSignaturePad();
   window.addEventListener('resize', drawRegions);
 }
@@ -3263,6 +3513,8 @@ function closeAllMenus() {
 
 async function start() {
   wire();
+  await restoreConsoleState();
+  activity.add('info', 'viewer started');
   try {
     await host.call('ping');
     $('host-status').textContent = '✓ Native host connected.';

--- a/extension/test/activityLog.test.mjs
+++ b/extension/test/activityLog.test.mjs
@@ -1,0 +1,94 @@
+// Tests for the activity console's store (see extension/src/activity-log.js).
+// Run with: node --test extension/test/activityLog.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ActivityLog, formatEntry, formatTime } from '../src/activity-log.js';
+
+test('records level, message and detail in order', () => {
+  const log = new ActivityLog();
+  log.add('info', 'render', '42 ms');
+  log.add('error', 'render failed', 'out of memory');
+  assert.deepEqual(log.entries.map((e) => [e.level, e.message, e.detail]), [
+    ['info', 'render', '42 ms'],
+    ['error', 'render failed', 'out of memory'],
+  ]);
+});
+
+test('falls back to info for an unknown level', () => {
+  const log = new ActivityLog();
+  assert.equal(log.add('shout', 'x').level, 'info');
+});
+
+test('caps retention so a long session cannot grow without bound', () => {
+  const log = new ActivityLog(3);
+  for (const n of [1, 2, 3, 4, 5]) log.add('info', `entry ${n}`);
+  assert.deepEqual(log.entries.map((e) => e.message), ['entry 3', 'entry 4', 'entry 5']);
+  assert.equal(log.dropped, 2);
+});
+
+test('a capacity below one is still usable', () => {
+  const log = new ActivityLog(0);
+  log.add('info', 'a');
+  log.add('info', 'b');
+  assert.deepEqual(log.entries.map((e) => e.message), ['b']);
+});
+
+test('clear() empties the log and resets the dropped count', () => {
+  const log = new ActivityLog(1);
+  log.add('info', 'a');
+  log.add('info', 'b');
+  assert.equal(log.dropped, 1);
+  log.clear();
+  assert.deepEqual(log.entries, []);
+  assert.equal(log.dropped, 0);
+});
+
+test('subscribers see additions, and null on clear', () => {
+  const log = new ActivityLog();
+  const seen = [];
+  const unsubscribe = log.subscribe((entry) => seen.push(entry === null ? 'clear' : entry.message));
+  log.add('info', 'a');
+  log.clear();
+  unsubscribe();
+  log.add('info', 'b');
+  assert.deepEqual(seen, ['a', 'clear']);
+});
+
+test('sequence numbers keep rising so a renderer can append only what is new', () => {
+  const log = new ActivityLog(2);
+  const seqs = ['a', 'b', 'c'].map((m) => log.add('info', m).seq);
+  assert.deepEqual(seqs, [1, 2, 3]);
+});
+
+test('formats a timestamp to millisecond precision', () => {
+  assert.equal(formatTime(new Date(2026, 0, 2, 3, 4, 5, 6)), '03:04:05.006');
+});
+
+test('formats one entry as a padded plain-text line', () => {
+  const entry = { time: new Date(2026, 0, 2, 3, 4, 5, 6), level: 'warn', message: 'links', detail: 'none' };
+  assert.equal(formatEntry(entry), '03:04:05.006  WARN   links — none');
+});
+
+test('omits the separator when there is no detail', () => {
+  const entry = { time: new Date(2026, 0, 2, 3, 4, 5, 6), level: 'info', message: 'ping', detail: '' };
+  assert.equal(formatEntry(entry), '03:04:05.006  INFO   ping');
+});
+
+test('toText() renders the whole log for Copy all, one entry per line', () => {
+  const log = new ActivityLog();
+  log.add('info', 'a');
+  log.add('error', 'b', 'boom');
+  const lines = log.toText().split('\n');
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /ERROR {2}b — boom$/);
+});
+
+test('stores document-derived text verbatim, without interpreting it', () => {
+  // The console renders untrusted text (host errors, file names, field names, URLs). The store
+  // must not transform it, and the renderer must use textContent (#74).
+  const log = new ActivityLog();
+  const nasty = '<img src=x onerror=alert(1)>';
+  assert.equal(log.add('error', nasty, nasty).message, nasty);
+  assert.ok(log.toText().includes(nasty));
+});

--- a/extension/test/checkInnerHtml.test.mjs
+++ b/extension/test/checkInnerHtml.test.mjs
@@ -1,0 +1,131 @@
+// Tests for the interpolated-innerHTML rule (see scripts/check-innerhtml.mjs, issue #74).
+// Run with: node --test extension/test/checkInnerHtml.test.mjs
+//
+// The last test is the rule itself: it scans the real extension/src tree and fails CI on any new
+// violation. The rest exist so that rule is trustworthy — a detector that answers "fine" for
+// everything passes its own happy-path tests perfectly.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EXTENSION_SRC, checkDirectory, collectFiles, findViolations, isStaticLiteral, maskSource,
+} from '../../scripts/check-innerhtml.mjs';
+
+const violationsIn = (src) => findViolations(src, 'test.js');
+
+// ---------------------------------------------------------------- rejected
+
+test('rejects a template literal that interpolates', () => {
+  const found = violationsIn('modal.innerHTML = `<h2>${title}</h2>`;');
+  assert.equal(found.length, 1);
+  assert.equal(found[0].sink, 'innerHTML');
+  assert.equal(found[0].line, 1);
+});
+
+test('rejects a bare variable', () => {
+  assert.equal(violationsIn('el.innerHTML = markup;').length, 1);
+});
+
+test('rejects concatenation with a variable', () => {
+  assert.equal(violationsIn("el.innerHTML = '<b>' + name + '</b>';").length, 1);
+});
+
+test('rejects a function call', () => {
+  assert.equal(violationsIn('el.innerHTML = render(field);').length, 1);
+});
+
+test('rejects `+=` as well as `=`', () => {
+  assert.equal(violationsIn('el.innerHTML += row;').length, 1);
+});
+
+test('rejects outerHTML the same way', () => {
+  const found = violationsIn('el.outerHTML = `<i>${x}</i>`;');
+  assert.equal(found.length, 1);
+  assert.equal(found[0].sink, 'outerHTML');
+});
+
+test('rejects insertAdjacentHTML with a non-literal payload', () => {
+  const found = violationsIn("el.insertAdjacentHTML('beforeend', `<li>${url}</li>`);");
+  assert.equal(found.length, 1);
+  assert.equal(found[0].sink, 'insertAdjacentHTML');
+});
+
+test('rejects a conditional expression', () => {
+  assert.equal(violationsIn("el.innerHTML = ok ? '<b>y</b>' : '<b>n</b>';").length, 1);
+});
+
+test('reports the line each violation is on', () => {
+  const found = violationsIn('const a = 1;\n// nothing\nel.innerHTML = value;\n');
+  assert.equal(found.length, 1);
+  assert.equal(found[0].line, 3);
+});
+
+// ---------------------------------------------------------------- allowed
+
+test("allows innerHTML = '' — the ~20 places that clear a container", () => {
+  assert.deepEqual(violationsIn("list.innerHTML = '';"), []);
+  assert.deepEqual(violationsIn('list.innerHTML = "";'), []);
+  assert.deepEqual(violationsIn('list.innerHTML = ``;'), []);
+});
+
+test('allows a static string literal', () => {
+  assert.deepEqual(violationsIn("modal.innerHTML = '<h2>Certificate</h2>';"), []);
+});
+
+test('allows several static literals concatenated across lines', () => {
+  const src = "modal.innerHTML =\n  '<h2>Merge</h2>' +\n  '<p class=\"muted\">Drag to order.</p>';";
+  assert.deepEqual(violationsIn(src), []);
+});
+
+test('allows a template literal that interpolates nothing', () => {
+  assert.deepEqual(violationsIn('el.innerHTML = `<hr>`;'), []);
+});
+
+test('allows insertAdjacentHTML with only literal arguments', () => {
+  assert.deepEqual(violationsIn("el.insertAdjacentHTML('beforeend', '<hr>');"), []);
+});
+
+test('ignores a comparison, which assigns nothing', () => {
+  assert.deepEqual(violationsIn('if (el.innerHTML === markup) return;'), []);
+});
+
+// ------------------------------------------------- masking (no false positives)
+
+test('does not flag the word innerHTML inside a comment', () => {
+  assert.deepEqual(violationsIn('// never do el.innerHTML = markup;\nconst a = 1;'), []);
+  assert.deepEqual(violationsIn('/* el.innerHTML = markup; */\nconst a = 1;'), []);
+});
+
+test('does not flag the word innerHTML inside a string', () => {
+  assert.deepEqual(violationsIn("const warn = 'el.innerHTML = markup';"), []);
+});
+
+test('masking keeps offsets and hides literal bodies', () => {
+  const masked = maskSource("const a = 'xy';");
+  assert.equal(masked.length, "const a = 'xy';".length);
+  assert.equal(masked, "const a = 'SS';");
+});
+
+test('masking marks an interpolating template so it cannot pass as a literal', () => {
+  assert.ok(!isStaticLiteral(maskSource('`a${b}c`')));
+  assert.ok(isStaticLiteral(maskSource('`abc`')));
+});
+
+test('an escaped quote does not end a literal early', () => {
+  assert.deepEqual(violationsIn("el.innerHTML = '<p>don\\'t</p>';"), []);
+});
+
+// --------------------------------------------------------------- the rule
+
+test('scans every JS file under extension/src', () => {
+  const files = collectFiles(EXTENSION_SRC);
+  assert.ok(files.some((f) => f.endsWith('viewer.js')), 'viewer.js must be scanned');
+  assert.ok(files.some((f) => f.endsWith('activity-log.js')), 'activity-log.js must be scanned');
+});
+
+test('extension/src contains no interpolated innerHTML/outerHTML/insertAdjacentHTML', () => {
+  const violations = checkDirectory(EXTENSION_SRC);
+  assert.deepEqual(
+    violations.map((v) => `${v.file}:${v.line} ${v.message}`), [],
+    'Build the node with createElement/textContent instead — see issue #74.');
+});

--- a/scripts/check-innerhtml.mjs
+++ b/scripts/check-innerhtml.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// Fails the build when anything under extension/src/ assigns a non-literal to innerHTML /
+// outerHTML, or passes a non-literal to insertAdjacentHTML (#74).
+//
+// Why a rule and not a review habit: the viewer is an extension page with chrome.* privileges and
+// it renders text that comes straight out of the document being edited — field names, file names,
+// link URLs, host error strings. A real XSS shipped here because such text reached a helper whose
+// innerHTML was two calls away (#73). Clearing a container with `innerHTML = ''` (about twenty
+// places) and building static chrome from a string literal are both still fine; interpolating
+// anything is not.
+//
+// Usage: node scripts/check-innerhtml.mjs [dir...]     (default: extension/src)
+// Exits 1 and prints `file:line:col message` for every violation.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const SINKS = ['innerHTML', 'outerHTML'];
+const SCANNED_EXTENSIONS = new Set(['.js', '.mjs']);
+
+/**
+ * Rewrites `source` so that every string, template and comment body becomes a filler character,
+ * keeping the original length and offsets. That lets the checks below use plain indexOf/regex on
+ * real code without matching the word "innerHTML" inside a comment or a string, while still being
+ * able to tell a literal apart from an expression.
+ *
+ * Filler alphabet: `S` for the body of a literal that interpolates nothing, `T` for an entire
+ * template literal that does interpolate (delimiters included, so it can never look like a
+ * literal), and a space for comments.
+ */
+export function maskSource(source) {
+  const out = source.split('');
+  const blank = (from, to, fill) => { for (let i = from; i < to; i++) out[i] = fill; };
+  let i = 0;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '/' && source[i + 1] === '/') {
+      const end = source.indexOf('\n', i);
+      const stop = end === -1 ? source.length : end;
+      blank(i, stop, ' ');
+      i = stop;
+    } else if (c === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      for (let j = i; j < stop; j++) if (source[j] !== '\n') out[j] = ' ';
+      i = stop;
+    } else if (c === "'" || c === '"') {
+      i = maskQuoted(source, out, i, c);
+    } else if (c === '`') {
+      i = maskTemplate(source, out, i);
+    } else {
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/** Masks a '…' / "…" literal starting at `start`; returns the index just past it. */
+function maskQuoted(source, out, start, quote) {
+  let i = start + 1;
+  while (i < source.length) {
+    if (source[i] === '\\') { out[i] = 'S'; out[i + 1] = 'S'; i += 2; continue; }
+    if (source[i] === quote) return i + 1;
+    if (source[i] !== '\n') out[i] = 'S';
+    i++;
+  }
+  return i;
+}
+
+/** Masks a `…` template starting at `start`; returns the index just past it. */
+function maskTemplate(source, out, start) {
+  let i = start + 1;
+  let interpolates = false;
+  let depth = 0;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') { i += 2; continue; }
+    if (depth === 0 && c === '$' && source[i + 1] === '{') { interpolates = true; depth = 1; i += 2; continue; }
+    if (depth > 0) {
+      if (c === '{') depth++;
+      else if (c === '}') depth--;
+      i++;
+      continue;
+    }
+    if (c === '`') { i++; break; }
+    i++;
+  }
+  // `T` for an interpolating template (delimiters included, so it cannot pass as a literal),
+  // `S` for a plain one — which is just a string with nicer quoting.
+  const fill = interpolates ? 'T' : 'S';
+  for (let j = start; j < i; j++) if (source[j] !== '\n') out[j] = fill;
+  if (!interpolates) { out[start] = '`'; out[i - 1] = '`'; }
+  return i;
+}
+
+/** True when `masked` is a string literal, or several joined with `+` — and nothing else. */
+export function isStaticLiteral(masked) {
+  const text = masked.replace(/\s+/g, '');
+  if (text === '') return false;
+  let i = 0;
+  let expectLiteral = true;
+  while (i < text.length) {
+    if (expectLiteral) {
+      const quote = text[i];
+      if (quote !== "'" && quote !== '"' && quote !== '`') return false;
+      i++;
+      while (text[i] === 'S') i++;
+      if (text[i] !== quote) return false;
+      i++;
+      expectLiteral = false;
+    } else {
+      if (text[i] !== '+') return false;
+      i++;
+      expectLiteral = true;
+    }
+  }
+  return !expectLiteral;
+}
+
+/** Scans forward from `from` for the `;` that ends the statement, ignoring nested brackets. */
+function statementEnd(masked, from) {
+  let depth = 0;
+  for (let i = from; i < masked.length; i++) {
+    const c = masked[i];
+    if ('([{'.includes(c)) depth++;
+    else if (')]}'.includes(c)) { if (depth === 0) return i; depth--; }
+    else if (c === ';' && depth === 0) return i;
+  }
+  return masked.length;
+}
+
+/** Splits a masked argument list (without the outer parens) at top-level commas. */
+function splitArgs(masked) {
+  const args = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < masked.length; i++) {
+    const c = masked[i];
+    if ('([{'.includes(c)) depth++;
+    else if (')]}'.includes(c)) depth--;
+    else if (c === ',' && depth === 0) { args.push(masked.slice(start, i)); start = i + 1; }
+  }
+  args.push(masked.slice(start));
+  return args.filter((a) => a.trim() !== '');
+}
+
+function positionOf(source, index) {
+  const before = source.slice(0, index);
+  const line = before.split('\n').length;
+  const col = index - (before.lastIndexOf('\n') + 1) + 1;
+  return { line, col };
+}
+
+/** Returns every violation in one file's source: [{ line, col, sink, message }]. */
+export function findViolations(source, file = '<source>') {
+  const masked = maskSource(source);
+  const violations = [];
+  const report = (index, sink, message) => {
+    const { line, col } = positionOf(source, index);
+    violations.push({ file, line, col, sink, message });
+  };
+
+  for (const sink of SINKS) {
+    const pattern = new RegExp(`\\.${sink}\\s*(\\+?=)(?!=)`, 'g');
+    let match;
+    while ((match = pattern.exec(masked)) !== null) {
+      const rhsStart = match.index + match[0].length;
+      const rhs = masked.slice(rhsStart, statementEnd(masked, rhsStart));
+      if (!isStaticLiteral(rhs)) {
+        report(match.index, sink,
+          `${sink} is assigned a non-literal — build the node with createElement/textContent instead`);
+      }
+    }
+  }
+
+  const insert = /\.insertAdjacentHTML\s*\(/g;
+  let call;
+  while ((call = insert.exec(masked)) !== null) {
+    const open = call.index + call[0].length - 1;
+    const close = statementEnd(masked, open + 1);
+    for (const arg of splitArgs(masked.slice(open + 1, close))) {
+      if (!isStaticLiteral(arg)) {
+        report(call.index, 'insertAdjacentHTML',
+          'insertAdjacentHTML is passed a non-literal — build the node with createElement/textContent instead');
+        break;
+      }
+    }
+  }
+  return violations;
+}
+
+/** Every scannable file under `dir`, recursively. */
+export function collectFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectFiles(full));
+    else if (SCANNED_EXTENSIONS.has(path.extname(entry.name))) files.push(full);
+  }
+  return files;
+}
+
+/** Scans a directory tree and returns every violation found. */
+export function checkDirectory(dir) {
+  return collectFiles(dir).flatMap((file) => findViolations(fs.readFileSync(file, 'utf8'), file));
+}
+
+export const EXTENSION_SRC = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)), '..', 'extension', 'src');
+
+function main(argv) {
+  const dirs = argv.length > 0 ? argv : [EXTENSION_SRC];
+  const violations = dirs.flatMap((dir) => checkDirectory(dir));
+  for (const v of violations) {
+    process.stderr.write(`${v.file}:${v.line}:${v.col} ${v.message}\n`);
+  }
+  if (violations.length > 0) {
+    process.stderr.write(`\n${violations.length} HTML-injection sink(s) found. `
+      + 'Only a static string literal (including the empty string used to clear a container) '
+      + 'may be assigned to innerHTML/outerHTML.\n');
+    return 1;
+  }
+  process.stdout.write(`No interpolated innerHTML/outerHTML/insertAdjacentHTML under ${dirs.join(', ')}.\n`);
+  return 0;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary
Fixes #72 and #74, and adds an **activity console** — a log pane docked at the bottom of the viewer, opened from a new **Help** menu.

The three belong together: #72 is about failures being swallowed, the console gives them somewhere to surface, and #74's rule is exactly what a log rendering untrusted text must obey.

![activity console](https://github.com/user-attachments/assets/placeholder)

The console lists every host action with its **round-trip duration**, document open/save, tool changes, and every error — timestamped and levelled. Auto-scroll, copy-all, clear, and a cap on retained entries so a long session can't grow unbounded. `extension/src/activity-log.js` is a DOM-free store, so the ring buffer and formatting are unit-testable without a browser.

## #72 — stop swallowing failures
13 `catch {}` blocks in `viewer.js` discarded their error. They now log with context, **without** changing correct user-facing behaviour — the retry-on-scroll in `renderPageEl` is deliberate and stays, so a transient hiccup during fast scrolling still doesn't nag. Where a page genuinely can't be rendered it now gets a visible placeholder rather than silent blank space.

The improvement is best seen in the screenshot: `refreshFormFields`' old `catch { state.formFields = []; }` now reads

> **form fields could not be listed — injected host failure — the document will appear to have no fillable fields**

which names the consequence, not just the error. That is the class of message that would have made #20 obvious in seconds instead of presenting as a blank page.

## #74 — ban interpolated innerHTML
`scripts/check-innerhtml.mjs` fails CI when `innerHTML`/`outerHTML`/`insertAdjacentHTML` is assigned anything but a static literal under `extension/src/`. The ~20 `innerHTML = ''` container clears stay allowed.

**My earlier audit was incomplete, and the rule caught it.** I had reported one latent case (`promptDialog()`'s `${title}`). The checker found **two**: that one *and* `renderRedactList()`'s `` item.innerHTML = `<span>#${index + 1} — page ${region.page}</span>` ``. Both fixed. That is a good argument for the rule existing — a careful manual read missed a live interpolation.

**Verified the rule fires:** on a clean tree it exits 0; reintroducing a violation gives

```
extension/src/viewer.js:2507:15 innerHTML is assigned a non-literal —
  build the node with createElement/textContent instead
exit=1
```

## The extension's unit tests were never running in CI
`ci.yml` had no Node step at all, so `extension/test/*.test.mjs` had only ever run locally — and the new #74 rule could not have failed CI without it. Added `actions/setup-node` (SHA-pinned, verified against `git ls-remote` to resolve to exactly `v4.4.0`) plus a `node --test` step and a dedicated checker step, so a violation points straight at the offending line.

## Test plan
- [x] `dotnet test --configuration Release --filter "Category!=Performance"` — **520/520**, unchanged (no C# touched)
- [x] `node --test "extension/test/**/*.test.mjs"` — **48/48** (14 existing + 34 new)
- [x] Playwright e2e — **74/74** (70 baseline + 4 new), green on **repeated full runs**
- [x] Workflow YAML parses; the new action pin resolves to its stated tag

All 4 new e2e tests confirmed failing first against the unmodified viewer (`#menu-help-trigger` not found, `.page-error` not found). The forced-failure test uses `hostgate.js`'s `fail: [...]` injection — the mechanism added in #19, used here for what it was built for.

Ran the suite repeatedly rather than once, because #19 shipped a flake that only appeared when tests ran as a group and passed in isolation.

## Security note
The console renders untrusted text — error messages, file names, form-field names and URLs all originate in the document. Every entry is built with `createElement`/`textContent`. A console built with `innerHTML` would have been a worse sink than the one #73 fixed, in the very PR adding a rule against it; the new rule passes on the new code.

## Out of scope
`viewer.js` is now ~3,570 lines and the console rendering could reasonably be its own module. Noted, not done here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_