### PR TITLE
Fix edited text drifting off the baseline (#96); cover the #90 selection route

### DIFF
--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -1383,8 +1383,11 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // The invisible selectable text layer builds over the rendered page.
     const span = page.locator('.page[data-page="1"] .text-layer span', { hasText: 'Selectable' });
     await expect(span).toHaveCount(1);
-    // Where the sentence's ink sits now, so the replacement can be held to the same baseline.
-    const before = await inkBounds(page, { x: 60, y: 680, width: 340, height: 45 });
+    // The original run's baseline (its extracted PDF-space box), so the replacement can be held to
+    // it. Comparing extracted run boxes rather than ink bounds keeps the baseline check independent
+    // of which glyphs happen to have descenders.
+    const original = (await textRuns(page)).find((r) => /Selectable/.test(r.text));
+    expect(original).toBeTruthy();
 
     // Selecting it yields the real text (so Ctrl/Cmd+C copies actual characters, not an image).
     await span.click({ clickCount: 3 });
@@ -1409,16 +1412,14 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await expect(page.locator('#status')).toContainText('Text replaced');
     await expectText(page).toContain('Replaced Via Menu');
     await expectText(page).not.toContain('Selectable');
-    // The original words are off the paper as well as out of the text, and the replacement is
-    // drawn where they were — on the same baseline and starting at the same left edge, not a
-    // line lower or a line higher.
-    const after = await inkBounds(page, { x: 60, y: 680, width: 340, height: 45 });
-    expect(after).not.toBeNull();
-    // Within a few points of the original baseline and left edge — the guard is "not a line off"
-    // (a line is 10-28pt here), so 3pt absorbs the sub-pixel metrics shift from the em-size fix
-    // (#84) without letting a real vertical jump through.
-    expect(Math.abs(after.y - before.y)).toBeLessThan(3);
-    expect(Math.abs(after.x - before.x)).toBeLessThan(3);
+    // The replacement is drawn where the original was — same baseline, same left edge, not a line
+    // lower or higher. Before #96 the edit laid the text out top-down in a box, so the layout
+    // engine's leading pushed the baseline off the original line; 2pt is well inside a line
+    // (10-28pt here) but tight enough to catch that drift.
+    const replaced = (await textRuns(page)).find((r) => /Replaced/.test(r.text));
+    expect(replaced).toBeTruthy();
+    expect(Math.abs(replaced.y - original.y)).toBeLessThan(2);
+    expect(Math.abs(replaced.x - original.x)).toBeLessThan(3);
     // The replacement is shorter than the original, so the paper past its right edge is clear.
     expect(await inkFraction(page, { x: 320, y: 694, width: 120, height: 24 })).toBe(0);
     await page.close();
@@ -1808,6 +1809,37 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // The rest of the page is untouched paper — the region was the run, not the page.
     expect(await bandStats(page, { x: 60, y: 400, width: 400, height: 100 }).then((s) => s.paper))
       .toBe(1);
+    await page.close();
+  });
+
+  test('text edit (#90): right-clicking a selection, Edit, then Apply changes the document', async () => {
+    // #90 as reported: the user *highlights* text, right-clicks, chooses Edit, edits, presses Apply
+    // — and nothing happens. The sibling "the right-click route applies" test drives the
+    // no-selection span route; this one drives the selection route the issue actually describes, all
+    // the way through Apply to a changed document.
+    const file = fixture('ctxseledit.pdf', [[
+      { text: 'Amount Due 500', x: 72, y: 700 },
+      { text: 'keep me', x: 72, y: 640 },
+    ]]);
+    const page = await openViewerWith(file);
+    const span = page.locator('.page[data-page="1"] .text-layer span', { hasText: 'Amount' });
+    await span.waitFor({ timeout: 15000 });
+    await span.click({ clickCount: 3 }); // highlight the run
+    const b = await span.boundingBox();
+    await page.mouse.click(b.x + b.width / 2, b.y + b.height / 2, { button: 'right' });
+
+    await page.locator('#context-menu').getByRole('button', { name: /Edit text/ }).click();
+    await expect(page.locator('#panel-edit')).toBeVisible();
+    await expect(page.locator('#edit-text')).toHaveValue(/Amount Due 500/);
+
+    await page.fill('#edit-text', 'Amount Due 750');
+    await page.click('#edit-apply');
+    await expect(page.locator('#status')).toContainText('Text replaced');
+
+    // The file changed, not just the panel — and the control line is untouched.
+    await expectText(page).toContain('Amount Due 750');
+    await expectText(page).not.toContain('500');
+    await expectText(page).toContain('keep me');
     await page.close();
   });
 

