### PR TITLE
Make the intermittent golden failure diagnosable (#88)

### DIFF
--- a/src/PdfEditor.Core/ContentStreamEditor.cs
+++ b/src/PdfEditor.Core/ContentStreamEditor.cs
@@ -262,13 +262,14 @@ internal sealed class ContentStreamEditor : PdfCanvasProcessor
                     return; // fully covered: drop the draw call entirely
                 var fill = _kinds == ContentKinds.TextAndPixelsBeneath
                     ? ScrubFill.SurroundingPaper : ScrubFill.Black;
-                if (ImageScrubber.TryScrubPixels(stream, bbox, _regions, fill))
+                if (ImageScrubber.TryScrubPixels(stream, bbox, _regions, out var scrubFailure, fill))
                 {
                     WriteOperands(operands);
                     return;
                 }
-                _warnings.Add($"Image '{name.GetValue()}' partially overlaps a redaction " +
-                              "region and could not be pixel-scrubbed; it was removed entirely.");
+                _warnings.Add($"Image '{name.GetValue()}' partially overlaps a redaction region " +
+                              $"and could not be pixel-scrubbed ({scrubFailure}); it was removed " +
+                              "entirely.");
                 return;
             }
             WriteOperands(operands);

--- a/src/PdfEditor.Core/ImageScrubber.cs
+++ b/src/PdfEditor.Core/ImageScrubber.cs
@@ -29,18 +29,26 @@ internal static class ImageScrubber
     /// <summary>
     /// Attempts to scrub the region overlap out of the image's pixel data.
     /// <paramref name="drawnBBox"/> is the user-space rectangle the image is drawn into.
-    /// Returns false when the image format could not be decoded, in which case the
-    /// caller must fall back to dropping the image.
+    /// Returns false when the image could not be scrubbed, in which case the caller must fall back
+    /// to dropping the image; <paramref name="failureReason"/> then says why, so the drop is a named
+    /// failure rather than a silent one (#88) — a decode failure in particular can be transient
+    /// (memory pressure), which reads very differently from an unsupported format.
     /// </summary>
     public static bool TryScrubPixels(PdfStream imageStream, Rectangle drawnBBox,
-        IList<Rectangle> regions, ScrubFill fill = ScrubFill.Black)
+        IList<Rectangle> regions, out string? failureReason, ScrubFill fill = ScrubFill.Black)
     {
+        failureReason = null;
         try
         {
             var xobject = new PdfImageXObject(imageStream);
             byte[] bytes = xobject.GetImageBytes(true);
             using var bitmap = SKBitmap.Decode(bytes);
-            if (bitmap == null) return false;
+            if (bitmap == null)
+            {
+                failureReason = "the image could not be decoded — an unsupported/corrupt format, "
+                    + "or possibly transient memory pressure";
+                return false;
+            }
 
             float sx = bitmap.Width / drawnBBox.GetWidth();
             float sy = bitmap.Height / drawnBBox.GetHeight();
@@ -74,12 +82,18 @@ internal static class ImageScrubber
             // No readable pixels means we cannot prove the scrubbed image is what gets written, so
             // report failure and let the caller drop the image outright. Failing closed is the only
             // safe direction here: this is redaction.
-            if (rgb == null) return false;
+            if (rgb == null)
+            {
+                failureReason = "the scrubbed pixels could not be read back "
+                    + "(possibly transient memory pressure)";
+                return false;
+            }
             ReplaceWithRgb(imageStream, bitmap.Width, bitmap.Height, rgb);
             return true;
         }
-        catch
+        catch (Exception e)
         {
+            failureReason = $"scrubbing threw {e.GetType().Name}: {e.Message}";
             return false;
         }
     }

--- a/tests/PdfEditor.Core.Tests/ContentStreamEditorCoverageTests.cs
+++ b/tests/PdfEditor.Core.Tests/ContentStreamEditorCoverageTests.cs
@@ -228,6 +228,14 @@ public class ContentStreamEditorCoverageTests
         var result = Redactor.Redact(pdf, new[] { new RectRegion(1, 100, 500, 100, 100) });
 
         Assert.Equal(0, TestPdfAssert.CountImages(result.Pdf));
-        Assert.Contains(result.Warnings, w => w.Contains("could not be pixel-scrubbed"));
+        // The drop must be a *named* failure, not a bare one: a scrub failure can be transient
+        // (memory pressure on decode/read-back), which reads very differently from an unsupported
+        // format, and #88 is about being able to tell them apart from the log. The warning must
+        // carry a concrete reason clause, not merely say the image was removed.
+        Assert.Contains(result.Warnings, w =>
+            w.Contains("could not be pixel-scrubbed (")
+            && (w.Contains("could not be decoded")
+                || w.Contains("could not be read")
+                || w.Contains("scrubbing threw")));
     }
 }

--- a/tests/PdfEditor.Core.Tests/Golden/GoldenFile.cs
+++ b/tests/PdfEditor.Core.Tests/Golden/GoldenFile.cs
@@ -87,11 +87,23 @@ internal static class GoldenFile
             shown++;
         }
 
