### PR TITLE
Measure the real type size when editing text, not the glyph box height (#29)

### DIFF
--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1040,6 +1040,48 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+  test('edit text: the panel pre-fills with the run\'s real type size, and the edit keeps it (#29)', async () => {
+    // 28pt Helvetica. The detector used to report the ascender-to-descender box height instead of
+    // the type size — 25.9pt here — and the replacement was then stamped at that, so every edit
+    // shrank the text a little more.
+    const file = fixture('fontmatch.pdf', [[{ text: 'Match My Size', x: 72, y: 700, size: 28 }]]);
+    const page = await openViewerWith(file);
+    await openConsole(page);
+
+    // Drag an edit box over the line. (The right-click "Edit text" entry reaches the same panel,
+    // but applying from there is a no-op on main — see the note in the PR; not this issue's bug.)
+    await ui(page, '#tool-edit');
+    await dragPdfRect(page, { x: 60, y: 690, width: 320, height: 45 });
+    await expect(page.locator('#panel-edit')).toBeVisible();
+    await expect(page.locator('#edit-text')).toHaveValue(/Match My Size/);
+
+    // The size control is what the user sees and what gets sent back, so assert on its value.
+    await expect(page.locator('#edit-size')).toHaveValue('28.0');
+    await expect(page.locator('#edit-font')).toHaveValue('helvetica');
+
+    // The console says what it matched against, so a substitution is never silent.
+    const matched = page.locator('#console-log .console-entry', { hasText: 'matched the existing text style' });
+    await expect(matched).toHaveCount(1);
+    await expect(matched.locator('.console-detail')).toContainText('28.0pt');
+
+    // Apply the edit without touching the size, then re-open the replaced run: it still measures
+    // 28pt. Before the fix this came back as 25.9 and fell further on each pass.
+    await page.fill('#edit-text', 'Replaced Words');
+    await page.locator('#edit-apply').click();
+    await expect(page.locator('#status')).toContainText('Text replaced.');
+
+    await ui(page, '#tool-edit');
+    await dragPdfRect(page, { x: 60, y: 690, width: 320, height: 45 });
+    await expect(page.locator('#edit-text')).toHaveValue(/Replaced Words/);
+    await expect(page.locator('#edit-size')).toHaveValue('28.0');
+
+    // The console's open/closed state is persisted in extension storage, so leaving it open here
+    // would dock a pane in every later test's viewer and move the page geometry under them.
+    await page.locator('#console-close').click();
+    await expect(page.locator('#console-pane')).toBeHidden();
+    await page.close();
+  });
+
   test('highlight: dragging across text marks it, keeping the text readable', async () => {
     const file = fixture('highlight.pdf', [[{ text: 'HIGHLIGHT THIS LINE', x: 72, y: 700 }]]);
     const page = await openViewerWith(file);

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1491,11 +1491,25 @@ async function beginTextEdit(region) {
     setStyleToggle('edit-bold', found.bold);
     setStyleToggle('edit-italic', found.italic);
     $('edit-color').value = '#000000';
+    // Record what the size/face controls were matched to. The user sees the pre-filled controls;
+    // the console says what they were derived from, which is the only place the original font name
+    // appears at all (the picker can only offer the three families the editor can stamp).
+    activity.add('info', 'matched the existing text style', describeMatchedFont(found));
     showPanel('panel-edit');
     $('edit-text').focus();
   } catch (e) {
     fail(e);
   }
+}
+
+/** "times 11.0pt bold (from ABCDEF+MinionPro-Bold)" — for the activity console. */
+function describeMatchedFont(found) {
+  const size = Number(found.fontSize);
+  let text = `${found.fontFamily} ${Number.isFinite(size) ? size.toFixed(1) : '?'}pt`;
+  if (found.bold) text += ' bold';
+  if (found.italic) text += ' italic';
+  if (found.sourceFont && found.sourceFont !== found.fontFamily) text += ` (from ${found.sourceFont})`;
+  return text;
 }
 
 /** Opens the text panel in "add" mode for stamping brand-new text into a region. */
@@ -1535,7 +1549,16 @@ async function applyTextEdit() {
     });
     hidePanels();
     if (adding) setTool('text');
-    await applyContentEdit(result.pdf, [region.page], adding ? 'Text added.' : 'Text replaced.');
+    // Warnings from an edit used to be dropped on the floor. A font substitution changes how the
+    // document looks, so it is reported rather than left for the user to notice later (#29, #72).
+    const warnings = result.warnings ?? [];
+    for (const warning of warnings) {
+      activity.add('warn', adding ? 'text added with a warning' : 'text replaced with a warning', warning);
+    }
+    const substituted = warnings.some((w) => /substitut/i.test(w));
+    let message = adding ? 'Text added.' : 'Text replaced.';
+    if (substituted) message += ' The original font could not be reused — see Help ▸ Activity console.';
+    await applyContentEdit(result.pdf, [region.page], message);
   } catch (e) {
     fail(e);
   }