--- a/src/PdfEditor.Core/TextTools.cs
+++ b/src/PdfEditor.Core/TextTools.cs
@@ -59,8 +59,11 @@ public static class TextTools
 
         var removed = Redactor.RemoveContent(pdf, new[] { region }, password,
             RemovalKindFor(pdf, region, password));
+        // Baseline-anchored (wrap: false) so the replacement lands on the original text's baseline,
+        // in-line with the words around it, rather than being laid out top-down in a box and drifting
+        // below the line (#96). Move and find & replace already stamp this way.
         var stamped = StampText(removed.Pdf, region, newText, size, password,
-            fontName: stampFont, color: ParseColor(colorHex), confineToRegion: false);
+            wrap: false, fontName: stampFont, color: ParseColor(colorHex));
 
         var warnings = new List<string>(removed.Warnings);
         if (DescribeSubstitution(found.SourceFont, stampFont) is { } note) warnings.Add(note);
@@ -322,11 +325,27 @@ public static class TextTools
             }
             else
             {
-                // Single-line stamp on the original baseline (used by find & replace).
+                // Baseline-anchored stamp (find & replace, edit, move). The region's bottom is the
+                // descent line of the text that was there, so the baseline sits one descender-depth
+                // above it; drawing there keeps the new text in-line with the surrounding words
+                // instead of letting the layout engine's leading push it below the line (#96).
+                // Wrapping is deliberately not applied — a replaced run extends along its own line
+                // rather than reflowing onto the next one, which would collide with the line below.
                 float baseline = region.Y + fontSize * 0.21f; // approximate descender share
                 pdfCanvas.BeginText().SetFontAndSize(font, fontSize);
                 if (color != null) pdfCanvas.SetFillColor(color);
-                pdfCanvas.MoveText(region.X, baseline).ShowText(text).EndText();
+                pdfCanvas.MoveText(region.X, baseline);
+                // Honour explicit line breaks the caller typed, one baseline-spaced line each. The
+                // leading is only emitted when there is a second line to place, so the common
+                // single-line edit stays a plain Td/Tj with nothing extra in the stream.
+                var lines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+                pdfCanvas.ShowText(lines[0]);
+                if (lines.Length > 1)
+                {
+                    pdfCanvas.SetLeading(fontSize * 1.15f);
+                    for (int i = 1; i < lines.Length; i++) pdfCanvas.NewlineShowText(lines[i]);
+                }
+                pdfCanvas.EndText();
             }
         }
         return output.ToArray();

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/acroform-text-field.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/acroform-text-field.txt
@@ -38,7 +38,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: replaced copy
   typeset: Helvetica@12.0
-  ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 qx2
+  ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: needAppearances=none fields=1
   field: name=(golden.existing) type=Tx value=(recorded) hasAppearance=yes

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-constant-and-blend.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-constant-and-blend.txt
@@ -42,7 +42,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@12.0
-  ops: BTx2 ETx2 Qx4 Tdx2 Tfx2 Tjx2 fx2 gx1 gsx2 qx4 rex2 rgx2
+  ops: BTx2 ETx2 Qx3 Tdx2 Tfx2 Tjx2 fx2 gx1 gsx2 qx3 rex2 rgx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   gs GSa: BM=/Multiply CA=0.6 ca=0.4

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-image-softmask.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-image-softmask.txt
@@ -40,7 +40,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@12.0
-  ops: BTx2 Dox1 ETx2 Qx3 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx3
+  ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Im1: subtype=Image size=8x8 cs=/DeviceRGB bpc=8 filter=/FlateDecode smask=yes mask=no

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-luminosity-softmask.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-luminosity-softmask.txt
@@ -40,7 +40,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@12.0
-  ops: BTx2 ETx2 Qx3 Tdx2 Tfx2 Tjx2 fx1 gx1 gsx1 qx3 rex1 rgx1
+  ops: BTx2 ETx2 Qx2 Tdx2 Tfx2 Tjx2 fx1 gx1 gsx1 qx2 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   gs GSm: SMask=Luminosity(G=form Transparency(cs=/DeviceGray I=true K=none) BC=[0] TR=no)

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-nested-groups.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/alpha-nested-groups.txt
@@ -75,7 +75,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@9.0
-  ops: BTx2 Dox1 ETx2 Qx3 Tdx2 Tfx2 Tjx2 cmx1 gx1 gsx1 qx3
+  ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 gx1 gsx1 qx2
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   gs GS1: BM=/Normal ca=0.8

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-broken-embedded-program.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-broken-embedded-program.txt
@@ -40,7 +40,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@20.0
-  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  ops: BTx3 ETx3 Qx1 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   font T1: subtype=TrueType base=BCDEEE+Calibri encoding=WinAnsiEncoding toUnicode=no widths=23 embedded=yes

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-differences-encoding.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-differences-encoding.txt
@@ -40,7 +40,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@28.0
-  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  ops: BTx3 ETx3 Qx1 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx1
   font D1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding+Differences[4] toUnicode=no widths=3
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-type0-identity-h.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-type0-identity-h.txt
@@ -40,7 +40,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@24.0
-  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  ops: BTx3 ETx3 Qx1 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx1
   font C0: subtype=Type0 base=AAAAAA+DejaVuSans encoding=Identity-H toUnicode=yes widths=0 descendant=[subtype=CIDFontType2 base=AAAAAA+DejaVuSans toUnicode=no widths=0 embedded=no]
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/font-type3-glyph-procedures.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/font-type3-glyph-procedures.txt
@@ -40,7 +40,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: golden corpus replaced copy
   typeset: Helvetica@10.0 Helvetica@36.0
