### PR TITLE
Bug round: find &amp; replace sizing, add-text clipping, and the text-edit regression net

### DIFF
--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -2633,7 +2633,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
   });
 
   // eslint-disable-next-line playwright/no-skipped-test
-  test.fixme('add text: a caption longer than its box is stamped in full, not clipped', async () => {
+  test('add text: a caption longer than its box is stamped in full, not clipped', async () => {
     // LIVE BUG. Placing text with a plain click gives a 240x26pt box and defaults the type size
     // to the box height (26pt). "STAMPED CAPTION" does not fit 240pt at 26pt, and TextTools.
     // StampText lays the string into a fixed-size iText Canvas, so the overflow is *clipped and
@@ -2748,7 +2748,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
   });
 
   // eslint-disable-next-line playwright/no-skipped-test
-  test.fixme('text edit: the type size survives repeated edits (#29/#84)', async () => {
+  test('text edit: the type size survives repeated edits (#29/#84)', async () => {
     // LIVE BUG. TextTools.GetTextInRegion reports the type size as the *glyph* box height —
     // chunks.Max(c => c.FontHeight), the ascent-to-descent span of the rendered characters —
     // rather than the em size the text was set in. For Helvetica that is 0.925 em, so every
@@ -2787,7 +2787,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
   });
 
   // eslint-disable-next-line playwright/no-skipped-test
-  test.fixme('text edit: a replacement longer than the original is not truncated', async () => {
+  test('text edit: a replacement longer than the original is not truncated', async () => {
     // LIVE BUG, and the one the maintainer reported as "HELLO" becoming "WORL". TextTools.
     // StampText lays the replacement into an iText Canvas sized to the *original* region, so
     // anything that does not fit is clipped away and lost. Replacing "HELLO" (24pt, in a
@@ -3337,5 +3337,6 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await expectText(page).not.toContain('Original Sentence');
     await page.close();
   });
+
 
 });

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -3309,4 +3309,33 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
+
+  test('text edit: editing highlighted (selected) text applies (#90)', async () => {
+    // #90 reported that right-clicking highlighted text, choosing Edit and pressing Apply did
+    // nothing. That is the selection path (selectionRegion), distinct from the run-under-cursor
+    // path #85/#89 fixed. This holds the whole selection route end to end so it cannot regress.
+    const file = fixture('sel-edit.pdf', [[{ text: 'Original Sentence Here', x: 72, y: 700, size: 18 }]]);
+    const page = await openViewerWith(file);
+    await page.locator('.page[data-page="1"] .text-layer span').first().waitFor({ timeout: 15000 });
+
+    // Highlight the run, then right-click the selection and choose Edit text.
+    await page.evaluate(() => {
+      const span = document.querySelector('.page[data-page="1"] .text-layer span');
+      window.getSelection().selectAllChildren(span);
+    });
+    await page.locator('.page[data-page="1"] .text-layer span').first().click({ button: 'right' });
+    await page.locator('#context-menu').getByRole('button', { name: /Edit text/ }).click();
+    await expect(page.locator('#panel-edit')).toBeVisible();
+    await expect(page.locator('#edit-text')).toHaveValue(/Original Sentence Here/);
+
+    await page.fill('#edit-text', 'Replaced Sentence');
+    await page.click('#edit-apply');
+    await expect(page.locator('#status')).toContainText('Text replaced');
+
+    // The document really changed — Apply ran, it was not a no-op.
+    await expectText(page).toContain('Replaced Sentence');
+    await expectText(page).not.toContain('Original Sentence');
+    await page.close();
+  });
+
 });

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -145,8 +145,15 @@ public static class TextTools
         string? fontFamily = null, bool bold = false, bool italic = false,
         string? colorHex = null, string? password = null)
     {
+        // Lay the text out from the region's top-left to the page edge rather than confining it to
+        // the box. A click places a fixed 240x26 default box and defaults the size to its height, so
+        // any caption that does not fit used to be clipped and *lost* — "STAMPED CAPTION" became
+        // "STAMPED CAPTIO" (#86 family; the same clipping ReplaceTextInRegion fixed in #29). Adding
+        // text must never silently drop characters; the trade is that a caption longer than the box
+        // extends past its right edge instead of wrapping inside it.
         var stamped = StampText(pdf, region, text, fontSize, password,
-            fontName: ResolveFont(fontFamily, bold, italic), color: ParseColor(colorHex));
+            fontName: ResolveFont(fontFamily, bold, italic), color: ParseColor(colorHex),
+            confineToRegion: false);
         return EditResult.Of(stamped);
     }
 

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -233,6 +233,15 @@ public static class TextTools
 
         var warnings = new List<string>();
         byte[] current = pdf;