--- a/src/PdfEditor.Core/Models.cs
+++ b/src/PdfEditor.Core/Models.cs
@@ -37,8 +37,16 @@ public sealed record DocumentInfo(int PageCount, IReadOnlyList<PageInfo> Pages, 
 /// Text found inside a region, with the dominant font size (user-space points) and a
 /// best-effort read of the dominant font: family (<c>helvetica</c>/<c>times</c>/<c>courier</c>)
 /// and whether it is bold/italic — used to pre-fill the edit controls.
+/// <para>
+/// <paramref name="FontSize"/> is the size the glyphs are <em>drawn</em> at (transforms applied),
+/// not the height of their ascender-to-descender box — see
+/// <c>TextTools.EmSizeFromBoxHeight</c>. <paramref name="SourceFont"/> is the PostScript name of
+/// the dominant font as the document declares it, kept so an edit can tell whether the face it is
+/// about to stamp is the original or a substitute.
+/// </para>
 /// </summary>
-public sealed record RegionText(string Text, float FontSize, string FontFamily, bool Bold, bool Italic);
+public sealed record RegionText(string Text, float FontSize, string FontFamily, bool Bold, bool Italic,
+    string SourceFont = "");
 
 /// <summary>Result of an operation that rewrites the document.</summary>
 public sealed record EditResult(byte[] Pdf, IReadOnlyList<string> Warnings)

--- a/src/PdfEditor.Core/PdfEditor.Core.csproj
+++ b/src/PdfEditor.Core/PdfEditor.Core.csproj
@@ -7,6 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The font-measurement helpers behind text editing (#29) are pure functions with edge cases
+         — unusable font metrics, subset name tags — that are far cheaper to pin down directly than
+         to reach through a hand-built PDF for each one. They stay internal: this widens the test
+         project's reach, not the public API. -->
+    <InternalsVisibleTo Include="PdfEditor.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="itext" Version="9.7.0" />
     <PackageReference Include="itext.bouncy-castle-adapter" Version="9.7.0" />
     <PackageReference Include="PDFtoImage" Version="5.2.1" />

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -26,14 +26,18 @@ public static class TextTools
         using var doc = PdfIo.OpenReadOnly(pdf, password);
         var rect = new Rectangle(region.X, region.Y, region.Width, region.Height);
         var chunks = CollectChunks(doc, region.Page).Where(c => ContainsCenter(rect, c.BBox)).ToList();
-        float size = chunks.Count == 0 ? 12f : chunks.Max(c => c.FontHeight);
         string dominantFont = chunks
             .Where(c => !string.IsNullOrEmpty(c.FontName))
-            .GroupBy(c => c.FontName)
+            .GroupBy(c => c.FontName, StringComparer.Ordinal)
             .OrderByDescending(g => g.Count())
             .FirstOrDefault()?.Key ?? "";
+        // Take the size from the run the region is mostly made of, so a single stray large glyph
+        // cannot decide the size for a paragraph — and so size and family describe the same run.
+        var sizing = chunks.Where(c => string.Equals(c.FontName, dominantFont, StringComparison.Ordinal)).ToList();
+        if (sizing.Count == 0) sizing = chunks;
+        float size = sizing.Count == 0 ? 12f : MathF.Round(sizing.Max(c => c.FontSize), 2);
         var (family, bold, italic) = DetectFont(dominantFont);
-        return new RegionText(AssembleText(chunks), size, family, bold, italic);
+        return new RegionText(AssembleText(chunks), size, family, bold, italic, dominantFont);
     }
 
     /// <summary>
@@ -42,14 +46,50 @@ public static class TextTools
     /// size, style, and colour (all optional — omitted values fall back to what was there).
     /// </summary>
     public static EditResult ReplaceTextInRegion(byte[] pdf, RectRegion region, string newText,
-        float? fontSize = null, string? fontFamily = null, bool bold = false, bool italic = false,
+        float? fontSize = null, string? fontFamily = null, bool? bold = null, bool? italic = null,
         string? colorHex = null, string? password = null)
     {
-        float size = fontSize ?? GetTextInRegion(pdf, region, password).FontSize;
+        var found = GetTextInRegion(pdf, region, password);
+        float size = fontSize ?? found.FontSize;
+        // Family and style fall back to the run being replaced, as the summary above promises. They
+        // used to default to plain Helvetica instead, so any caller that named a size but no face
+        // silently reset bold Times body copy to regular Helvetica (#29).
+        string stampFont = ResolveFont(fontFamily ?? found.FontFamily,
+            bold ?? found.Bold, italic ?? found.Italic);
+
         var removed = Redactor.RemoveContent(pdf, new[] { region }, password);
         var stamped = StampText(removed.Pdf, region, newText, size, password,
-            fontName: ResolveFont(fontFamily, bold, italic), color: ParseColor(colorHex));
-        return new EditResult(stamped, removed.Warnings);
+            fontName: stampFont, color: ParseColor(colorHex));
+
+        var warnings = new List<string>(removed.Warnings);
+        if (DescribeSubstitution(found.SourceFont, stampFont) is { } note) warnings.Add(note);
+        return new EditResult(stamped, warnings);
+    }
+
+    /// <summary>
+    /// Reports, in words, when replacement text will not be set in the font the original was set
+    /// in. Only the standard-14 faces can be stamped today, so editing a run in any other font is a
+    /// silent change to how the document looks — exactly the kind of quiet substitution a user needs
+    /// told about rather than left to notice. Returns null when the original face is reproduced.
+    /// </summary>
+    /// <remarks>
+    /// Reusing the embedded program itself is issue #34; widening the stampable set is #28. Until
+    /// then the honest thing is to say what was swapped for what.
+    /// </remarks>
+    internal static string? DescribeSubstitution(string? sourceFont, string stampFont)
+    {
+        string original = StripSubsetPrefix(sourceFont);
+        if (original.Length == 0) return null;                                   // nothing detected
+        if (string.Equals(original, stampFont, StringComparison.OrdinalIgnoreCase)) return null;
+        return $"The original font '{original}' cannot be embedded by the editor, so the replacement "
+            + $"text was substituted with '{stampFont}'. Spacing and letterforms will differ.";
+    }
+
+    /// <summary>Drops the six-letter subset tag PDF writers prepend (e.g. <c>ABCDEF+Calibri</c>).</summary>
+    internal static string StripSubsetPrefix(string? fontName)
+    {
+        string name = (fontName ?? "").Trim();
+        return name.Length > 7 && name[6] == '+' ? name[7..] : name;
     }
 
     /// <summary>
@@ -257,7 +297,51 @@ public static class TextTools
 
     // ------------------------------------------------------------ extraction
 
-    private sealed record Chunk(string Text, Rectangle BBox, float FontHeight, string FontName);
+    private sealed record Chunk(string Text, Rectangle BBox, float FontHeight, float FontSize, string FontName);
+
+    /// <summary>
+    /// Recovers the type size a run was set in from the height of its transformed
+    /// ascender-to-descender box.
+    /// <para>
+    /// The box is <em>not</em> the em: it spans only <c>(ascender - descender) / 1000</c> of it —
+    /// 0.925 for Helvetica, 0.900 for Times, 0.786 for Courier. Treating the box height as the font
+    /// size (which this code did until #29) re-stamped every edited run 7–21% smaller than the
+    /// original, and because each edit re-measured its own undersized output the error compounded:
+    /// three passes over 24pt Courier left it under 12pt.
+    /// </para>
+    /// <para>
+    /// Working back from the box rather than from the <c>Tf</c> operand is deliberate — the box has
+    /// the text matrix and CTM already applied, so a run scaled by a <c>Tm</c>/<c>cm</c> yields the
+    /// size it is drawn at, which is the size the replacement has to be stamped at.
+    /// </para>
+    /// </summary>
+    /// <param name="boxHeight">Transformed ascent-line to descent-line distance.</param>
+    /// <param name="ascender">Font ascender, normalised to a 1000-unit em.</param>
+    /// <param name="descender">Font descender (negative), normalised to a 1000-unit em.</param>
+    internal static float EmSizeFromBoxHeight(float boxHeight, float ascender, float descender)
+    {
+        float span = (ascender - descender) / 1000f;
+        // Fonts that report no usable vertical metrics — Type 3 faces, undecodable embedded
+        // programs — leave the box height as the only estimate there is. Guarding on a plausible
+        // range also keeps a zero or absurd span from producing an infinity or a NaN.
+        if (!float.IsFinite(span) || span < 0.4f || span > 2f) return boxHeight;
+        return boxHeight / span;
+    }
+
+    /// <summary>Vertical metrics of a run's font, normalised to a 1000-unit em; (0,0) if unusable.</summary>
+    private static (float Ascender, float Descender) VerticalMetrics(PdfFont? font)
+    {
+        try
+        {
+            var metrics = font?.GetFontProgram()?.GetFontMetrics();
+            return metrics == null ? (0f, 0f) : (metrics.GetTypoAscender(), metrics.GetTypoDescender());
+        }
+        catch (Exception ex) when (ex is NullReferenceException or InvalidOperationException
+                                       or iText.Kernel.Exceptions.PdfException)
+        {
+            return (0f, 0f); // same fallback as a font with no metrics at all
+        }
+    }
 
     private static List<Chunk> CollectChunks(PdfDocument doc, int pageNumber)
     {
@@ -289,10 +373,18 @@ public static class TextTools
                 float maxY = asc.GetStartPoint().Get(1);
                 if (maxX <= minX) continue;
                 string fontName = "";
-                try { fontName = single.GetFont()?.GetFontProgram()?.GetFontNames()?.GetFontName() ?? ""; }
+                PdfFont? font = null;
+                try
+                {
+                    font = single.GetFont();
+                    fontName = font?.GetFontProgram()?.GetFontNames()?.GetFontName() ?? "";
+                }
                 catch { /* some embedded fonts expose no usable name; family detection just falls back */ }
+                float boxHeight = maxY - minY;
+                var (ascender, descender) = VerticalMetrics(font);
                 _chunks.Add(new Chunk(single.GetText(),
-                    new Rectangle(minX, minY, maxX - minX, maxY - minY), maxY - minY, fontName));
+                    new Rectangle(minX, minY, maxX - minX, boxHeight), boxHeight,
+                    EmSizeFromBoxHeight(boxHeight, ascender, descender), fontName));
             }
         }
 

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -422,7 +422,10 @@ public static class MessageProcessor
             fontSize = text.FontSize,
             fontFamily = text.FontFamily,
             bold = text.Bold,