-  ops: BTx3 ETx3 Qx2 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx2
+  ops: BTx3 ETx3 Qx1 TJx1 Tdx3 Tfx3 Tjx2 gx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   font T3: subtype=Type3 base=none encoding=none+Differences[4] toUnicode=no widths=2 charProcs=square/triangle fontMatrix=[0.001 0 0 0.001 0 0]

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/hidden-data.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/hidden-data.txt
@@ -38,7 +38,7 @@ catalog: has-OpenAction=no has-Names=yes has-Outlines=yes has-OCProperties=yes h
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=1 group=none
   text: Visible content replaced copy
   typeset: Helvetica@12.0
-  ops: BTx2 ETx2 Qx2 Tdx2 Tfx2 Tjx2 qx2
+  ops: BTx2 ETx2 Qx1 Tdx2 Tfx2 Tjx2 qx1
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-itext-3.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-itext-3.txt
@@ -67,7 +67,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 595 842] crop=none rotate=0 annots=0 group=none
   text: Document with nested forms replaced copy
   typeset: Helvetica@10.0 Helvetica@12.0
-  ops: BTx2 Dox1 ETx2 Qx3 Tdx2 Tfx2 Tjx2 cmx1 qx3
+  ops: BTx2 Dox1 ETx2 Qx2 Tdx2 Tfx2 Tjx2 cmx1 qx2
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Fm1: subtype=Form bbox=[0 0 200 120] matrix=none group=none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-raw-4.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/nested-forms-raw-4.txt
@@ -50,7 +50,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: replaced copy
   typeset: Helvetica@12.0
-  ops: BTx1 Dox1 ETx1 Qx3 Tdx1 Tfx1 Tjx1 qx3
+  ops: BTx1 Dox1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 qx2
   font F1: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
   xobject Nested: subtype=Form bbox=[0 0 100 100] matrix=none group=none
     ops: Dox1 Qx1 qx1

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/plain-multipage.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/plain-multipage.txt
@@ -58,7 +58,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none
   text: replaced copy
   typeset: Helvetica@18.0
-  ops: BTx2 ETx2 Qx2 TJx1 Tdx2 Tfx2 Tjx1 fx1 qx2 rex1 rgx1
+  ops: BTx2 ETx2 Qx1 TJx1 Tdx2 Tfx2 Tjx1 fx1 qx1 rex1 rgx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 page 2: media=[0 0 400 600] crop=none rotate=0 annots=0 group=none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/stream-undecodable-flate.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/stream-undecodable-flate.txt
@@ -38,7 +38,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: replaced copy
   typeset: Helvetica@12.0
-  ops: BTx1 ETx1 Qx2 Tdx1 Tfx1 Tjx1 qx2
+  ops: BTx1 ETx1 Qx1 Tdx1 Tfx1 Tjx1 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none

--- a/tests/PdfEditor.Core.Tests/Golden/goldens/stream-wrong-length.txt
+++ b/tests/PdfEditor.Core.Tests/Golden/goldens/stream-wrong-length.txt
@@ -38,7 +38,7 @@ catalog: has-OpenAction=no has-Names=no has-Outlines=no has-OCProperties=no has-
 page 1: media=[0 0 200 200] crop=none rotate=0 annots=0 group=none
   text: replaced copy Hello
   typeset: Helvetica@12.0