+
+        // Measure each match's real type size and face on the original document, before anything is
+        // removed. m.Height is the ascender-to-descender box, not the em (it is 0.79–0.93 of it), so
+        // stamping at m.Height re-set every replacement 7–21% too small; and passing no font stamped
+        // it all in Helvetica whatever the original was (#86). GetTextInRegion recovers both via the
+        // same #84 machinery ReplaceTextInRegion uses.
+        var styles = matches.Select(m =>
+            GetTextInRegion(pdf, new RectRegion(m.Page, m.X, m.Y, m.Width, m.Height), password)).ToList();
+
         // Inset each match rect slightly so glyphs of adjacent words that merely touch
         // the boundary are not removed with it.
         var regions = matches.Select(m => new RectRegion(m.Page,
@@ -241,11 +250,19 @@ public static class TextTools
         warnings.AddRange(removed.Warnings);
         current = removed.Pdf;
 
-        foreach (var m in matches)
+        var substitutions = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < matches.Count; i++)
         {
+            var m = matches[i];
+            var style = styles[i];
             var region = new RectRegion(m.Page, m.X, m.Y, m.Width, m.Height);
-            current = StampText(current, region, replacement, m.Height, password, wrap: false);
+            string stampFont = ResolveFont(style.FontFamily, style.Bold, style.Italic);
+            current = StampText(current, region, replacement, style.FontSize, password,
+                wrap: false, fontName: stampFont);
+            // Report a face that could not be reproduced once, not once per occurrence.
+            if (DescribeSubstitution(style.SourceFont, stampFont) is { } note) substitutions.Add(note);
         }
+        warnings.AddRange(substitutions);
         return (new EditResult(current, warnings), matches.Count);
     }
 

--- a/tests/PdfEditor.Core.Tests/TextToolsTests.cs
+++ b/tests/PdfEditor.Core.Tests/TextToolsTests.cs
@@ -287,6 +287,21 @@ public class TextToolsTests
     }
 
     [Fact]
+    public void ReplaceAll_StampsTheReplacementAtTheOriginalTypeSize()
+    {
+        // #86: ReplaceAll passed the match's ascender-to-descender box height (m.Height) as the font
+        // size. That box is only ~0.93 of the em for Helvetica, so every replacement came out ~7%
+        // too small. Re-measuring the replaced run must give the original 24pt, not the ~22.2pt box.
+        byte[] pdf = TestPdfs.WithText(("SECRET", 72, 700, 24));
+
+        var (result, count) = TextTools.ReplaceAll(pdf, "SECRET", "PUBLIC");
+        Assert.Equal(1, count);
+
+        float measured = TextTools.GetTextInRegion(result.Pdf, new RectRegion(1, 60, 688, 220, 44)).FontSize;
+        Assert.InRange(measured, 23f, 25f);
+    }
+
+    [Fact]
     public void ReplaceAll_KeepsSurroundingWordsIntact()
     {
         byte[] pdf = TestPdfs.WithText(("Payable to ACME within 30 days", 72, 700, 12));


### PR DESCRIPTION
Bundles the text-editing/redaction bug cluster. Each fix has a test watched failing without it.

## Fixed

**#86 — Find & replace stamped the wrong size, always in Helvetica.** `ReplaceAll` passed each match's ascender-to-descender box height as the font size and no font name, so every replacement came out 7–21% too small and always Helvetica. It now measures each match with `GetTextInRegion` (the #84 machinery `ReplaceTextInRegion` uses) and stamps at the recovered em size in the detected family/style, warning once about any face it can't reproduce. Test re-measures a 24pt replacement: the fix gives ~24, the old `m.Height` path gives exactly 22.2 and fails.

**Add-text clipped long captions (a `test.fixme` from #92).** Placing text laid it into a fixed-size canvas, so a caption longer than its box was clipped and lost — `STAMPED CAPTION` → `STAMPED CAPTIO`. Now lays out to the page edge (`confineToRegion:false`), the same fix `ReplaceTextInRegion` got for #29.

## Verified already fixed — regression tests added or activated

**#90 — right-click *highlighted* text ▸ Edit ▸ Apply does nothing.** I could not reproduce this on current main in three scenarios (single-run, partial, multi-line selection) — the whole selection route works. #90 was filed minutes after #89 merged and reads as a pre-#89 build. Added a regression test that locks the selection-edit route end to end. **Please retest on 1.0.2 and close if it passes.**

**Two `test.fixme`s from #92 now pass** and are promoted to active tests: type size surviving repeated edits (fixed by #84) and a replacement longer than the original not truncated (fixed by #89). Both were filed on a branch predating those merges.

## Not fixed here — deliberately

**Redaction on a `/Rotate 90` page doesn't remove the text under the box** (still `test.fixme`, fully diagnosed in the test). This is a coordinate-space fix in `cssToPdf` on the **safety-critical redaction path** — a wrong move breaks redaction on ordinary pages, which is far worse than the rotated-page bug. It deserves its own focused PR with dedicated coordinate tests, not a rushed slot in this bundle. Verified it is the drag→PDF mapping, not the host: search-and-mark redaction removes the same word on the same rotated fixture.

**#82 (Cloudflare serial scanning) and #88 (intermittent Core flake)** are different subsystems (a perf refactor and a flake investigation) — I'd keep them out of this editing-bug bundle rather than mix concerns. Say the word and I'll take them next.

## Verification

- Backend **566** (Core 411, NativeHost 121, Integration 17, Perf 17), build clean
- e2e **114 passed, 1 fixme**; `check-innerhtml` clean
- Each fix watched failing without it (e.g. #86 mutant → exactly 22.2)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_