-            italic = text.Italic
+            italic = text.Italic,
+            // The font as the document names it, so the viewer can report what it matched against
+            // — 'helvetica' alone hides the fact that the original was, say, DejaVuSans.
+            sourceFont = text.SourceFont
         };
     }
 
@@ -431,8 +434,10 @@ public static class MessageProcessor
         var result = TextTools.ReplaceTextInRegion(Pdf(p), Region(p[RegionKey]!.AsObject()),
             p["text"]?.GetValue<string>() ?? "", p["fontSize"]?.GetValue<float>(),
             p["fontFamily"]?.GetValue<string>(),
-            p["bold"]?.GetValue<bool>() ?? false,
-            p["italic"]?.GetValue<bool>() ?? false,
+            // Left absent, family and style inherit the run being replaced rather than
+            // resetting it to plain Helvetica.
+            p["bold"]?.GetValue<bool>(),
+            p["italic"]?.GetValue<bool>(),
             p[ColorKey]?.GetValue<string>(),
             Password(p));
         return new { pdf = Convert.ToBase64String(result.Pdf), warnings = result.Warnings };

--- a/tests/PdfEditor.Core.Tests/Golden/GoldenCorpus.cs
+++ b/tests/PdfEditor.Core.Tests/Golden/GoldenCorpus.cs
@@ -115,6 +115,10 @@ internal static class GoldenCorpus
         new List<(string, Func<byte[], byte[]>)>
         {
             ("redact", pdf => Redactor.Redact(pdf, new[] { Region }).Pdf),
+            // In-place text editing: the path #29 was about. Neither a size nor a face is named,
+            // so the result records what the editor infers from the run it is replacing — which is
+            // what the `typeset:` line in the projection exists to pin down.
+            ("replace-region-text", pdf => TextTools.ReplaceTextInRegion(pdf, Region, "replaced copy").Pdf),
             ("rotate-90", pdf => PageTools.Rotate(pdf, new[] { 1 }, 90).Pdf),
             ("merge-with-self", pdf => Merger.Merge(new[] { pdf, pdf })),
             ("sanitize", pdf => Sanitizer.Sanitize(pdf, new SanitizeOptions()).Pdf),

--- a/tests/PdfEditor.Core.Tests/Golden/GoldenProjection.cs
+++ b/tests/PdfEditor.Core.Tests/Golden/GoldenProjection.cs
@@ -151,6 +151,7 @@ internal static class GoldenProjection
             .Append('\n');
 
         report.Append("  text: ").Append(Safely(() => Normalise(PdfTextExtractor.GetTextFromPage(page)))).Append('\n');
+        report.Append("  typeset: ").Append(Safely(() => Typeset(page))).Append('\n');
         report.Append("  ops: ").Append(Safely(() => Operators(page.GetContentBytes()))).Append('\n');
         DescribeResources(page.GetResources().GetPdfObject(), "  ", 0, report);
     }
@@ -427,6 +428,49 @@ internal static class GoldenProjection
     /// </summary>
     private static string Bucket(int length) =>
         "~" + (length / 256 * 256).ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The distinct <c>face@size</c> pairs the page's text is actually drawn in, sorted.
