### PR TITLE
Split viewer.js (#81): extract the coordinate transforms, and map the rest

### DIFF
--- a/extension/src/geometry.js
+++ b/extension/src/geometry.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Coordinate transforms between the displayed page image and the document's unrotated crop box.
+//
+// The rendered image is the page's crop box (origin x,y; size width×height in PDF user space)
+// with the page's clockwise rotation applied. Mapping between the image and the document has to
+// account for both the crop-box origin AND the rotation, or redactions and edits land shifted or
+// rotated. These two functions are the rotation half, kept pure (no DOM, no viewer state) so the
+// rotation logic — the subtlety behind rotated-page placement bugs — can be reasoned about and
+// tested on its own.
+//
+// (fx, fy) are fractions across the *unrotated* crop box — fx from its left, fy from its bottom.
+// (u, v) are fractions across the *displayed* image — u from its left, v from its top.
+
+/** Fraction across the displayed image (u,v) → fraction across the unrotated crop box (fx,fy). */
+export function displayToPage(rotation, u, v) {
+  switch (rotation) {
+    case 90: return [v, u];
+    case 180: return [1 - u, v];
+    case 270: return [1 - v, 1 - u];
+    default: return [u, 1 - v];
+  }
+}
+
+/** Fraction across the unrotated crop box (fx,fy) → fraction across the displayed image (u,v). */
+export function pageToDisplay(rotation, fx, fy) {
+  switch (rotation) {
+    case 90: return [fy, fx];
+    case 180: return [1 - fx, fy];
+    case 270: return [1 - fy, 1 - fx];
+    default: return [fx, 1 - fy];
+  }
+}

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -4,6 +4,7 @@
 import { HostClient, bytesToBase64, base64ToBytes } from './host-client.js';
 import { runFormScript } from './formScript.js';
 import { ActivityLog, formatTime } from './activity-log.js';
+import { displayToPage, pageToDisplay } from './geometry.js';
 
 const host = new HostClient();
 
@@ -308,32 +309,8 @@ function pageSize(pageNum = state.page) {
   return state.info.pages[pageNum - 1];
 }
 
-// The rendered image is the page's crop box (origin x,y; size width×height in PDF user
-// space) with the page's clockwise rotation applied. So mapping between the image and the
-// document has to account for both the crop-box origin AND the rotation, or redactions land
-// shifted/rotated. (fx,fy) below are fractions across the *unrotated* crop box — fx from its
-// left, fy from its bottom — and (u,v) are fractions across the *displayed* image, u from
-// its left, v from its top.
-
-/** Fraction across the displayed image (u,v) → fraction across the unrotated crop box. */
-function displayToPage(rotation, u, v) {
-  switch (rotation) {
-    case 90: return [v, u];
-    case 180: return [1 - u, v];
-    case 270: return [1 - v, 1 - u];
-    default: return [u, 1 - v];
-  }
-}
-
-/** Fraction across the unrotated crop box (fx,fy) → fraction across the displayed image. */
-function pageToDisplay(rotation, fx, fy) {
-  switch (rotation) {
-    case 90: return [fy, fx];
-    case 180: return [1 - fx, fy];
-    case 270: return [1 - fy, 1 - fx];
-    default: return [fx, 1 - fy];
-  }
-}
+// Rotation transforms between the displayed image and the unrotated crop box now live in
+// geometry.js (imported above); cssToPdf/pdfRectToCss below add the crop-box origin and scale.
 
 /** CSS pixel (relative to a page's image) → PDF user-space point on that page. */
 function cssToPdf(pageNum, img, cssX, cssY) {

--- a/extension/test/geometry.test.mjs
+++ b/extension/test/geometry.test.mjs
@@ -1,0 +1,39 @@
+// Unit tests for the pure page/display coordinate transforms (see extension/src/geometry.js).
+// Run with: node --test extension/test/geometry.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { displayToPage, pageToDisplay } from '../src/geometry.js';
+
+const ROTATIONS = [0, 90, 180, 270];
+const POINTS = [[0, 0], [1, 0], [0, 1], [1, 1], [0.3, 0.7], [0.25, 0.9]];
+
+test('pageToDisplay is the inverse of displayToPage for every rotation', () => {
+  for (const r of ROTATIONS) {
+    for (const [u, v] of POINTS) {
+      const [fx, fy] = displayToPage(r, u, v);
+      const [u2, v2] = pageToDisplay(r, fx, fy);
+      assert.ok(Math.abs(u2 - u) < 1e-9 && Math.abs(v2 - v) < 1e-9,
+        `rotation ${r}: (${u},${v}) → (${fx},${fy}) → (${u2},${v2})`);
+    }
+  }
+});
+
+test('rotation 0 flips only the vertical axis (image top-down vs page bottom-up)', () => {
+  // Display top-left (0,0) is the crop box's top-left: fx=0, fy=1.
+  assert.deepEqual(displayToPage(0, 0, 0), [0, 1]);
+  assert.deepEqual(displayToPage(0, 1, 1), [1, 0]);
+});
+
+test('rotation 90 maps the display top-left to the crop box bottom-left', () => {
+  // A quarter turn clockwise: the image's top-left corner is the unrotated box's bottom-left.
+  assert.deepEqual(displayToPage(90, 0, 0), [0, 0]);   // fx=0 (left), fy=0 (bottom)
+  assert.deepEqual(displayToPage(90, 1, 0), [0, 1]);   // moving down the image → along the box
+});
+
+test('the corners of the display map to the four corners of the box, for every rotation', () => {
+  for (const r of ROTATIONS) {
+    const mapped = POINTS.slice(0, 4).map(([u, v]) => displayToPage(r, u, v).join(','));
+    assert.equal(new Set(mapped).size, 4, `rotation ${r} collapsed corners: ${mapped}`);
+  }
+});


### PR DESCRIPTION
First tranche of breaking up the 3,500-line `viewer.js` (#81), plus the plan and the one real blocker for the rest.

## What's extracted

The two pure rotation transforms (`displayToPage` / `pageToDisplay`) → **`geometry.js`**. They have no DOM or viewer-state dependency, so they lift out cleanly and — for the first time — get **unit tests** (`extension/test/geometry.test.mjs`, 4 cases: inverse round-trip across all rotations, corner mapping, the 0° and 90° specifics). Isolating them has direct value: rotated-page placement bugs (e.g. the rotate-90 redaction one in #93) live in exactly this logic and couldn't be tested on their own while buried in the viewer.

`viewer.js` imports them back; `cssToPdf` / `pdfRectToCss` stay, since they add the crop-box origin and scale, which do need viewer state. No behaviour change.

## Why this is a tranche, not the whole split

I looked at doing the full decomposition in one PR and it isn't safe to rush, for one concrete reason worth recording:

- The natural core module is the shared substrate — `state`, `host`, `$`, `activity`, and the status helpers (`setStatus`/`toast`/`fail`/…). Those are all defined once and never reassigned, so they hoist cleanly.
- **But `pageEls` is reassigned** (`viewer.js:564`, `pageEls = []`), and ES-module imports are read-only live bindings — you cannot assign to an imported name. So `pageEls` can't be a bare exported `let` that the viewer reassigns; it has to move behind a holder object (`view.pageEls = []`), which touches every `pageEls` reference. That's a deliberate, test-guarded step, not a mechanical lift, so it gets its own tranche rather than being folded in here where a mistake would break the file the whole extension depends on.

## Planned seams (follow-up tranches)

The file already has clear section banners. Target modules, roughly in dependency order:

1. **`core.js`** — `state`, `host`, `activity`, `$`, status helpers, `pageSize` + `cssToPdf`/`pdfRectToCss` (after the `pageEls` holder change).
2. Leaf features that only read core: **signatures**, **OCR**, **compare**, **find & replace**, **sanitize/hidden-info**.
3. Heavier features: **redaction**, **text edit / move**, **highlight (sweep)**, **draw**, **forms + JS/URL safety**, **links**, **page organizer**.
4. **`wiring.js`** — the `wire()` event hookup last, importing from all of the above.

Each tranche is behaviour-preserving and verified by the full e2e suite, which is exactly the safety net that makes this refactor tractable now that #92 landed.

## Verification

- `geometry.test.mjs` 4/4; existing extension unit suites unchanged; `check-innerhtml` clean.
- e2e **110 passed, 4 fixme** — identical to `main`, behaviour preserved.
- Does not touch `viewer.spec.js`, so no conflict with the bug PR (#93).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_