### PR TITLE
Fix the release pipeline: build files never attached under immutable releases

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -106,10 +106,17 @@ jobs:
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      - name: Create the release candidate (prerelease) and attach the packages
+      # Create the release as a DRAFT with the packages attached, then publish it in the next step.
+      # This repository has immutable releases enabled: once a release is published its assets are
+      # frozen, and softprops publishes a prerelease immediately, so uploading the zips afterwards
+      # failed with "Cannot upload asset ... to an immutable release" and every RC since had no
+      # build files attached. A draft is still mutable, so the assets attach here; publishing a
+      # draft that already carries its assets is allowed.
+      - name: Create the release candidate (draft) and attach the packages
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          draft: true
           prerelease: true
           generate_release_notes: true
           files: |
@@ -129,3 +136,11 @@ jobs:
             This is **not** published to the Chrome Web Store. To promote it, create a new
             Release targeting this commit with the clean tag
             `${{ steps.version.outputs.final_tag }}` and leave "Set as a pre-release" unchecked.
+
+      # Flip the draft to a published prerelease. It already carries its assets, so this succeeds
+      # under immutable releases. A GITHUB_TOKEN-published release does not fire "release: published"
+      # for other workflows (GitHub's anti-recursion rule), so this does not trip release-extension.yml.
+      - name: Publish the release candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${{ steps.version.outputs.tag }}" --draft=false --prerelease

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -124,8 +124,19 @@ jobs:
             ./scripts/package-bundle.sh "$rid" dist
           done
 
-      - name: Attach to the GitHub Release
+      # Best-effort. This workflow reacts to a release a human has already *published*, and this
+      # repository has immutable releases enabled, so its assets are frozen the moment it exists —
+      # softprops can neither overwrite nor add to them ("Cannot delete asset from an immutable
+      # release"). That failure previously failed the whole `package` job and so blocked the Chrome
+      # Web Store deploy below, which is the actual point of a promotion — v1.0.1 and v1.0.2 never
+      # reached the store because of it. The deploy consumes the build artifact uploaded above, not
+      # these release assets, so it does not need the attach to succeed. The standalone zips for a
+      # promoted version live on its release-candidate prerelease, which is built as a draft and so
+      # keeps its assets (see release-candidate.yml). Making the final release carry them too would
+      # need this workflow to own the release as draft→publish rather than react to a published one.
+      - name: Attach to the GitHub Release (best-effort; see note)
         if: github.event_name == 'release'
+        continue-on-error: true
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Both release workflows have failed on every run since immutable releases were enabled on this repo. The build and packaging always succeed; the failure is at asset-attach time.

## Root cause

Immutable releases freeze a release's assets the moment it's published. Both workflows tried to attach assets to an already-published release.

**`release-candidate.yml` (every merge to main)** — runs 30–37 all failed:
```
Cannot upload asset pdf-editor-bundle-win-x64.zip to an immutable release.
```
`softprops/action-gh-release` publishes the prerelease immediately, then the zip uploads are rejected. So **every post-merge RC since v1.0.3-30 was created with no build files attached** — your exact symptom.

**`release-extension.yml` (manual promote)** — the v1.0.1 and v1.0.2 runs both failed:
```
Cannot delete asset from an immutable release
```
It reacts to a release a human already published (immutable before the workflow starts). The attach failure failed the `package` job, which **blocked the Chrome Web Store deploy** — so **v1.0.1 and v1.0.2 never reached the store.**

## Fixes

**RC:** create the release as a **draft** (still mutable → the extension zip and four platform bundles attach), then flip it to a published prerelease with `gh release edit --draft=false`. Publishing a draft that already carries its assets is allowed. Anti-recursion still holds (a GITHUB_TOKEN publish doesn't fire `release: published` elsewhere).

**Promote:** the attach to the human-published release can't succeed under immutability, but the store deploy consumes the in-run build artifact, not the release assets — so the attach is now **best-effort** (`continue-on-error`) and the deploy proceeds. The standalone zips for a promoted version live on its RC prerelease (now a draft, so it keeps them).

## Verification

- Both workflow files validated as parseable YAML; the new draft→publish and best-effort steps are in place.
- These only run on GitHub, so the **live test is the next merge to main** — it will run the fixed `release-candidate.yml` and should produce a prerelease with all five zips attached. I'll confirm from the run once this lands.

## Maintainer decision (left out deliberately)

To make a **promoted final release** *also* carry the zips (not just deploy to the store), this workflow would need to own the release as draft→publish instead of reacting to a human-published one — a change to your documented manual promote steps. Happy to do that as a follow-up if you want it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_