+    /// <para>
+    /// The resource inventory above records which fonts a page <em>declares</em>; this records what
+    /// the glyphs are really set in, which is the thing an editing regression damages. #29 shipped
+    /// because nothing in the suite looked at type size: replaced text came back 7–21% smaller than
+    /// the original and every projection stayed identical. Sizes are the <c>Tf</c> operand with the
+    /// text and graphics matrices applied, rounded to 0.1pt so a harmless last-bit difference in a
+    /// matrix cannot make the recordings flap.
+    /// </para>
+    /// </summary>
+    private static string Typeset(PdfPage page)
+    {
+        var listener = new TypesetListener();
+        new PdfCanvasProcessor(listener).ProcessPageContent(page);
+        return listener.Runs.Count == 0 ? "<no text>" : string.Join(' ', listener.Runs);
+    }
+
+    private sealed class TypesetListener : iText.Kernel.Pdf.Canvas.Parser.Listener.IEventListener
+    {
+        public SortedSet<string> Runs { get; } = new(StringComparer.Ordinal);
+
+        public void EventOccurred(iText.Kernel.Pdf.Canvas.Parser.Data.IEventData data, EventType type)
+        {
+            if (data is not iText.Kernel.Pdf.Canvas.Parser.Data.TextRenderInfo t
+                || string.IsNullOrWhiteSpace(t.GetText())) return;
+
+            var m = t.GetTextMatrix();
+            float scale = (float)Math.Sqrt(Math.Abs(
+                m.Get(iText.Kernel.Geom.Matrix.I11) * m.Get(iText.Kernel.Geom.Matrix.I22)
+                - m.Get(iText.Kernel.Geom.Matrix.I12) * m.Get(iText.Kernel.Geom.Matrix.I21)));
+            float size = t.GetFontSize() * (scale == 0 ? 1 : scale);
+
+            string face;
+            try { face = t.GetFont()?.GetFontProgram()?.GetFontNames()?.GetFontName() ?? "<unnamed>"; }
+            catch (Exception ex) when (ex is not OutOfMemoryException) { face = "<unreadable>"; }
+
+            Runs.Add(string.Create(CultureInfo.InvariantCulture, $"{face}@{size:F1}"));
+        }
+
+        public ICollection<EventType>? GetSupportedEvents() => null;
+    }
 
     private static string Safely(Func<string> describe)
     {

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/acroform-text-field.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/acroform-text-field.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
 acroform: needAppearances=none fields=1
   field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes
@@ -22,7 +23,23 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: Qx1 fx1 qx1 rex1 rgx1
+acroform: needAppearances=none fields=1
+  field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes
+validation: clean
+== replace-region-text ==
+bytes: ~2048
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=yes has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
+  text: replaced copy
+  typeset: Helvetica@12.0
+  ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 qx2
+  font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: needAppearances=none fields=1
   field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes
 validation: clean
@@ -35,6 +52,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=90 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
 acroform: needAppearances=none fields=1
   field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes
@@ -48,9 +66,11 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
 page 2: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
 acroform: none
 validation: clean
@@ -63,6 +83,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
 acroform: needAppearances=none fields=1
   field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes
@@ -76,6 +97,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=2 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
 acroform: needAppearances=none fields=2
   field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes
@@ -90,6 +112,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx2 cmx1 qx2
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
 acroform: needAppearances=none fields=1

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-constant-and-blend.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-constant-and-blend.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx2 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
@@ -24,8 +25,26 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx3 Tdx1 Tfx1 Tjx1 fx3 gx1 gsx2 qx3 rex3 rgx3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  gs GSa: BM=/Multiply CA=0.6 ca=0.4
+  gs GSb: AIS=false BM=/Screen ca=0.75
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~1536
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@12.0
+  ops: BTx2 ETx2 Qx4 Tdx2 Tfx2 Tjx2 fx2 gx1 gsx2 qx4 rex2 rgx2
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
   gs GSb: AIS=false BM=/Screen ca=0.75
 acroform: none
@@ -39,6 +58,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx2 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
@@ -54,12 +74,14 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx2 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
   gs GSb: AIS=false BM=/Screen ca=0.75
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx2 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
@@ -75,6 +97,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx2 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
@@ -90,6 +113,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx2 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4
@@ -106,6 +130,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx4 Tdx1 Tfx1 Tjx1 cmx1 fx2 gx1 gsx2 qx4 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-image-softmask.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-image-softmask.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
@@ -23,8 +24,25 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 cmx1 fx1 gx1 qx2 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2048
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@12.0
+  ops: BTx2 ETx2 Qx3 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx3
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
 acroform: none
 validation: clean
@@ -37,6 +55,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
@@ -51,11 +70,13 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
@@ -70,6 +91,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
@@ -84,6 +106,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
@@ -99,6 +122,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox2 ETx1 Qx3 Tdx1 Tfx1 Tjx1 cmx2 gx1 qx3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-luminosity-softmask.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-luminosity-softmask.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 gx1 gsx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
@@ -23,8 +24,25 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 fx2 gx1 gsx1 qx2 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~1792
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@12.0
+  ops: BTx2 ETx2 Qx3 Tdx2 Tfx2 Tjx2 fx1 gx1 gsx1 qx3 rex1 rgx1
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
 acroform: none
 validation: clean
@@ -37,6 +55,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 gx1 gsx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
@@ -51,11 +70,13 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 gx1 gsx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 gx1 gsx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
@@ -70,6 +91,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 gx1 gsx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
@@ -84,6 +106,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 gx1 gsx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)
@@ -99,6 +122,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx3 Tdx1 Tfx1 Tjx1 cmx1 fx1 gx1 gsx1 qx3 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-nested-groups.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-nested-groups.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 gsx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
@@ -32,8 +33,51 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx1 Dox1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 cmx1 fx1 gx1 gsx1 qx2 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  gs GS1: BM=/Normal ca=0.8
+  xobject Fm1: subtype=Form bbox=[0 0 300 240] matrix=none group=Transparency(cs=/DeviceRGB I=false K=false)
+    ops: Dox1 Qx1 cmx1 fx1 gsx1 qx1 rex1 rgx1
+    gs GS2: BM=/Multiply ca=0.5
+    xobject Fm2: subtype=Form bbox=[0 0 200 160] matrix=none group=Transparency(cs=/DeviceRGB I=true K=true)
+      ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 fx1 gx1 gsx1 qx1 rex1 rgx1
+      font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+      gs GS3: BM=/Darken ca=0.35
+      xobject Fm3: subtype=Form bbox=[0 0 120 100] matrix=none group=Transparency(cs=/DeviceGray I=true K=false)
+        ops: fx1 gx1 rex1
+  xobject Fm2: subtype=Form bbox=[0 0 300 240] matrix=none group=Transparency(cs=/DeviceRGB I=false K=false)
+    ops: Dox1 Qx1 cmx1 fx1 gsx1 qx1 rex1 rgx1
+    gs GS2: BM=/Multiply ca=0.5
+    xobject Fm1: subtype=Form bbox=[0 0 200 160] matrix=none group=Transparency(cs=/DeviceRGB I=true K=true)
+      ops: BTx1 Dox1 ETx1 Qx1 TJx1 Tdx1 Tfx1 cmx1 fx1 gx1 gsx1 qx1 rex1 rgx1
+      font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+      gs GS3: BM=/Darken ca=0.35
+      xobject Fm1: subtype=Form bbox=[0 0 120 100] matrix=none group=Transparency(cs=/DeviceGray I=true K=false)
+        ops: fx1 gx1 rex1
+      xobject Fm3: subtype=Form bbox=[0 0 120 100] matrix=none group=Transparency(cs=/DeviceGray I=true K=false)
+        ops: fx1 gx1 rex1
+    xobject Fm2: subtype=Form bbox=[0 0 200 160] matrix=none group=Transparency(cs=/DeviceRGB I=true K=true)
+      ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 fx1 gx1 gsx1 qx1 rex1 rgx1
+      font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+      gs GS3: BM=/Darken ca=0.35
+      xobject Fm3: subtype=Form bbox=[0 0 120 100] matrix=none group=Transparency(cs=/DeviceGray I=true K=false)
+        ops: fx1 gx1 rex1
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~3584
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@9.0
+  ops: BTx2 Dox1 ETx2 Qx3 Tdx2 Tfx2 Tjx2 cmx1 gx1 gsx1 qx3
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
   xobject Fm1: subtype=Form bbox=[0 0 300 240] matrix=none group=Transparency(cs=/DeviceRGB I=false K=false)
     ops: Dox1 Qx1 cmx1 fx1 gsx1 qx1 rex1 rgx1
@@ -72,6 +116,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 gsx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
@@ -95,6 +140,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 gsx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
@@ -109,6 +155,7 @@ page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
         ops: fx1 gx1 rex1
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 gsx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
@@ -132,6 +179,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 gsx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
@@ -155,6 +203,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 gx1 gsx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8
@@ -179,6 +228,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus inner group
+  typeset: Helvetica@10.0 Helvetica@9.0
   ops: BTx1 Dox2 ETx1 Qx3 Tdx1 Tfx1 Tjx1 cmx2 gx1 gsx1 qx3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-broken-embedded-program.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-broken-embedded-program.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