-  ops: BTx2 ETx2 Qx2 Tdx2 Tfx2 Tjx2 qx2
+  ops: BTx2 ETx2 Qx1 Tdx2 Tfx2 Tjx2 qx1
   font F1: subtype=Type1 base=Helvetica toUnicode=no widths=0
   font F2: subtype=Type1 base=Helvetica encoding=WinAnsiEncoding toUnicode=no widths=0
 acroform: none

--- a/tests/PdfEditor.Core.Tests/TextFontFidelityTests.cs
+++ b/tests/PdfEditor.Core.Tests/TextFontFidelityTests.cs
@@ -94,6 +94,33 @@ public class TextFontFidelityTests
         }
     }
 
+    /// <summary>
+    /// #96: an edited run must land on the <em>same baseline</em> as the text it replaced, in-line
+    /// with the words around it. The edit path used to lay the replacement out top-down in a box, so
+    /// the layout engine's leading pushed the first line below the original line. The region here is
+    /// the tight ascent-to-descent box the viewer actually selects, not a loose band.
+    /// </summary>
+    [Fact]
+    public void ReplaceTextInRegion_KeepsTheReplacementOnTheOriginalBaseline()
+    {
+        const float size = 24f;
+        // WithTextInFont draws its baseline at y=700.
+        byte[] pdf = TestPdfs.WithTextInFont(iText.IO.Font.Constants.StandardFonts.HELVETICA, "ORIGINAL", size);
+        var span = Assert.Single(TextTools.GetTextSpans(pdf, 1));
+        var region = new RectRegion(1, span.X, span.Y, span.Width, span.Height);
+
+        var result = TextTools.ReplaceTextInRegion(pdf, region, "REPLACED");
+
+        var after = Assert.Single(TextTools.GetTextSpans(result.Pdf, 1));
+        Assert.Equal("REPLACED", after.Text);
+        // Same font and size, so TextSpan.Y (the descent line) is the baseline shifted by a fixed
+        // descent; equal descent lines therefore mean equal baselines. Before the fix the run landed
+        // roughly 0.3*em (~7pt at 24pt) below the line.
+        Assert.True(Math.Abs(after.Y - span.Y) <= 1.5f, string.Create(CultureInfo.InvariantCulture,
+            $"Edited text landed at descent-line {after.Y:F2}, {Math.Abs(after.Y - span.Y):F2}pt off "
+            + $"the original {span.Y:F2}; it should sit in-line with the surrounding text."));
+    }
+
     /// <summary>Moving a run must not resize it either — it re-stamps at the detected size.</summary>
     [Fact]
     public void MoveText_PreservesTheTypeSize()


### PR DESCRIPTION
Fixes #96. Adds the missing regression coverage that lets #90 be closed.

## #96 — edited text not in-line with the existing text

Editing existing text stamped the replacement through iText's `Canvas`/`Paragraph` layout (top-aligned, with multiplied leading), so the first baseline was placed by the layout engine's leading model rather than on the original text's baseline. The replacement landed below (or above) the line around it — the misalignment in the issue screenshot.

Move and find & replace already avoid this by stamping on an explicit baseline. This routes `ReplaceTextInRegion` through that same path, and teaches it to honour explicit line breaks so multi-line edits still work. A single-line edit now emits a plain `Td`/`Tj` with nothing extra; the leading is only written when there's a second line to place.

**Golden impact (intended):** `replace-region-text` is a golden operation, so this changes every corpus recording — the Canvas wrapper's extra `q`/`Q` save-restore pair is gone (`Qx2→Qx1`, `qx2→qx1`). The stamped text and type size are unchanged. Goldens re-recorded via `PDFEDITOR_UPDATE_GOLDENS=1` and reviewed; the diff is exactly that one op-histogram line per file.

## #90 — right-click a selection → Edit → Apply

The underlying fix (`beginTextEdit` owning the pending region) is already on `main`, with an end-to-end guard for the *no-selection span* route. The issue describes the *selection* route ("highlight text, right-click, Edit, Apply"), which had no apply-test. This adds one that drives it all the way to a changed document, so #90 can be closed with confidence once released.

I also hardened the existing right-click-edit e2e test: it compared **ink bounds**, which a descender in the replacement shifts independently of the baseline — it passed before only because the old layout placed the baseline too high and the descender happened to cancel it. It now compares the extracted **run baselines**, measuring alignment directly (and catches the old ~3pt drift).

## Tests

- New Core test `ReplaceTextInRegion_KeepsTheReplacementOnTheOriginalBaseline`.
- New e2e test for the #90 selection route.
- Both verified load-bearing by reverting the fix and watching them go red.
- Full Core suite (414) green; edit-related e2e set green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_