-        return report
+        report
             .AppendLine()
             .Append("If this change is intended, re-run with ").Append(UpdateVariable)
-            .AppendLine("=1 to re-record, then review the diff before committing.")
-            .ToString();
+            .AppendLine("=1 to re-record, then review the diff before committing.");
+
+        // The whole actual projection, verbatim. The line diff above is enough for an intended,
+        // reproducible change; it is not enough for the intermittent, unreproducible sighting (#88),
+        // where the run that failed is the only evidence there will ever be. Dumping the full
+        // projection means that run's output survives in the CI log, so the next investigator can
+        // diff it offline against the recording — or re-record from it — instead of trying to force
+        // the flake to happen again.
+        report
+            .AppendLine()
+            .AppendLine("Full actual projection (for offline diff / re-recording):")
+            .AppendLine(Indent(actual));
+
+        return report.ToString();
     }
 
     private static string Indent(string text) =>

--- a/tests/PdfEditor.Core.Tests/Golden/GoldenSuiteSelfTests.cs
+++ b/tests/PdfEditor.Core.Tests/Golden/GoldenSuiteSelfTests.cs
@@ -90,6 +90,29 @@ public class GoldenSuiteSelfTests
     }
 
     /// <summary>
+    /// On a mismatch the failure message must carry the <em>whole</em> actual projection, not just
+    /// the differing lines. The line diff is enough for a reproducible change a developer can re-run;
+    /// it is not enough for the intermittent sighting (#88), where the failing CI run is the only
+    /// evidence that will ever exist. If the full projection is in the log, the next investigator can
+    /// diff it offline instead of trying to force the flake again.
+    /// </summary>
+    [Fact]
+    public void Mismatch_DumpsTheWholeActualProjection_ForOfflineDiff()
+    {
+        var doc = GoldenCorpus.Documents.Single(d => d.Name == "plain-multipage");
+        // A multi-line actual with a sentinel line that is NOT in the recording, so finding it in
+        // the message proves the full body was dumped rather than only the diffed lines.
+        const string sentinel = "sentinel-line-only-in-actual-not-in-recording";
+        string actual = "== source ==\nfirst\n" + sentinel + "\nlast\n";
+
+        string? failure = GoldenFile.Compare(doc.Name, actual, allowUpdate: false);
+
+        Assert.NotNull(failure);
+        Assert.Contains("Full actual projection", failure, StringComparison.Ordinal);
+        Assert.Contains(sentinel, failure, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// A transparency-specific negative case. Dropping the <c>/ExtGState</c> resource leaves a
     /// document that still opens, still validates, still has the same text and the same page
     /// geometry — and renders completely differently. Structural assertions miss it; the


### PR DESCRIPTION
Closes #88.

That issue tracks a Core golden test (`Corpus_MatchesRecordedGolden`) that has flaked twice, on unrelated branches, and reproduces on neither the branch nor `main`. Its own conclusion is to **make the next sighting diagnosable rather than try to force it now** — and it lists two concrete next steps. This PR does both.

## 1. Dump the whole actual projection on a golden mismatch

`GoldenFile` already prints a line-oriented diff. That's enough for a reproducible change a developer can re-run locally; it is *not* enough for an intermittent, CI-only sighting, where the failing run is the only evidence that will ever exist. The comparator now appends the **entire actual projection** (indented) after the diff, so that run's output survives in the CI log — the next investigator can diff it offline against the recording, or re-record from it, instead of trying to reproduce the flake.

## 2. Name *why* an image was dropped instead of dropping it silently

The issue's leading hypothesis is that under parallel-test memory pressure `SKBitmap.Decode` returns null, `ImageScrubber` returns a bare `false`, and the image is dropped — changing the projection with no trace of why. `TryScrubPixels` now reports the reason through a new out-parameter, and the redaction warning includes it:

- decode returned null → *"the image could not be decoded — an unsupported/corrupt format, or possibly transient memory pressure"*
- pixel read-back returned null → *"the scrubbed pixels could not be read back (possibly transient memory pressure)"*
- an exception → *"scrubbing threw `<Type>`: `<message>`"*

A decode/read failure (transient) now reads differently from an unsupported format — the swallowed-failure class #72 was about. The success path is byte-for-byte unchanged.

## Tests

- **`GoldenSuiteSelfTests.Mismatch_DumpsTheWholeActualProjection_ForOfflineDiff`** — asserts the failure message carries the full actual body (via a sentinel line and the new section header).
- **`ContentStreamEditorCoverageTests.CorruptImage_…`** — the existing corrupt-image drop test now also asserts the warning carries a concrete reason clause.

Both were verified load-bearing by reverting each change and confirming the matching test goes red. Full golden + redaction suites (94 tests) pass.

## Note

This is diagnosability, not a fix for a confirmed defect — the root cause is still unproven by design. It makes the next occurrence self-explaining so it can be fixed with evidence rather than guessed at.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_