@@ -23,8 +24,25 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx2 ETx2 Qx1 TJx1 Tdx2 Tfx2 Tjx1 fx1 gx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2304
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@20.0
+  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
 acroform: none
 validation: clean
@@ -37,6 +55,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
@@ -51,11 +70,13 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
@@ -70,6 +91,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
@@ -84,6 +106,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes
@@ -99,6 +122,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus subset
+  typeset: BCDEEE+Calibri@20.0 Helvetica@10.0
   ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-differences-encoding.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-differences-encoding.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -23,9 +24,26 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx2 ETx2 Qx1 TJx1 Tdx2 Tfx2 Tjx1 fx1 gx1 qx1 rex1 rgx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~1536
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@28.0
+  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
 validation: clean
 == rotate-90 ==
@@ -37,6 +55,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -51,11 +70,13 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -70,6 +91,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -84,6 +106,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -99,6 +122,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus ZYX
+  typeset: Helvetica@10.0 Helvetica@28.0
   ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx2
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-missing-resource.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-missing-resource.txt
@@ -9,12 +9,15 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
 validation: clean
 == redact ==
 threw: InvalidDataException: This PDF could not be read: rewriting the page content stream failed because the document is malformed or corrupt (NullReferenceException).
+== replace-region-text ==
+threw: InvalidDataException: This PDF could not be read: extracting text from page 1 failed because the document is malformed or corrupt (NullReferenceException).
 == rotate-90 ==
 bytes: ~1024
 pdf-version: PDF-1.7
@@ -24,6 +27,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -37,10 +41,12 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -54,6 +60,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -67,6 +74,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: needAppearances=none fields=1
@@ -81,6 +89,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <failed: NullReferenceException>
+  typeset: <failed: NullReferenceException>
   ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-type0-identity-h.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-type0-identity-h.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -23,9 +24,26 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx2 ETx2 Qx1 TJx1 Tdx2 Tfx2 Tjx1 fx1 gx1 qx1 rex1 rgx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2304
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@24.0
+  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
 validation: clean
 == rotate-90 ==
@@ -37,6 +55,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -51,11 +70,13 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -70,6 +91,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -84,6 +106,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
@@ -99,6 +122,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus GOLDEN
+  typeset: AAAAAA+DejaVuSans@24.0 Helvetica@10.0
   ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx2
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-type3-glyph-procedures.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-type3-glyph-procedures.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
@@ -23,8 +24,25 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus
+  typeset: Helvetica@10.0
   ops: BTx2 ETx2 Qx1 TJx1 Tdx2 Tfx2 Tjx1 fx1 gx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2048
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: golden corpus replaced copy
+  typeset: Helvetica@10.0 Helvetica@36.0
+  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
 acroform: none
 validation: clean
@@ -37,6 +55,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
@@ -51,11 +70,13 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
@@ -70,6 +91,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
@@ -84,6 +106,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 ETx2 Tdx2 Tfx2 Tjx2 gx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]
@@ -99,6 +122,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus abab
+  typeset: <unnamed>@36.0 Helvetica@10.0
   ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/hidden-data.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/hidden-data.txt
@@ -9,6 +9,7 @@ info: Title=Internal Draft Author=Jane Author has-CreationDate=yes has-ModDate=y
 catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
@@ -22,8 +23,24 @@ info: Title=Internal Draft Author=Jane Author has-CreationDate=yes has-ModDate=y
 catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2816
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: Title=Internal Draft Author=Jane Author has-CreationDate=yes has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes has-Metadata=no
+page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
+  text: Visible content replaced copy
+  typeset: Helvetica@12.0
+  ops: BTx2 ETx2 Qx2 Tdx2 Tfx2 Tjx2 qx2
+  font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
 validation: clean
 == rotate-90 ==
@@ -35,6 +52,7 @@ info: Title=Internal Draft Author=Jane Author has-CreationDate=yes has-ModDate=y
 catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=90 annots=1 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
@@ -48,10 +66,12 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=yes has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 page 2: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
@@ -65,6 +85,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=yes has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
@@ -78,6 +99,7 @@ info: Title=Internal Draft Author=Jane Author has-CreationDate=yes has-ModDate=y
 catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=2 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: needAppearances=none fields=1
@@ -92,6 +114,7 @@ info: Title=Internal Draft Author=Jane Author has-CreationDate=yes has-ModDate=y
 catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Visible content
+  typeset: Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 cmx1 qx2
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-itext-3.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-itext-3.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -29,8 +30,46 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms
+  typeset: Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 cmx1 fx1 qx2 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+  xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+    ops: Dox1 Qx1 qx1
+    xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+      ops: Dox1 Qx1 qx1
+      xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+        ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
+        font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+  xobject Fm2: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+    ops: Dox1 Qx1 qx1
+    xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+      ops: Dox1 Qx1 qx1
+      xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+        ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
+        font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+    xobject Fm2: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+      ops: Dox1 Qx1 qx1
+      xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+        ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
+        font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+      xobject Fm2: subtype=Form bbox=[0 0 200 120] matrix=none group=none
+        ops: BTx1 ETx1 TJx1 Tdx1 Tfx1
+        font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2816
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=yes has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
+  text: Document with nested forms replaced copy
+  typeset: Helvetica@10.0 Helvetica@12.0
+  ops: BTx2 Dox1 ETx2 Qx3 Tdx2 Tfx2 Tjx2 cmx1 qx3
+  font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
     ops: Dox1 Qx1 qx1
     xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -64,6 +103,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=90 annots=0 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -84,6 +124,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -95,6 +136,7 @@ page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
         font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 page 2: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -115,6 +157,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -135,6 +178,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 cmx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none
@@ -156,6 +200,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms innermost
+  typeset: Helvetica@10.0 Helvetica@12.0
   ops: BTx1 Dox2 ETx1 Qx3 Tdx1 Tfx1 Tjx1 cmx2 qx3
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-raw-4.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-raw-4.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx1 qx1
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
@@ -28,7 +29,29 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx2 fx1 qx2 rex1 rgx1
+  xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
+    ops: Dox1 Qx1 qx1
+    xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
+      ops: Dox1 Qx1 qx1
+      xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
+        ops: Dox1 Qx1 qx1
+        xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2048
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: replaced copy
+  typeset: Helvetica@12.0
+  ops: BTx1 Dox1 ETx1 Qx3 Tdx1 Tfx1 Tjx1 qx3
+  font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
     xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
