### PR TITLE
Fix redaction leaving recoverable text under the box on rotated pages

### DIFF
--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -2676,7 +2676,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
   });
 
   // eslint-disable-next-line playwright/no-skipped-test
-  test.fixme('redaction on a rotated (/Rotate 90) page removes the text under the box', async () => {
+  test('redaction on a rotated (/Rotate 90) page removes the text under the box', async () => {
     // LIVE BUG — and the most serious one in this branch. On a /Rotate 90 page, dragging a
     // redaction box paints the black rectangle exactly where it was drawn and removes *no text
     // at all*. The words stay in the file: selectable, copyable and searchable underneath an

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1130,19 +1130,30 @@ pagesEl.addEventListener('pointerup', async (e) => {
   // — a scan — where there is nothing to select, so a box is all the user can express.
   if (state.tool === 'highlight') {
     if (Math.abs(x1 - x0) < 5 && Math.abs(y1 - y0) < 5) return; // ignore a click
-    const a = cssToPdf(pageNum, pe.img, Math.min(x0, x1), Math.max(y0, y1));
-    const b = cssToPdf(pageNum, pe.img, Math.max(x0, x1), Math.min(y0, y1));
-    applyHighlight({ page: pageNum, x: a.x, y: a.y, width: b.x - a.x, height: Math.max(b.y - a.y, 1) },
-      { snap: state.highlightMode !== 'box' });
+    // min/max in PDF space, not screen space, so the box is not negative-sized on a rotated page
+    // (same fix as the main region below).
+    const h1 = cssToPdf(pageNum, pe.img, x0, y0);
+    const h2 = cssToPdf(pageNum, pe.img, x1, y1);
+    applyHighlight({
+      page: pageNum, x: Math.min(h1.x, h2.x), y: Math.min(h1.y, h2.y),
+      width: Math.abs(h2.x - h1.x), height: Math.max(Math.abs(h2.y - h1.y), 1),
+    }, { snap: state.highlightMode !== 'box' });
     return;
   }
   if (tiny) return;
 
-  const a = cssToPdf(pageNum, pe.img, Math.min(x0, x1), Math.max(y0, y1)); // bottom-left
-  const b = cssToPdf(pageNum, pe.img, Math.max(x0, x1), Math.min(y0, y1)); // top-right
+  // Map both dragged corners to PDF space, then take min/max there. Picking the "bottom-left" and
+  // "top-right" in *screen* space only lines up with PDF min/max on an unrotated page: on a
+  // /Rotate 90/270 page cssToPdf swaps the axes, so screen-min maps to PDF-max and the region
+  // came out with a negative width/height. A negative-width rect still draws (the black box
+  // appeared) but fails the redactor's glyph-intersection test (left > right matches nothing), so
+  // the text under the box was never removed — recoverable under an opaque rectangle (#rotate-90).
+  const c1 = cssToPdf(pageNum, pe.img, x0, y0);
+  const c2 = cssToPdf(pageNum, pe.img, x1, y1);
   const region = {
     page: pageNum,
-    x: a.x, y: a.y, width: b.x - a.x, height: b.y - a.y,
+    x: Math.min(c1.x, c2.x), y: Math.min(c1.y, c2.y),
+    width: Math.abs(c2.x - c1.x), height: Math.abs(c2.y - c1.y),
   };
 
   if (state.tool === 'redact') {


### PR DESCRIPTION
The most serious of the recent bugs, now fixed with the safety check it needed.

## The bug

On a `/Rotate 90` or `270` page, dragging a redaction box painted the black rectangle but removed **no text** — the words stayed selectable, copyable and searchable underneath an opaque box. That is exactly the disclosure redaction exists to prevent.

## Cause (diagnosed empirically)

The drag region was built by mapping the screen's bottom-left and top-right corners to PDF space and subtracting. That yields PDF min/max only on an unrotated page — `cssToPdf` swaps the axes on a rotated page, so screen-min maps to PDF-*max* and the region came out **negative-sized**. On the rotated fixture, instrumenting the drag showed:

```
drag region:  x=220.24, width=-113.1, y=370.37, height=67.3
find-text:    ROTSECRET at x=120, width=86, y=397, height=13   (squarely inside the drag's span)
```

A negative-width rectangle still *draws* (so the box appeared), but the redactor's glyph-intersection test needs `left < right` — with `left > right` it matches nothing, so no glyph was removed.

## Fix

Map both dragged corners to PDF space and take min/max *there*, so the region is always positive-sized regardless of rotation. Applied to the main region (redact/edit/text/sign/field) and the box-highlight fallback, which shared the pattern.

## Why it's safe on the common path

The change is behaviour-identical on unrotated pages — PDF-space min/max equals the old bottom-left/top-right there. Proven, not asserted:

- Reverting the fix turns the rotated-page test **red** while the unrotated redaction tests (`content removed and box painted`, `per-page overlays`) stay **green** — they pass with *and* without the fix.
- No C# touched: search-and-mark redaction (absolute PDF coordinates, never had this bug) is untouched.

## Verification

- e2e **115 passed** — the `redaction on a /Rotate 90 page removes the text under the box` case is now active (was a `test.fixme`).
- `check-innerhtml` clean.

Closes the last of the four `test.fixme` bugs surfaced by the #92 overhaul.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_