### PR TITLE
Scan document URLs concurrently and cap the count (#82)

### DIFF
--- a/src/PdfEditor.Core/CloudflareUrlScanner.cs
+++ b/src/PdfEditor.Core/CloudflareUrlScanner.cs
@@ -22,33 +22,64 @@ public static class CloudflareUrlScanner
 {
     private const string ApiBase = "https://api.cloudflare.com/client/v4";
 
+    /// <summary>How many Cloudflare scans may be in flight at once.</summary>
+    public const int DefaultMaxConcurrency = 6;
+
+    /// <summary>
+    /// The most distinct URLs a single document will submit to Cloudflare. Beyond this, the
+    /// remaining URLs keep their local heuristic verdict. Each scan is a submit plus up to a dozen
+    /// polls, so without a ceiling a link-bomb document could enqueue thousands of round trips.
+    /// </summary>
+    public const int DefaultMaxUrls = 100;
+
     /// <summary>Rates every link, using Cloudflare when <paramref name="creds"/> is usable.</summary>
     public static async Task<IReadOnlyList<UrlVerdict>> ScanAsync(
         IReadOnlyList<PdfLink> links, CloudflareCredentials? creds,
-        HttpClient? http = null, TimeSpan? pollDelay = null, CancellationToken ct = default)
+        HttpClient? http = null, TimeSpan? pollDelay = null, CancellationToken ct = default,
+        int maxConcurrency = DefaultMaxConcurrency, int maxUrls = DefaultMaxUrls)
     {
         var delay = pollDelay ?? TimeSpan.FromSeconds(2);
-        var results = new List<UrlVerdict>();
         bool useCloudflare = creds is { IsUsable: true };
-        HttpClient? client = useCloudflare ? (http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(30) }) : null;
 
-        // De-duplicate identical URLs so we don't scan the same link many times.
-        var scanned = new Dictionary<string, bool?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var link in links)
+        // No Cloudflare: every link gets the local heuristic and we make no network calls at all.
+        if (!useCloudflare)
+            return links.Select(l => Merge(UrlClassifier.Classify(l), null)).ToList();
+
+        HttpClient? owned = http is null ? new HttpClient { Timeout = TimeSpan.FromSeconds(30) } : null;
+        HttpClient client = http ?? owned!;
+        try
         {
-            var heuristic = UrlClassifier.Classify(link);
-            bool? malicious = null;
-            if (useCloudflare)
+            // Distinct URLs in first-seen order, capped: a document with thousands of links must not
+            // turn into thousands of serialized scans. (Enumerable.Distinct preserves order.)
+            var uniqueUrls = links.Select(l => l.Url)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(Math.Max(0, maxUrls))
+                .ToList();
+
+            // Scan those URLs concurrently rather than one-after-another. Each scan is a submit plus
+            // up to ~24s of polling, so serial scanning made a link-heavy document take minutes and
+            // hold the host busy the whole time (#82). A semaphore bounds how many run at once so we
+            // neither starve the host nor hammer the Cloudflare API.
+            var verdicts = new System.Collections.Concurrent.ConcurrentDictionary<string, bool?>(
+                StringComparer.OrdinalIgnoreCase);
+            using var gate = new SemaphoreSlim(Math.Max(1, maxConcurrency));
+            var scans = uniqueUrls.Select(async url =>
             {
-                if (!scanned.TryGetValue(link.Url, out malicious))
-                {
-                    malicious = await TryVerdictAsync(client!, creds!, link.Url, delay, ct);
-                    scanned[link.Url] = malicious;
-                }
-            }
-            results.Add(Merge(heuristic, malicious));
+                await gate.WaitAsync(ct);
+                try { verdicts[url] = await TryVerdictAsync(client, creds!, url, delay, ct); }
+                finally { gate.Release(); }
+            });
+            await Task.WhenAll(scans);
+
+            // Map every link back to its URL's verdict; URLs past the cap have none and keep the
+            // heuristic. Merge is applied per link so repeated URLs all reflect the one scan.
+            return links.Select(l => Merge(UrlClassifier.Classify(l),
+                verdicts.TryGetValue(l.Url, out var malicious) ? malicious : null)).ToList();
         }
-        return results;
+        finally
+        {
+            owned?.Dispose();
+        }
     }
 
     /// <summary>

--- a/tests/PdfEditor.Core.Tests/UrlToolsTests.cs
+++ b/tests/PdfEditor.Core.Tests/UrlToolsTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Net.Http;
 using PdfEditor.Core;
 
 namespace PdfEditor.Tests;
@@ -238,4 +240,73 @@ public class CloudflareMergeTests
         Assert.Equal(2, verdicts.Count);
         Assert.Equal(1, handler.Submits); // the identical URL is only submitted once
     }