@@ -47,6 +70,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx1 qx1
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
@@ -66,6 +90,7 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx1 qx1
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
@@ -76,6 +101,7 @@ page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
         xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx1 qx1
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
@@ -95,6 +121,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx1 qx1
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
@@ -114,6 +141,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx1 qx1
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1
@@ -134,6 +162,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox2 Qx3 cmx1 qx3
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/plain-multipage.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/plain-multipage.txt
@@ -9,14 +9,17 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -30,14 +33,42 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: BTx1 ETx1 Qx1 TJx1 Tdx1 Tfx1 fx2 qx1 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
+  ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~2048
+pdf-version: PDF-1.7
+pages: 3
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: replaced copy
+  typeset: Helvetica@18.0
+  ops: BTx2 ETx2 Qx2 TJx1 Tdx2 Tfx2 Tjx1 fx1 qx2 rex1 rgx1
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
+page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: Page 2 payload
+  typeset: Helvetica@18.0
+  ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
+  text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -51,14 +82,17 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=90 annots=0 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -72,26 +106,32 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 4: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 5: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 6: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -105,14 +145,17 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -126,14 +169,17 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=1 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: needAppearances=none fields=1
@@ -148,15 +194,18 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 1 payload
+  typeset: Helvetica@18.0
   ops: BTx1 Dox1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 cmx1 fx1 qx2 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 2 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 3: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: Page 3 payload
+  typeset: Helvetica@18.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1 fx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/stream-undecodable-flate.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/stream-undecodable-flate.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -22,8 +23,24 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Qx1 fx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~1280
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
+  text: replaced copy
+  typeset: Helvetica@12.0
+  ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 qx2
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
 validation: clean
 == rotate-90 ==
@@ -35,6 +52,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=90 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -48,10 +66,12 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -65,6 +85,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -78,6 +99,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=1 group=none
   text: <empty>
+  typeset: <no text>
   ops: <none>
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: needAppearances=none fields=1
@@ -92,6 +114,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: <empty>
+  typeset: <no text>
   ops: Dox1 Qx2 cmx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/stream-wrong-length.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/stream-wrong-length.txt
@@ -9,6 +9,7 @@ info: has-CreationDate=no has-ModDate=no has-ID=no
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -22,8 +23,24 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 fx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+acroform: none
+validation: clean
+== replace-region-text ==
+bytes: ~1280
+pdf-version: PDF-1.7
+pages: 1
+encrypted: no
+info: has-CreationDate=no has-ModDate=yes has-ID=yes
+catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
+page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
+  text: replaced copy Hello
+  typeset: Helvetica@12.0
+  ops: BTx2 ETx2 Qx2 Tdx2 Tfx2 Tjx2 qx2
+  font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
+  font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none
 validation: clean
 == rotate-90 ==
@@ -35,6 +52,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=90 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -48,10 +66,12 @@ info: has-CreationDate=yes has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 page 2: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -65,6 +85,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: none
@@ -78,6 +99,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=1 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 ETx1 Tdx1 Tfx1 Tjx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
 acroform: needAppearances=none fields=1
@@ -92,6 +114,7 @@ info: has-CreationDate=no has-ModDate=yes has-ID=yes
 catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-Metadata=no
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: Hello
+  typeset: Helvetica@12.0
   ops: BTx1 Dox1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 cmx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   xobject Im1: subtype=Image size=24x12 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no

--- a/tests/PdfEditor.Core.Tests/TestPdfAssert.cs
+++ b/tests/PdfEditor.Core.Tests/TestPdfAssert.cs
@@ -18,6 +18,44 @@ public static class TestPdfAssert
         return PdfTextExtractor.GetTextFromPage(doc.GetPage(page), new LocationTextExtractionStrategy());
     }
 
+    /// <summary>
+    /// The (base font name, type size) of every text-showing run on a page, read from the rendered
+    /// graphics state.
+    /// <para>
+    /// This is deliberately independent of <c>TextTools</c>'s own measurement: the font-fidelity
+    /// tests (#29) must not verify the detector against itself, or a detector that is wrong in a
+    /// self-consistent way passes. The size reported here is the <c>Tf</c> operand scaled by the
+    /// text/graphics matrices, i.e. the size the glyphs are actually drawn at.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<(string Font, float Size)> DrawnRuns(byte[] pdf, int page = 1)
+    {
+        using var doc = new PdfDocument(new PdfReader(new MemoryStream(pdf)));
+        var listener = new RunListener();
+        new PdfCanvasProcessor(listener).ProcessPageContent(doc.GetPage(page));
+        return listener.Runs;
+    }
+
+    private sealed class RunListener : IEventListener
+    {
+        public List<(string Font, float Size)> Runs { get; } = new();
+
+        public void EventOccurred(IEventData data, EventType type)
+        {
+            if (data is not TextRenderInfo t || string.IsNullOrWhiteSpace(t.GetText())) return;
+            // GetFontSize() is the Tf operand; the vertical scale of the text matrix carries any
+            // Tm/cm scaling on top of it.
+            var matrix = t.GetTextMatrix();
+            float scale = (float)Math.Sqrt(Math.Abs(
+                matrix.Get(iText.Kernel.Geom.Matrix.I11) * matrix.Get(iText.Kernel.Geom.Matrix.I22)
+                - matrix.Get(iText.Kernel.Geom.Matrix.I12) * matrix.Get(iText.Kernel.Geom.Matrix.I21)));
+            string name = t.GetFont()?.GetFontProgram()?.GetFontNames()?.GetFontName() ?? "";
+            Runs.Add((name, t.GetFontSize() * (scale == 0 ? 1 : scale)));
+        }
+
+        public ICollection<EventType>? GetSupportedEvents() => null;
+    }
+
     /// <summary>Counts image draw events on a page (XObject and inline images).</summary>
     public static int CountImages(byte[] pdf, int page = 1)
     {

--- a/tests/PdfEditor.Core.Tests/TestPdfs.cs
+++ b/tests/PdfEditor.Core.Tests/TestPdfs.cs
@@ -39,6 +39,25 @@ public static class TestPdfs
         return output.ToArray();
     }
 