+
+    // A thread-safe scripted endpoint that records how many requests are in flight at once, so a
+    // test can prove the scans actually run concurrently rather than one after another.
+    private sealed class ConcurrentCloudflare : System.Net.Http.HttpMessageHandler
+    {
+        private int _inFlight;
+        private int _submits;
+        public int MaxConcurrent;
+        public int Submits => _submits;
+
+        protected override async Task<System.Net.Http.HttpResponseMessage> SendAsync(
+            System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken ct)
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                int now = System.Threading.Interlocked.Increment(ref _inFlight);
+                int seen;
+                do { seen = MaxConcurrent; } while (now > seen &&
+                    System.Threading.Interlocked.CompareExchange(ref MaxConcurrent, now, seen) != seen);
+                System.Threading.Interlocked.Increment(ref _submits);
+                try { await Task.Delay(30, ct); }
+                finally { System.Threading.Interlocked.Decrement(ref _inFlight); }
+                return Json(System.Net.HttpStatusCode.OK, """{"uuid":"abc-123"}""");
+            }
+            return Json(System.Net.HttpStatusCode.OK,
+                "{\"verdicts\":{\"overall\":{\"malicious\":false}}}");
+        }
+
+        private static System.Net.Http.HttpResponseMessage Json(System.Net.HttpStatusCode code, string body) =>
+            new(code) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
+    }
+
+    [Fact]
+    public async Task ScanAsync_ScansDistinctUrlsConcurrently_NotOneAtATime()
+    {
+        // Six distinct URLs. Serial scanning (the #82 bug) would only ever have one request in
+        // flight; with bounded concurrency more than one runs at once.
+        var links = Enumerable.Range(0, 6).Select(i => new PdfLink(1, $"https://example.com/{i}")).ToArray();
+        var handler = new ConcurrentCloudflare();
+        using var http = new HttpClient(handler);
+
+        var verdicts = await CloudflareUrlScanner.ScanAsync(links, Creds, http, TimeSpan.Zero,
+            maxConcurrency: 4);
+
+        Assert.Equal(6, verdicts.Count);
+        Assert.True(handler.MaxConcurrent > 1,
+            $"expected concurrent scans, but only {handler.MaxConcurrent} was ever in flight");
+        Assert.True(handler.MaxConcurrent <= 4, "concurrency exceeded the requested bound");
+    }
+
+    [Fact]
+    public async Task ScanAsync_CapsHowManyUrlsAreSubmitted()
+    {
+        // Five distinct URLs but a cap of two: only two reach Cloudflare, the rest keep the
+        // local heuristic so a link-bomb document cannot enqueue unbounded scans.
+        var links = Enumerable.Range(0, 5).Select(i => new PdfLink(1, $"https://google.com/{i}")).ToArray();
+        var handler = new ConcurrentCloudflare();
+        using var http = new HttpClient(handler);
+
+        var verdicts = await CloudflareUrlScanner.ScanAsync(links, Creds, http, TimeSpan.Zero,
+            maxConcurrency: 4, maxUrls: 2);
+
+        Assert.Equal(5, verdicts.Count);
+        Assert.Equal(2, handler.Submits);
+        // Exactly the two scanned links carry a Cloudflare source; the other three stay heuristic.
+        Assert.Equal(2, verdicts.Count(v => v.Source == "cloudflare"));
+        Assert.Equal(3, verdicts.Count(v => v.Source == "heuristic"));
+    }
+
 }


### PR DESCRIPTION
Fixes #82.

## The problem

`CloudflareUrlScanner.ScanAsync` rated links strictly **one at a time**, and each scan is a submit followed by up to a dozen 2s polls — ~24s worst case per unique URL. A link-heavy document therefore took **minutes**, all serial, holding the native host busy the whole time. And it was **unbounded**: a document with thousands of links enqueued thousands of scans.

## The fix

- **Concurrency.** Distinct URLs are scanned in parallel under a `SemaphoreSlim` (`DefaultMaxConcurrency = 6`), so wall-clock is bounded by the slowest few rather than the sum of all.
- **A cap.** At most `DefaultMaxUrls = 100` distinct URLs are submitted; URLs past the cap keep their local heuristic verdict, so a link-bomb document can't enqueue unbounded work.
- Both are parameters with sensible defaults. An internally-created `HttpClient` is now disposed (it never was).

## Behaviour preserved

Per link, unchanged: each still gets the heuristic merged with its one Cloudflare result, identical URLs are still scanned once, and no credentials still means no network calls. The four existing scanner tests pass unchanged.

## Tests (both watched failing)

- `ScanAsync_ScansDistinctUrlsConcurrently_NotOneAtATime` — a thread-safe fake handler records max in-flight requests; asserts >1. Forcing the semaphore back to 1 fails it with `only 1 was ever in flight`.
- `ScanAsync_CapsHowManyUrlsAreSubmitted` — a cap of 2 over 5 URLs submits exactly 2 and leaves the other 3 heuristic.

Core suite **413 passed**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_