+    /// <summary>
+    /// A single page holding one line of text set in a named standard-14 font at a known size.
+    /// Used by the font-fidelity tests (#29), which need the type size the text was actually set
+    /// in to be ground truth they can assert against.
+    /// </summary>
+    public static byte[] WithTextInFont(string standardFontName, string text, float size,
+        float x = 72, float y = 700)
+    {
+        using var output = new MemoryStream();
+        using (var doc = new PdfDocument(new PdfWriter(output)))
+        {
+            var page = doc.AddNewPage(new PageSize(PageWidth, PageHeight));
+            new PdfCanvas(page).BeginText()
+                .SetFontAndSize(PdfFontFactory.CreateFont(standardFontName), size)
+                .MoveText(x, y).ShowText(text).EndText();
+        }
+        return output.ToArray();
+    }
+
     /// <summary>A document with the given number of pages, each labelled.</summary>
     public static byte[] MultiPage(int pages, string labelPrefix = "Page")
     {

--- a/tests/PdfEditor.Core.Tests/TextFontFidelityTests.cs
+++ b/tests/PdfEditor.Core.Tests/TextFontFidelityTests.cs
@@ -1,0 +1,216 @@
+using System.Globalization;
+using iText.IO.Font.Constants;
+using PdfEditor.Core;
+using Xunit;
+
+namespace PdfEditor.Tests;
+
+/// <summary>
+/// Font fidelity when editing existing text (issue #29): an edited run must come back out of the
+/// document in the same family, weight, slant and — the part that was actually broken — the same
+/// type size it went in at.
+/// <para>
+/// Sizes are asserted against <see cref="TestPdfAssert.DrawnRuns"/>, which reads the <c>Tf</c>
+/// operand out of the rewritten content stream, rather than against
+/// <see cref="TextTools.GetTextInRegion"/>. Checking the detector with the detector would let a
+/// self-consistently wrong measurement pass.
+/// </para>
+/// </summary>
+public class TextFontFidelityTests
+{
+    /// <summary>The band the fixtures' single line of text sits in.</summary>
+    private static RectRegion Band(float size) => new(1, 60, 700 - size * 0.5f, 400, size * 2f);
+
+    public static TheoryData<string, float> StandardFonts() => new()
+    {
+        { iText.IO.Font.Constants.StandardFonts.HELVETICA, 10f },
+        { iText.IO.Font.Constants.StandardFonts.HELVETICA, 24f },
+        { iText.IO.Font.Constants.StandardFonts.HELVETICA_BOLD, 18f },
+        { iText.IO.Font.Constants.StandardFonts.TIMES_ROMAN, 11f },
+        { iText.IO.Font.Constants.StandardFonts.TIMES_BOLDITALIC, 24f },
+        { iText.IO.Font.Constants.StandardFonts.COURIER, 12f },
+        { iText.IO.Font.Constants.StandardFonts.COURIER_OBLIQUE, 24f },
+    };
+
+    /// <summary>
+    /// The detector must report the size the text was <em>set</em> in. It used to report the height
+    /// of the ascender-to-descender box instead, which is only (ascender-descender)/1000 of the em:
+    /// 92.5% for Helvetica, 90% for Times, 78.6% for Courier.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(StandardFonts))]
+    public void GetTextInRegion_ReportsTheTypeSizeTheTextWasSetIn(string fontName, float size)
+    {
+        byte[] pdf = TestPdfs.WithTextInFont(fontName, "Measure me", size);
+
+        var found = TextTools.GetTextInRegion(pdf, Band(size));
+
+        Assert.Equal("Measure me", found.Text);
+        Assert.True(Math.Abs(found.FontSize - size) <= 0.25f, string.Create(CultureInfo.InvariantCulture,
+            $"{fontName} was set at {size}pt but was detected as {found.FontSize:F2}pt."));
+    }
+
+    /// <summary>
+    /// The end-to-end complaint: replace a run without naming a size and the stamped text must be
+    /// drawn at the size the original was drawn at.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(StandardFonts))]
+    public void ReplaceTextInRegion_StampsTheReplacementAtTheOriginalTypeSize(string fontName, float size)
+    {
+        byte[] pdf = TestPdfs.WithTextInFont(fontName, "Original words", size);
+        var region = Band(size);
+        var found = TextTools.GetTextInRegion(pdf, region);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, region, "Replacement words",
+            fontSize: null, fontFamily: found.FontFamily, bold: found.Bold, italic: found.Italic);
+
+        var run = Assert.Single(TestPdfAssert.DrawnRuns(result.Pdf));
+        Assert.True(Math.Abs(run.Size - size) <= 0.25f, string.Create(CultureInfo.InvariantCulture,
+            $"{fontName} text set at {size}pt was re-stamped at {run.Size:F2}pt."));
+    }
+
+    /// <summary>
+    /// The compounding case, and the one a user actually notices: the size error was applied afresh
+    /// on every edit, so text shrank a little each time it was touched. Courier lost 21% per pass —
+    /// three edits took 24pt down to under 12pt.
+    /// </summary>
+    [Fact]
+    public void ReplaceTextInRegion_RepeatedEdits_DoNotShrinkTheText()
+    {
+        const float size = 24f;
+        byte[] pdf = TestPdfs.WithTextInFont(iText.IO.Font.Constants.StandardFonts.COURIER, "Edit me", size);
+        var region = Band(size);
+
+        for (int pass = 1; pass <= 3; pass++)
+        {
+            var found = TextTools.GetTextInRegion(pdf, region);
+            pdf = TextTools.ReplaceTextInRegion(pdf, region, "Edit me",
+                fontSize: null, fontFamily: found.FontFamily, bold: found.Bold, italic: found.Italic).Pdf;
+
+            var run = Assert.Single(TestPdfAssert.DrawnRuns(pdf));
+            Assert.True(Math.Abs(run.Size - size) <= 0.25f, string.Create(CultureInfo.InvariantCulture,
+                $"After {pass} edit(s), 24pt Courier is being drawn at {run.Size:F2}pt."));
+        }
+    }
+
+    /// <summary>Moving a run must not resize it either — it re-stamps at the detected size.</summary>
+    [Fact]
+    public void MoveText_PreservesTheTypeSize()
+    {
+        const float size = 20f;
+        byte[] pdf = TestPdfs.WithTextInFont(
+            iText.IO.Font.Constants.StandardFonts.TIMES_ROMAN, "Move me", size);
+
+        var moved = TextTools.MoveText(pdf, Band(size), 0, -120);
+
+        var run = Assert.Single(TestPdfAssert.DrawnRuns(moved.Pdf));
+        Assert.True(Math.Abs(run.Size - size) <= 0.25f, string.Create(CultureInfo.InvariantCulture,
+            $"Moved 20pt text is being drawn at {run.Size:F2}pt."));
+    }
+
+    /// <summary>Family, weight and slant survive the round trip along with the size.</summary>
+    [Theory]
+    [MemberData(nameof(StandardFonts))]
+    public void ReplaceTextInRegion_ReproducesTheOriginalFontFace(string fontName, float size)
+    {
+        byte[] pdf = TestPdfs.WithTextInFont(fontName, "Face check", size);
+        var region = Band(size);
+        var found = TextTools.GetTextInRegion(pdf, region);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, region, "Face check",
+            fontSize: null, fontFamily: found.FontFamily, bold: found.Bold, italic: found.Italic);
+
+        var run = Assert.Single(TestPdfAssert.DrawnRuns(result.Pdf));
+        Assert.Equal(fontName, run.Font);
+    }
+
+    // ------------------------------------------------------- deliberate fallback
+
+    /// <summary>
+    /// When the run's font is one the stamper can actually reproduce, the edit is silent — a
+    /// warning on every edit would train users to ignore the one that matters.
+    /// </summary>
+    [Fact]
+    public void ReplaceTextInRegion_WhenTheFontIsReproduced_DoesNotWarnAboutSubstitution()
+    {
+        byte[] pdf = TestPdfs.WithTextInFont(
+            iText.IO.Font.Constants.StandardFonts.TIMES_BOLD, "Reproducible", 14);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, Band(14), "Reproducible");
+
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("substitut", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// A font outside the three families the stamper can produce gets silently swapped for the
+    /// nearest one it can. Symbol is the case that needs no embedded-font machinery to demonstrate:
+    /// replacing Symbol text turns Greek letterforms into Helvetica, which is a visible change to
+    /// the document and must be reported rather than assumed to be fine.
+    /// </summary>
+    [Fact]
+    public void ReplaceTextInRegion_WhenTheOriginalFontCannotBeReproduced_ReportsTheSubstitution()
+    {
+        byte[] pdf = TestPdfs.WithTextInFont(
+            iText.IO.Font.Constants.StandardFonts.SYMBOL, "abgd", 18);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, Band(18), "alpha beta");
+
+        string warning = Assert.Single(result.Warnings,
+            w => w.Contains("substitut", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("Symbol", warning, StringComparison.Ordinal);       // names the original
+        Assert.Contains("Helvetica", warning, StringComparison.Ordinal);    // and the replacement
+    }
+
+    [Theory]
+    [InlineData("ABCDEF+Calibri", "Calibri")]         // the six-letter subset tag PDF writers add
+    [InlineData("Calibri", "Calibri")]                 // no tag
+    [InlineData("ABCDE+X", "ABCDE+X")]                 // too short to be a tag; left alone
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void StripSubsetPrefix_RemovesOnlyARealSubsetTag(string? input, string expected)
+        => Assert.Equal(expected, TextTools.StripSubsetPrefix(input));
+
+    /// <summary>
+    /// The substitution notice keys off the original PostScript name, so a subset-tagged copy of a
+    /// face the editor can stamp (<c>ABCDEF+Helvetica</c>) must not be reported as a substitution —
+    /// nothing about it changes — while a genuinely different face must be.
+    /// </summary>
+    [Theory]
+    [InlineData("Helvetica", "Helvetica", false)]
+    [InlineData("ABCDEF+Helvetica", "Helvetica", false)]
+    [InlineData("Times-Bold", "Times-Bold", false)]
+    [InlineData("", "Helvetica", false)]               // nothing detected: nothing to claim
+    [InlineData("ABCDEF+Calibri", "Helvetica", true)]
+    [InlineData("Symbol", "Helvetica", true)]
+    public void DescribeSubstitution_ReportsOnlyARealFaceChange(string source, string stamp, bool expected)
+        => Assert.Equal(expected, TextTools.DescribeSubstitution(source, stamp) is not null);
+
+    /// <summary>
+    /// The metric guard: fonts reporting an implausible or unusable ascender/descender span fall
+    /// back to the box height rather than producing a divide-by-nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(0f, 0f, 18.5f)]          // no metrics at all
+    [InlineData(100f, -50f, 18.5f)]      // span 0.15 — too small to be an em
+    [InlineData(3000f, -500f, 18.5f)]    // span 3.5 — too large
+    [InlineData(718f, -207f, 20f)]       // Helvetica: 18.5 / 0.925 = 20
+    public void EmSizeFromBoxHeight_FallsBackWhenMetricsAreUnusable(
+        float ascender, float descender, float expected)
+        => Assert.Equal(expected, TextTools.EmSizeFromBoxHeight(18.5f, ascender, descender), 0.01f);
+
+    /// <summary>
+    /// A run whose font exposes no usable vertical metrics at all still has to yield a plausible
+    /// size rather than a zero, an infinity, or a NaN that would propagate into the stamp.
+    /// </summary>
+    [Fact]
+    public void GetTextInRegion_FontWithoutUsableMetrics_StillReportsAPlausibleSize()
+    {
+        byte[] pdf = Golden.GoldenPdfs.Type3GlyphProcedures();
+
+        var found = TextTools.GetTextInRegion(pdf, new RectRegion(1, 0, 0, 600, 800));
+
+        Assert.True(float.IsFinite(found.FontSize) && found.FontSize > 0,
+            string.Create(CultureInfo.InvariantCulture, $"Type 3 run reported size {found.FontSize}."));
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #29. Edited text now keeps the original's size as well as its face.

**The issue's premise was half wrong, and that changed the fix.** Font *type* was already working — family, weight and slant were detected, surfaced and passed back correctly, and the seven `ReproducesTheOriginalFontFace` tests passed **before** any change. **Size** was the broken half.

## Root cause
`GetTextInRegion` returned the transformed **ascender-to-descender box height**, not the type size. That box is only `(ascender − descender) / 1000` of the em:

| Face | Box height as a fraction of the em |
| --- | --- |
| Helvetica | 0.925 |
| Times | 0.900 |
| **Courier** | **0.786** |

Because `ReplaceTextInRegion` defaulted its size from that same measurement, **every edit re-measured its own undersized output and shrank again**:

```
24pt Courier → 18.86 → 14.82 → 11.65        (three successive edits)
```

Fixed by taking the size from the run the region is mostly made of, so size and family describe the same run and a single stray large glyph can't decide the size for a paragraph.

## Two adjacent defects fixed with it
- **`ReplaceTextInRegion`'s doc comment was a lie.** It claimed an omitted family/style "falls back to what was there"; they actually reset to plain Helvetica. `bool bold/italic` became `bool?` so omission genuinely means "keep". A caller that named a size but no face was silently restyling the text.
- **Face substitution was silent.** When the original face can't be reused, it now reports through `EditResult.Warnings` into the activity console (#80), naming original and replacement — and only when the face actually changes.

## Test plan
- [x] `dotnet test --configuration Release --filter "Category!=Performance"` — **561/561** (Core 406, NativeHost 121, Integration 17, Perf 17); base 520, so +41
- [x] `node --test "extension/test/**/*.test.mjs"` — **48/48**
- [x] Playwright e2e — **75/75**, full suite run **three times** in-group
- [x] Build clean (3 warnings, pre-existing on `main`); coverage 94.2%

**Verified the guards are load-bearing:** reintroducing the glyph-box measurement fails **22** tests — every `StampsTheReplacementAtTheOriginalTypeSize` case, `RepeatedEdits_DoNotShrinkTheText`, and six golden recordings.

The golden suite (#53) was **extended rather than bypassed**: its projection now records `typeset: face@size` per page and adds a `replace-region-text` operation, so font fidelity is covered by the same net as everything else.

## Flagged during development
- **A group flake was introduced and fixed.** The first new e2e test left the activity console open, and its state persists in extension storage — so it docked a pane in every later test and broke `move image` consistently in-group while passing alone. Exactly the #19 shape. Fixed by closing the console; three consecutive in-group runs green, independently reproduced.
- **`DecompressionBomb_StaysWithinBudget`** was reported failing once under full-solution load, and claimed pre-existing on `main`. I could not reproduce it: 4/4 in isolation and clean across my full-suite runs. No fuzz code is touched here. Flagged rather than dropped — worth watching, since an allocation-budget assertion is inherently sensitive to concurrent load.

## Found, not fixed — each deserves its own issue
- **Right-click ▸ Edit text ▸ Apply is a silent no-op.** `viewer.js:1232` sets `pendingEditRegion`, then `setTool('select')` → `hidePanels()` nulls it.
- **`ReplaceAll` (find & replace) has the same size error** via a different code path. Deliberately out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_