### PR TITLE
Chrome Web Store prep: ID pinning, per-OS host installers, privacy policy + playbook

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -36,13 +36,12 @@ on:
   push:
     branches: ["main"]
 
-permissions:
-  contents: write
-
 jobs:
   # Compute the RC version once so every downstream build stamps the same number.
   version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # only reads git tag history
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       final_tag: ${{ steps.version.outputs.final_tag }}
@@ -82,6 +81,8 @@ jobs:
   build-msi:
     needs: version
     runs-on: windows-latest
+    permissions:
+      contents: read # checks out, builds, and uploads an artifact only
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
@@ -127,6 +128,8 @@ jobs:
   release-candidate:
     needs: [version, build-msi]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes the RC tag and creates/publishes the prerelease
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -3,7 +3,8 @@ name: Release Candidate
 # Every merge to main creates a release candidate: a tag "vX.Y.Z-<build>" (patch-bumped
 # from the latest *final* release tag, ignoring other RC tags), a packaged extension zip,
 # self-contained native-host builds for each desktop platform (Windows, Linux, macOS
-# Intel + Apple Silicon), and a GitHub prerelease with all of those attached as assets.
+# Intel + Apple Silicon), OS-native host installers (a Linux .deb and a Windows .msi),
+# and a GitHub prerelease with all of those attached as assets.
 #
 # This workflow builds, tests, packages, and publishes the prerelease itself rather than
 # handing the packaging off to release-extension.yml -- and it has to. GitHub deliberately
@@ -12,6 +13,15 @@ name: Release Candidate
 # here, let release-extension.yml react and attach the zip" design silently never packages
 # anything. The shared packaging logic still lives in one place -- scripts/package-extension.sh
 # -- which both this workflow and release-extension.yml invoke.
+#
+# The version number is computed once in the `version` job and consumed by the two build
+# jobs so the .deb, .msi, extension zip, and bundle zips all carry the same RC version:
+#   version        (ubuntu)         computes tag / final_tag / manifest_version
+#   build-msi      (windows-latest) stamps the manifest, builds the .msi (WiX only runs on
+#                                   Windows), and uploads it as an artifact
+#   release-candidate (ubuntu)      builds/tests, packages the extension + per-platform
+#                                   bundles + the .deb, pulls in the .msi artifact, then
+#                                   creates and publishes the prerelease with everything attached
 #
 # Promoting an RC to a real release is a manual step: create a new GitHub Release targeting
 # the RC's commit, but type a clean tag ("vX.Y.Z", no "-<build>" suffix) and leave "Set as a
@@ -30,27 +40,17 @@ permissions:
   contents: write
 
 jobs:
-  release-candidate:
+  # Compute the RC version once so every downstream build stamps the same number.
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      final_tag: ${{ steps.version.outputs.final_tag }}
+      manifest_version: ${{ steps.version.outputs.manifest_version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # full tag history, needed to find the previous final release
-
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-        with:
-          dotnet-version: "8.0.x"
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
-        with:
-          python-version: "3.x"
-
-      - name: Build
-        run: dotnet build --configuration Release
-      - name: Test
-        # Excludes the timing-based performance guards: this solution-wide run executes the suites
-        # in parallel on a shared runner, so their budgets would measure contention and fail at
-        # random. Performance is gated by the dedicated `perf` job in ci.yml instead.
-        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Performance"
 
       - name: Compute the release candidate tag
         id: version
@@ -76,9 +76,80 @@ jobs:
           echo "final_tag=v${next_version}" >> "$GITHUB_OUTPUT"
           echo "manifest_version=$manifest_version" >> "$GITHUB_OUTPUT"
 
+  # Build the Windows .msi on a Windows runner (WiX can only build an MSI on Windows) and
+  # hand it back to the release job as an artifact. The manifest is stamped first so the MSI's
+  # ProductVersion matches the RC version the other packages carry.
+  build-msi:
+    needs: version
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "8.0.x"
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: "3.x"
+
       - name: Stamp manifest.json with the release-candidate version
         run: |
-          python3 - "${{ steps.version.outputs.manifest_version }}" <<'EOF'
+          python3 - "${{ needs.version.outputs.manifest_version }}" <<'EOF'
+          import json
+          import sys
+
+          path = "extension/manifest.json"
+          with open(path) as f:
+              manifest = json.load(f)
+          manifest["version"] = sys.argv[1]
+          with open(path, "w") as f:
+              json.dump(manifest, f, indent=2)
+              f.write("\n")
+          EOF
+        shell: bash
+
+      - name: Install the WiX toolset
+        run: dotnet tool install --global wix
+
+      - name: Build the Windows MSI
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: ./scripts/package-msi.ps1 -OutputDir dist
+        shell: pwsh
+
+      - name: Upload the MSI artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pdf-editor-host-msi
+          path: dist/*.msi
+          if-no-files-found: error
+
+  release-candidate:
+    needs: [version, build-msi]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0 # full tag history, needed to create and push the RC tag
+
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "8.0.x"
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        run: dotnet build --configuration Release
+      - name: Test
+        # Excludes the timing-based performance guards: this solution-wide run executes the suites
+        # in parallel on a shared runner, so their budgets would measure contention and fail at
+        # random. Performance is gated by the dedicated `perf` job in ci.yml instead.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Performance"
+
+      - name: Stamp manifest.json with the release-candidate version
+        run: |
+          python3 - "${{ needs.version.outputs.manifest_version }}" <<'EOF'
           import json
           import sys
 
@@ -101,10 +172,21 @@ jobs:
             ./scripts/package-bundle.sh "$rid" dist
           done
 
+      - name: Package the Linux host installer (.deb)
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: ./scripts/package-deb.sh dist
+
+      - name: Download the Windows MSI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: pdf-editor-host-msi
+          path: dist
+
       - name: Create and push the release candidate tag
         run: |
-          git tag "${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
+          git tag "${{ needs.version.outputs.tag }}"
+          git push origin "${{ needs.version.outputs.tag }}"
 
       # Create the release as a DRAFT with the packages attached, then publish it in the next step.
       # This repository has immutable releases enabled: once a release is published its assets are
@@ -115,13 +197,15 @@ jobs:
       - name: Create the release candidate (draft) and attach the packages
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
+          tag_name: ${{ needs.version.outputs.tag }}
           draft: true
           prerelease: true
           generate_release_notes: true
           files: |
             dist/pdf-editor-extension-*.zip
             dist/pdf-editor-bundle-*.zip
+            dist/pdf-editor-host_*.deb
+            dist/*.msi
           body: |
             Release candidate built from ${{ github.sha }}.
 
@@ -130,12 +214,17 @@ jobs:
               (Windows, Linux, macOS Intel + Apple Silicon) containing the browser extension,
               the matching self-contained native host, and the install script. No .NET SDK is
               needed to use it — see `INSTALL.md` inside.
+            - `pdf-editor-host_<version>_amd64.deb` — a Debian/Ubuntu package that installs the
+              native host under `/opt/pdf-editor-host` and registers it with Chrome/Chromium
+              system-wide (`sudo apt install ./pdf-editor-host_<version>_amd64.deb`).
+            - `pdf-editor-host-<version>-x64.msi` — a Windows installer that installs the native
+              host under Program Files and registers it for Chrome/Chromium/Edge/Brave.
             - `pdf-editor-extension-v<version>.zip` — the extension on its own (Chrome Web
               Store-ready), for anyone who only wants that.
 
             This is **not** published to the Chrome Web Store. To promote it, create a new
             Release targeting this commit with the clean tag
-            `${{ steps.version.outputs.final_tag }}` and leave "Set as a pre-release" unchecked.
+            `${{ needs.version.outputs.final_tag }}` and leave "Set as a pre-release" unchecked.
 
       # Flip the draft to a published prerelease. It already carries its assets, so this succeeds
       # under immutable releases. A GITHUB_TOKEN-published release does not fire "release: published"
@@ -143,4 +232,4 @@ jobs:
       - name: Publish the release candidate
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "${{ steps.version.outputs.tag }}" --draft=false --prerelease
+        run: gh release edit "${{ needs.version.outputs.tag }}" --draft=false --prerelease

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -172,10 +172,20 @@ jobs:
             ./scripts/package-bundle.sh "$rid" dist
           done
 
-      - name: Package the Linux host installer (.deb)
+      - name: Install Linux packaging tooling (rpm + Arch package format)
+        # rpmbuild builds the .rpm; bsdtar (libarchive-tools) + zstd assemble the Arch
+        # .pkg.tar.zst by hand -- all run fine on Ubuntu, so no RedHat/Arch host is needed.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rpm libarchive-tools zstd
+
+      - name: Package the Linux host installers (.deb / .rpm / Arch .pkg.tar.zst)
+        # Debian/Ubuntu (.deb), RedHat family — Fedora/RHEL/openSUSE (.rpm), and Arch
+        # (.pkg.tar.zst). Same self-contained host + pinned native-messaging manifest in each.
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
-        run: ./scripts/package-deb.sh dist
+        run: |
+          ./scripts/package-deb.sh dist
+          ./scripts/package-rpm.sh dist
+          ./scripts/package-arch.sh dist
 
       - name: Download the Windows MSI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -205,6 +215,8 @@ jobs:
             dist/pdf-editor-extension-*.zip
             dist/pdf-editor-bundle-*.zip
             dist/pdf-editor-host_*.deb
+            dist/pdf-editor-host-*.rpm
+            dist/pdf-editor-host-*.pkg.tar.zst
             dist/*.msi
           body: |
             Release candidate built from ${{ github.sha }}.
@@ -217,6 +229,10 @@ jobs:
             - `pdf-editor-host_<version>_amd64.deb` — a Debian/Ubuntu package that installs the
               native host under `/opt/pdf-editor-host` and registers it with Chrome/Chromium
               system-wide (`sudo apt install ./pdf-editor-host_<version>_amd64.deb`).
+            - `pdf-editor-host-<version>-1.x86_64.rpm` — the same for the RedHat family
+              (Fedora/RHEL/CentOS/openSUSE): `sudo dnf install ./pdf-editor-host-<version>-1.x86_64.rpm`.
+            - `pdf-editor-host-<version>-1-x86_64.pkg.tar.zst` — the same for Arch Linux:
+              `sudo pacman -U ./pdf-editor-host-<version>-1-x86_64.pkg.tar.zst`.
             - `pdf-editor-host-<version>-x64.msi` — a Windows installer that installs the native
               host under Program Files and registers it for Chrome/Chromium/Edge/Brave.
             - `pdf-editor-extension-v<version>.zip` — the extension on its own (Chrome Web

--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -1,0 +1,109 @@
+# Publishing to the Chrome Web Store
+
+This project already automates the upload: `.github/workflows/release-extension.yml` packages
+`extension/` into a store-ready zip and, on a published (non-prerelease) GitHub Release, runs
+`chrome-webstore-upload-cli` to upload **and publish**. What that automation still needs is a
+registered extension, four API secrets, and a completed store listing. This document is the
+checklist for all of that.
+
+---
+
+## 0. Before you start — things to decide/fix
+
+- [ ] **Name.** `"PDF Editor"` in `extension/manifest.json` is very generic; the Web Store often
+      rejects generic/again-existing names. Pick a distinctive name (e.g. a brand word +
+      "PDF Editor"). Update `manifest.json` `name` and the store listing to match.
+- [ ] **Privacy policy hosted.** Host `docs/PRIVACY.md` at a public URL (GitHub Pages works) and
+      have that URL ready — it is **required** for this listing (broad host access).
+- [ ] **Native host reality.** This extension needs a separately-installed native messaging host
+      to do the actual PDF work. The host is **not** distributed through the Web Store; the listing
+      and the review notes must explain how users install it (link to the install scripts / bundle).
+
+## 1. One-time account + registration
+
+1. Create/enter a **Chrome Web Store developer account** (one-time US$5 fee) at
+   <https://chrome.google.com/webstore/devconsole>.
+2. Upload the packaged zip once (from a build artifact or `./scripts/package-extension.sh`) to
+   **register the item** and obtain its **Extension ID**. (You can save it as a draft.)
+
+## 2. API credentials for automated publishing
+
+The workflow needs four repo secrets. Get them via the Chrome Web Store API setup
+(<https://developer.chrome.com/docs/webstore/using-api>):
+
+1. In **Google Cloud Console**: create a project, enable the **Chrome Web Store API**, and create
+   an **OAuth client ID** of type *Desktop app* → gives `CLIENT_ID` and `CLIENT_SECRET`.
+2. Run the one-time OAuth consent flow to get a **`REFRESH_TOKEN`** for that client.
+3. Add these as GitHub **repository secrets** (they gate the `publish-to-chrome-web-store` job):
+   - `CHROME_EXTENSION_ID`
+   - `CHROME_CLIENT_ID`
+   - `CHROME_CLIENT_SECRET`
+   - `CHROME_REFRESH_TOKEN`
+
+   > If any secret is missing, the job skips gracefully and leaves the packaged zip as a build
+   > artifact for manual upload (see the workflow's "Check … credentials are configured" step).
+
+## 3. Store listing content
+
+Paste these into the Developer Dashboard listing.
+
+**Summary (≤132 chars):**
+> Edit, redact, merge, sign and password-protect PDFs in your browser. Local processing via a
+> native host — your files never leave your device.
+
+**Description:** adapt the feature list from the README. Lead with the single purpose (a PDF
+editor), then the highlights (edit text, true redaction with a compliance report, watermark,
+Bates numbering, forms, OCR, signing, compare). **State clearly** that a free native host must be
+installed and link to the install instructions.
+
+**Category:** Productivity. **Language(s):** as applicable.
+
+**Graphics required by the store:**
+- [ ] Store icon 128×128 (already in `extension/icons/icon128.png`).
+- [ ] At least one **screenshot 1280×800** (or 640×400). The generated shots in
+      `docs/screenshots/` are a starting point but are captured at a different size — recapture at
+      1280×800 (adjust the viewport in `e2e/scripts/doc-shots.js`) or crop/pad to the required size.
+- [ ] Optional: small promo tile 440×280.
+
+**Single purpose statement:**
+> A PDF editor: it lets the user view and edit PDF documents (text, redaction, forms, pages,
+> signatures) via a local native host.
+
+## 4. Permission justifications (the review will ask for each)
+
+| Permission | Why it's needed |
+| --- | --- |
+| `nativeMessaging` | All PDF processing runs in a local native host; this is how the extension talks to it. |
+| `downloads` | Save edited PDFs and the redaction/compliance reports to the user's computer. |
+| `storage` | Persist user preferences (activity-console state, optional Cloudflare credentials) locally. |
+| `contextMenus` | Right-click actions (Edit, Redact, Highlight, etc.) on selected text and pages. |
+| `webNavigation` / `tabs` | Detect when the user navigates to a PDF so the editor can offer to open it, and open the editor in a tab. |
+| `host_permissions: <all_urls>` | PDFs can live on **any** site; the content script must run everywhere to detect them and show the "Edit in PDF Editor" control. It reads only enough to recognise a PDF; it does not collect page content. |
+
+> **Minimise if you can.** `<all_urls>` + `tabs` + `webNavigation` draw the most scrutiny. If the
+> "detect a PDF on any page" feature can tolerate `activeTab`/narrower matches, consider it — but
+> the current auto-detect-anywhere behaviour does need broad access, so justify it as above.
+
+## 5. Data-use disclosures (Dashboard "Privacy practices" tab)
+
+- **Personal/most data types:** *not collected.*
+- Certify: not sold, not used for unrelated purposes, not used for creditworthiness/lending.
+- If you ship the **optional Cloudflare link-scanning** enabled-by-config, disclose that a user who
+  enters their own Cloudflare credentials sends document link URLs to Cloudflare (see `PRIVACY.md`).
+- Provide the hosted **privacy policy URL**.
+
+## 6. Publish
+
+Two paths:
+
+- **Automated:** publish a **non-prerelease GitHub Release** whose tag sets the version (e.g.
+  `v2.0.0`). The workflow packages, uploads and publishes to the store. (Release-candidate tags are
+  prereleases and stop before the store step.)
+- **Manual:** download the `pdf-editor-extension-v<version>.zip` build artifact (or run
+  `./scripts/package-extension.sh`) and upload it in the Dashboard, then click Publish.
+
+## 7. After first submission
+
+- Review can take days; native-messaging + broad host access may prompt reviewer questions —
+  answer with the justifications above and the native-host explanation.
+- Bump `manifest.json` `version` for every subsequent submission (the release tag stamps it in CI).

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,62 @@
+# Privacy Policy — PDF Editor
+
+_Last updated: 2026-08-07_
+
+> Fill in the **Developer** and **Contact** placeholders below, host this page at a public
+> URL (e.g. GitHub Pages), and enter that URL in the Chrome Web Store listing. A privacy
+> policy URL is **required** for this extension because it requests broad host access.
+
+**Developer:** `<your name / organisation>`
+**Contact:** `<your support email>`
+
+## The short version
+
+PDF Editor edits your PDFs **on your own computer**. The document content is processed by a
+**native host** that runs locally on your machine — it is never uploaded to us or to any server
+we control. We do **not** operate any backend, do **not** run analytics or telemetry, and do
+**not** create accounts or collect personal information.
+
+## What the extension accesses, and why
+
+- **Your PDFs and images.** Files you open, edit, redact, sign, merge, etc. are handled locally
+  by the native host installed on your device. Their content is not transmitted to the developer.
+- **Pages you navigate to (host access).** The extension detects PDFs in the browser so it can
+  offer to open them in the editor. It reads only enough of the page to recognise a PDF and to
+  place its "Edit in PDF Editor" control; it does not read or transmit page content otherwise.
+- **Downloads.** Used to save your edited PDFs and reports to your computer, at your request.
+- **Local settings storage.** Preferences (such as the activity-console state and any Cloudflare
+  credentials you choose to enter) are stored in your browser's local extension storage on your
+  device. They are not sent to the developer.
+
+## Network activity
+
+- **Opening a PDF by URL.** When you open a PDF that lives at a web address, the extension
+  fetches that file from that address (the same request your browser would make) so it can be
+  edited. This goes to the site hosting the PDF, not to the developer.
+- **Optional link-safety scanning (off unless you enable it).** If — and only if — you enter your
+  **own** Cloudflare URL Scanner credentials in the extension's options, the extension will send
+  the **link URLs found inside a document** to Cloudflare's URL Scanner API to classify them as
+  safe/suspicious. This is entirely opt-in; without your credentials, links are assessed locally
+  with a heuristic and nothing leaves your device. Data you send this way is governed by
+  Cloudflare's own privacy terms.
+
+Apart from the two cases above, the extension does not send your data anywhere.
+
+## Data we collect
+
+**None.** We do not collect, store, sell, or share personal data. There is no server component
+operated by the developer.
+
+## Children's privacy
+
+The extension is a document tool and is not directed at children; it collects no personal data
+from anyone.
+
+## Changes
+
+If this policy changes, the "Last updated" date above will change and the new version will be
+published at the same URL.
+
+## Contact
+
+Questions about this policy: `<your support email>`.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 3,
   "name": "PDF Editor",
   "version": "2.0.0",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK1fIDsukhIoTqFOKiZr6Beg2PtYsnlFkqcxMd31yjMkE7KIwFj8/tc2HoBUICzCbE4YI53TTyq//Fx1beLafT0oRL3LJSN7aMkdutz4mnkOCxVVrP8Og2tZJgp9uLH1OADxzOzhun/5Vj1PvTmDwKIwTjJ6qSN93xOpgzSS5yqiWJbpHthYpsxay5kSiOy4C6qxPKYp/u0s0pVhTjuUUjcgmrAWp/xo5Eov6vLsaonfVJVgcApdaUrBXQ3+uUnQrxR9AdVxcCZ7FL0Am9J/iJ0poha2mss2tarpbn+jZ3GQWwE52a2pNg6MjYElXczApal5b6IL/pqaICG+GQP5lQIDAQAB",
   "description": "Edit text, redact, merge, sign, and password-protect PDFs directly in your browser. Powered by a local native host.",
   "minimum_chrome_version": "116",
   "permissions": [
@@ -12,7 +13,9 @@
     "contextMenus",
     "tabs"
   ],
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "background": {
     "service_worker": "src/background.js",
     "type": "module"
@@ -32,8 +35,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["src/content.js"],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "src/content.js"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/installer/windows/PdfEditorHost.wxs
+++ b/installer/windows/PdfEditorHost.wxs
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  WiX v4 source for the PDF Editor native-messaging host MSI (Windows).
+
+  Built by scripts/package-msi.ps1 with the WiX toolset (`wix build`) on a Windows runner — it is
+  NOT built in the Linux dev/CI box. It installs the self-contained host under Program Files, ships
+  the native-messaging manifest next to the exe (its "path" is relative to the manifest, which
+  Chrome allows on Windows), and registers the host for the common Chromium-based browsers via
+  HKLM registry values pointing at that manifest. Uninstall removes all of it.
+
+  Build-time variables (passed with -d):
+    Version       e.g. 2.0.0        (MSI ProductVersion)
+    HostDir       published win-x64 self-contained host folder (harvested)
+    ManifestJson  path to the rendered com.pdfeditor.host.json (allowed_origins pinned)
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="PDF Editor Native Host"
+           Manufacturer="PDF Editor"
+           Version="$(var.Version)"
+           UpgradeCode="60F946AD-ED00-472A-B522-5E0EA8E02B9B"
+           Scope="perMachine">
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of the PDF Editor native host is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="PDF Editor Host" />
+    </StandardDirectory>
+
+    <!-- All published host files (runtime + native libs), auto-harvested from the publish folder. -->
+    <ComponentGroup Id="HostFiles" Directory="INSTALLFOLDER">
+      <Files Include="$(var.HostDir)\**" />
+    </ComponentGroup>
+
+    <!-- The native-messaging manifest + the registry pointers that register it with each browser. -->
+    <Component Id="NativeMessagingRegistration" Directory="INSTALLFOLDER" Guid="*">
+      <File Id="HostManifestJson" Source="$(var.ManifestJson)" Name="com.pdfeditor.host.json" />
+      <RegistryValue Root="HKLM" Key="SOFTWARE\Google\Chrome\NativeMessagingHosts\com.pdfeditor.host"
+                     Type="string" Value="[INSTALLFOLDER]com.pdfeditor.host.json" KeyPath="yes" />
+      <RegistryValue Root="HKLM" Key="SOFTWARE\Chromium\NativeMessagingHosts\com.pdfeditor.host"
+                     Type="string" Value="[INSTALLFOLDER]com.pdfeditor.host.json" />
+      <RegistryValue Root="HKLM" Key="SOFTWARE\Microsoft\Edge\NativeMessagingHosts\com.pdfeditor.host"
+                     Type="string" Value="[INSTALLFOLDER]com.pdfeditor.host.json" />
+      <RegistryValue Root="HKLM" Key="SOFTWARE\BraveSoftware\Brave-Browser\NativeMessagingHosts\com.pdfeditor.host"
+                     Type="string" Value="[INSTALLFOLDER]com.pdfeditor.host.json" />
+    </Component>
+
+    <Feature Id="Main" Title="PDF Editor Native Host" Level="1">
+      <ComponentGroupRef Id="HostFiles" />
+      <ComponentRef Id="NativeMessagingRegistration" />
+    </Feature>
+  </Package>
+</Wix>

--- a/scripts/extension-id.txt
+++ b/scripts/extension-id.txt
@@ -1,0 +1,1 @@
+ikbkielkpaloojhibinmcfbeekhkdblc

--- a/scripts/install-host.ps1
+++ b/scripts/install-host.ps1
@@ -14,7 +14,7 @@
 #   .\scripts\install-host.ps1 -ExtensionId <id> [-HostDir dir] [-FromSource]
 #                              [-Configuration Release] [-Repo owner/name] [-Tag vX.Y.Z]
 param(
-    [Parameter(Mandatory = $true)][string]$ExtensionId,
+    [string]$ExtensionId = "",
     [string]$HostDir = "",
     [switch]$FromSource,
     [string]$Configuration = "Release",
@@ -23,6 +23,17 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+# The published extension has a pinned ID (manifest "key"), so -ExtensionId is optional: fall back
+# to $env:CHROME_EXTENSION_ID, then to the committed/bundled extension-id.txt next to this script.
+if (-not $ExtensionId) { $ExtensionId = $env:CHROME_EXTENSION_ID }
+if (-not $ExtensionId) {
+    $idFile = Join-Path $PSScriptRoot "extension-id.txt"
+    if (Test-Path $idFile) { $ExtensionId = (Get-Content $idFile -Raw).Trim() }
+}
+if (-not $ExtensionId) {
+    throw "No extension ID. Pass -ExtensionId <id>, set CHROME_EXTENSION_ID, or provide extension-id.txt."
+}
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $publishDir = Join-Path $env:LOCALAPPDATA "PdfEditorHost"
 $hostName = "com.pdfeditor.host"

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -50,6 +50,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# The published extension has a pinned ID (manifest "key"), so the argument is optional: fall back
+# to $CHROME_EXTENSION_ID, then to the committed/bundled extension-id.txt next to this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "$EXTENSION_ID" ]]; then
+  EXTENSION_ID="${CHROME_EXTENSION_ID:-}"
+fi
+if [[ -z "$EXTENSION_ID" && -f "$SCRIPT_DIR/extension-id.txt" ]]; then
+  EXTENSION_ID="$(tr -d '[:space:]' < "$SCRIPT_DIR/extension-id.txt")"
+fi
 if [[ -z "$EXTENSION_ID" ]]; then
   usage
   exit 1

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Builds an Arch Linux package (.pkg.tar.zst) for the PDF Editor native messaging host
+# (linux-x64), installable with `pacman -U`.
+#
+# Like the .deb/.rpm, it installs the self-contained host under /opt/pdf-editor-host and
+# registers it system-wide with Chrome/Chromium by shipping the native-messaging manifest as
+# a package-owned file (`pacman -R` cleans it up). The manifest's allowed_origins is pinned to
+# the extension ID (from $CHROME_EXTENSION_ID, else scripts/extension-id.txt).
+#
+# Arch's own makepkg only runs on Arch, so this assembles the package format by hand with
+# bsdtar (libarchive-tools) + zstd -- both available on the ubuntu runner -- producing the
+# same .PKGINFO + .MTREE + payload layout makepkg emits. No Arch host required.
+#
+# Usage: ./scripts/package-arch.sh [output-dir]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+VERSION=$(python3 -c "import json; print(json.load(open('$REPO_ROOT/extension/manifest.json'))['version'])")
+
+EXTENSION_ID="${CHROME_EXTENSION_ID:-}"
+if [[ -z "$EXTENSION_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
+  EXTENSION_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/extension-id.txt")"
+fi
+if [[ -z "$EXTENSION_ID" ]]; then
+  echo "error: no extension ID (set CHROME_EXTENSION_ID or scripts/extension-id.txt)" >&2
+  exit 1
+fi
+
+HOST_NAME="com.pdfeditor.host"
+INSTALL_DIR="/opt/pdf-editor-host"
+EXE="PdfEditor.NativeHost"
+
+# pacman versions forbid a dash outside the pkgrel separator; the RC stamps 4-part dotted
+# versions (2.0.1.57) which are fine -- swap any stray dash for an underscore defensively.
+PKG_VERSION="${VERSION//-/_}"
+PKG_REL="1"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+PKGDIR="$STAGE/pkg"
+
+echo "Publishing native host (linux-x64, self-contained)..."
+dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
+  --configuration Release --runtime linux-x64 --self-contained true \
+  -p:PublishSingleFile=false --output "$PKGDIR$INSTALL_DIR" --nologo -v q
+
+chmod 0755 "$PKGDIR$INSTALL_DIR/$EXE"
+
+# Native-messaging manifest, pinned to the extension ID and pointing at the installed binary.
+# Chrome reads /etc/opt/chrome/... ; Chromium reads /etc/chromium/... -- register both.
+render_manifest() {
+  sed -e "s|__HOST_PATH__|$INSTALL_DIR/$EXE|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+    "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
+}
+for dir in "etc/opt/chrome/native-messaging-hosts" "etc/chromium/native-messaging-hosts"; do
+  mkdir -p "$PKGDIR/$dir"
+  render_manifest > "$PKGDIR/$dir/$HOST_NAME.json"
+done
+
+# .PKGINFO -- package metadata pacman reads. size is the installed byte total.
+INSTALLED_SIZE=$(du -sb "$PKGDIR" | cut -f1)
+BUILD_DATE=$(date +%s)
+cat > "$PKGDIR/.PKGINFO" <<EOF
+pkgname = pdf-editor-host
+pkgbase = pdf-editor-host
+pkgver = ${PKG_VERSION}-${PKG_REL}
+pkgdesc = PDF Editor native messaging host
+url = https://github.com/ZanattaMichael/Chromium-PDF-Editor
+builddate = $BUILD_DATE
+packager = PDF Editor <noreply@users.noreply.github.com>
+size = $INSTALLED_SIZE
+arch = x86_64
+license = MIT
+EOF
+
+# Mark the two manifests as pacman backup/config files so an upgrade doesn't clobber local edits.
+{
+  echo "backup = etc/opt/chrome/native-messaging-hosts/$HOST_NAME.json"
+  echo "backup = etc/chromium/native-messaging-hosts/$HOST_NAME.json"
+} >> "$PKGDIR/.PKGINFO"
+
+# .MTREE -- a gzip-compressed mtree manifest of every packaged file (makepkg's exact options),
+# listing .PKGINFO and the payload tree but not .MTREE itself.
+(
+  cd "$PKGDIR"
+  LANG=C bsdtar -czf .MTREE --format=mtree \
+    --options='!all,use-set,type,uid,gid,mode,time,size,md5,sha256,link' \
+    .PKGINFO opt etc
+)
+
+PKG_PATH="$OUTPUT_DIR/pdf-editor-host-${PKG_VERSION}-${PKG_REL}-x86_64.pkg.tar.zst"
+echo "Building $PKG_PATH ..."
+# .PKGINFO and .MTREE must be the first entries; then the payload tree.
+(
+  cd "$PKGDIR"
+  LANG=C bsdtar --zstd -cf "$PKG_PATH" .PKGINFO .MTREE opt etc
+)
+
+echo
+echo "Built: $PKG_PATH ($(du -h "$PKG_PATH" | cut -f1))"
+echo "Extension ID pinned: $EXTENSION_ID"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "arch_path=$PKG_PATH" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/package-bundle.sh
+++ b/scripts/package-bundle.sh
@@ -44,6 +44,7 @@ mkdir -p "$BUNDLE/scripts"
 cp "$REPO_ROOT/scripts/install-host.sh" \
    "$REPO_ROOT/scripts/install-host.ps1" \
    "$REPO_ROOT/scripts/com.pdfeditor.host.json.template" \
+   "$REPO_ROOT/scripts/extension-id.txt" \
    "$BUNDLE/scripts/"
 
 # 4) Short install guide.

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Builds a Debian package (.deb) for the PDF Editor native messaging host (linux-x64).
+#
+# The package installs the self-contained host under /opt/pdf-editor-host and registers it
+# system-wide with Chrome/Chromium by shipping the native-messaging manifest as a package-owned
+# file — so `apt remove` cleans it up automatically. The manifest's allowed_origins is pinned to
+# the extension ID (from $CHROME_EXTENSION_ID, else scripts/extension-id.txt).
+#
+# Usage: ./scripts/package-deb.sh [output-dir]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+VERSION=$(python3 -c "import json; print(json.load(open('$REPO_ROOT/extension/manifest.json'))['version'])")
+
+EXTENSION_ID="${CHROME_EXTENSION_ID:-}"
+if [[ -z "$EXTENSION_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
+  EXTENSION_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/extension-id.txt")"
+fi
+if [[ -z "$EXTENSION_ID" ]]; then
+  echo "error: no extension ID (set CHROME_EXTENSION_ID or scripts/extension-id.txt)" >&2
+  exit 1
+fi
+
+HOST_NAME="com.pdfeditor.host"
+INSTALL_DIR="/opt/pdf-editor-host"
+EXE="PdfEditor.NativeHost"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+DEBROOT="$STAGE/deb"
+
+echo "Publishing native host (linux-x64, self-contained)..."
+dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
+  --configuration Release --runtime linux-x64 --self-contained true \
+  -p:PublishSingleFile=false --output "$DEBROOT$INSTALL_DIR" --nologo -v q
+
+chmod 0755 "$DEBROOT$INSTALL_DIR/$EXE"
+
+# Native-messaging manifest, pinned to the extension ID and pointing at the installed binary.
+# Chrome reads /etc/opt/chrome/... ; Chromium reads /etc/chromium/... — register both.
+render_manifest() {
+  sed -e "s|__HOST_PATH__|$INSTALL_DIR/$EXE|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+    "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
+}
+for dir in "etc/opt/chrome/native-messaging-hosts" "etc/chromium/native-messaging-hosts"; do
+  mkdir -p "$DEBROOT/$dir"
+  render_manifest > "$DEBROOT/$dir/$HOST_NAME.json"
+done
+
+# Debian control metadata.
+INSTALLED_KB=$(du -sk "$DEBROOT$INSTALL_DIR" | cut -f1)
+mkdir -p "$DEBROOT/DEBIAN"
+cat > "$DEBROOT/DEBIAN/control" <<EOF
+Package: pdf-editor-host
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: amd64
+Maintainer: PDF Editor <noreply@users.noreply.github.com>
+Installed-Size: $INSTALLED_KB
+Description: PDF Editor native messaging host
+ Local backend for the PDF Editor browser extension. Performs PDF processing
+ (edit, redact, merge, sign, OCR) on your machine and is registered as a Chrome/
+ Chromium native messaging host so the extension can talk to it.
+EOF
+
+DEB_PATH="$OUTPUT_DIR/pdf-editor-host_${VERSION}_amd64.deb"
+echo "Building $DEB_PATH ..."
+# --root-owner-group: files owned by root:root without needing fakeroot.
+dpkg-deb --root-owner-group --build "$DEBROOT" "$DEB_PATH" >/dev/null
+
+echo
+echo "Built: $DEB_PATH ($(du -h "$DEB_PATH" | cut -f1))"
+echo "Extension ID pinned: $EXTENSION_ID"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "deb_path=$DEB_PATH" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/package-msi.ps1
+++ b/scripts/package-msi.ps1
@@ -1,0 +1,52 @@
+# Builds the Windows MSI for the PDF Editor native messaging host.
+#
+# Requires the WiX toolset v4+ (`dotnet tool install --global wix`) and the .NET SDK, and runs on
+# Windows (an MSI can only be built on Windows). Intended for a `windows-latest` CI runner; it is
+# not built in the Linux dev box.
+#
+# It publishes the self-contained win-x64 host, renders the native-messaging manifest with the
+# pinned extension ID (the manifest's "path" is relative to itself, which Chrome allows on Windows),
+# and invokes `wix build` against installer/windows/PdfEditorHost.wxs.
+#
+# Usage: .\scripts\package-msi.ps1 [-OutputDir dist]
+param(
+    [string]$OutputDir = "dist"
+)
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+$version = (Get-Content (Join-Path $repoRoot "extension\manifest.json") -Raw | ConvertFrom-Json).version
+
+# Pinned extension ID: $env:CHROME_EXTENSION_ID wins, else the committed extension-id.txt.
+$extensionId = $env:CHROME_EXTENSION_ID
+if (-not $extensionId) {
+    $extensionId = (Get-Content (Join-Path $PSScriptRoot "extension-id.txt") -Raw).Trim()
+}
+if (-not $extensionId) { throw "No extension ID (set CHROME_EXTENSION_ID or provide extension-id.txt)." }
+
+$stage = Join-Path ([System.IO.Path]::GetTempPath()) ("pdfeditor-msi-" + [guid]::NewGuid())
+$hostDir = Join-Path $stage "host"
+New-Item -ItemType Directory -Force -Path $hostDir | Out-Null
+
+Write-Host "Publishing native host (win-x64, self-contained)..."
+dotnet publish (Join-Path $repoRoot "src\PdfEditor.NativeHost") `
+    --configuration Release --runtime win-x64 --self-contained true `
+    -p:PublishSingleFile=false --output $hostDir --nologo -v q
+
+# Render the native-messaging manifest with a relative exe path and the pinned allowed origin.
+$template = Get-Content (Join-Path $PSScriptRoot "com.pdfeditor.host.json.template") -Raw
+$manifestJson = Join-Path $stage "com.pdfeditor.host.json"
+$template.Replace("__HOST_PATH__", "PdfEditor.NativeHost.exe").Replace("__EXTENSION_ID__", $extensionId) |
+    Set-Content -Path $manifestJson -Encoding UTF8
+
+$outDirFull = Join-Path $repoRoot $OutputDir
+New-Item -ItemType Directory -Force -Path $outDirFull | Out-Null
+$msiPath = Join-Path $outDirFull "pdf-editor-host-$version-x64.msi"
+
+Write-Host "Building $msiPath ..."
+wix build (Join-Path $repoRoot "installer\windows\PdfEditorHost.wxs") `
+    -d "Version=$version" -d "HostDir=$hostDir" -d "ManifestJson=$manifestJson" `
+    -o $msiPath
+
+Write-Host "Built: $msiPath"
+Write-Host "Extension ID pinned: $extensionId"

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Builds an RPM package (.rpm) for the PDF Editor native messaging host (linux-x64), for
+# RedHat-family distros (Fedora, RHEL, CentOS, openSUSE, etc.).
+#
+# Like the .deb, it installs the self-contained host under /opt/pdf-editor-host and registers
+# it system-wide with Chrome/Chromium by shipping the native-messaging manifest as a
+# package-owned file (marked %config so `dnf remove` cleans it up). The manifest's
+# allowed_origins is pinned to the extension ID (from $CHROME_EXTENSION_ID, else
+# scripts/extension-id.txt).
+#
+# rpmbuild runs fine on Debian/Ubuntu (`apt-get install rpm`), so this builds on the same
+# ubuntu runner as the .deb -- no RedHat host required.
+#
+# Usage: ./scripts/package-rpm.sh [output-dir]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+VERSION=$(python3 -c "import json; print(json.load(open('$REPO_ROOT/extension/manifest.json'))['version'])")
+
+EXTENSION_ID="${CHROME_EXTENSION_ID:-}"
+if [[ -z "$EXTENSION_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
+  EXTENSION_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/extension-id.txt")"
+fi
+if [[ -z "$EXTENSION_ID" ]]; then
+  echo "error: no extension ID (set CHROME_EXTENSION_ID or scripts/extension-id.txt)" >&2
+  exit 1
+fi
+
+HOST_NAME="com.pdfeditor.host"
+INSTALL_DIR="/opt/pdf-editor-host"
+EXE="PdfEditor.NativeHost"
+
+# RPM forbids a dash in the Version field; the RC build stamps a 4-part version like
+# 2.0.1.57 which is fine, but a dash-bearing tag would break it -- swap any dash for an
+# underscore defensively.
+RPM_VERSION="${VERSION//-/_}"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+BUILDROOT="$STAGE/buildroot"
+
+echo "Publishing native host (linux-x64, self-contained)..."
+dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
+  --configuration Release --runtime linux-x64 --self-contained true \
+  -p:PublishSingleFile=false --output "$BUILDROOT$INSTALL_DIR" --nologo -v q
+
+chmod 0755 "$BUILDROOT$INSTALL_DIR/$EXE"
+
+# Native-messaging manifest, pinned to the extension ID and pointing at the installed binary.
+# Chrome reads /etc/opt/chrome/... ; Chromium reads /etc/chromium/... -- register both.
+render_manifest() {
+  sed -e "s|__HOST_PATH__|$INSTALL_DIR/$EXE|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+    "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
+}
+for dir in "etc/opt/chrome/native-messaging-hosts" "etc/chromium/native-messaging-hosts"; do
+  mkdir -p "$BUILDROOT/$dir"
+  render_manifest > "$BUILDROOT/$dir/$HOST_NAME.json"
+done
+
+# RPM spec. %install copies the pre-staged buildroot into rpmbuild's own buildroot; there is
+# no compile step (the payload is already published).
+SPEC="$STAGE/pdf-editor-host.spec"
+cat > "$SPEC" <<EOF
+Name:           pdf-editor-host
+Version:        $RPM_VERSION
+Release:        1
+Summary:        PDF Editor native messaging host
+License:        MIT
+BuildArch:      x86_64
+AutoReqProv:    no
+
+%description
+Local backend for the PDF Editor browser extension. Performs PDF processing
+(edit, redact, merge, sign, OCR) on your machine and is registered as a Chrome/
+Chromium native messaging host so the extension can talk to it.
+
+%install
+cp -a %{_sourcedir}/buildroot/. %{buildroot}/
+
+%files
+$INSTALL_DIR
+%config /etc/opt/chrome/native-messaging-hosts/$HOST_NAME.json
+%config /etc/chromium/native-messaging-hosts/$HOST_NAME.json
+
+%changelog
+* $(LC_ALL=C date '+%a %b %d %Y') PDF Editor <noreply@users.noreply.github.com> - $RPM_VERSION-1
+- Automated release-candidate build.
+EOF
+
+echo "Building RPM ..."
+# _sourcedir points at our stage so %install can copy the pre-published buildroot; disabling
+# the debuginfo/strip/compress machinery keeps the self-contained .NET payload intact.
+rpmbuild -bb "$SPEC" \
+  --define "_topdir $STAGE/rpmbuild" \
+  --define "_sourcedir $STAGE" \
+  --define "_rpmdir $STAGE/rpmbuild/RPMS" \
+  --define "debug_package %{nil}" \
+  --define "__brp_strip %{nil}" \
+  --define "__brp_strip_static_archive %{nil}" \
+  --define "__brp_strip_comment_note %{nil}" \
+  --define "__os_install_post %{nil}" \
+  >/dev/null
+
+BUILT=$(find "$STAGE/rpmbuild/RPMS" -name '*.rpm' -print -quit)
+RPM_PATH="$OUTPUT_DIR/pdf-editor-host-${RPM_VERSION}-1.x86_64.rpm"
+mv "$BUILT" "$RPM_PATH"
+
+echo
+echo "Built: $RPM_PATH ($(du -h "$RPM_PATH" | cut -f1))"
+echo "Extension ID pinned: $EXTENSION_ID"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "rpm_path=$RPM_PATH" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
Groundwork for publishing to the Chrome Web Store and distributing the native host.

## Extension ID pinning
- Added a `&#34;key&#34;` to `extension/manifest.json` → deterministic ID **`ikbkielkpaloojhibinmcfbeekhkdblc`**, recorded in `scripts/extension-id.txt` as the single source of truth.
- `install-host.sh`/`.ps1` now default to that ID (the argument is optional), overridable via `$CHROME_EXTENSION_ID`; `package-bundle.sh` ships `extension-id.txt` so bundled installers register the right `allowed_origins` with no manual ID entry.
  - _Private key for that ID is kept out of the repo (in the session scratchpad); store it as a secret if you want to preserve the ID / self-sign a CRX._

## Per-OS native-host installers
- **Linux `.deb`** (`scripts/package-deb.sh`) — built and verified here. Installs the self-contained host to `/opt/pdf-editor-host` and registers the native-messaging manifest **system-wide** for Chrome and Chromium (package-owned, so `apt remove` cleans it up), `allowed_origins` pinned.
- **Windows MSI** (`installer/windows/PdfEditorHost.wxs` + `scripts/package-msi.ps1`) — WiX v4; builds on a `windows-latest` runner (an MSI can&#39;t be built on Linux). Installs to Program Files, ships the manifest beside the exe (relative path), and writes HKLM native-messaging keys for Chrome/Chromium/Edge/Brave; uninstall removes it all.
- **macOS `.pkg`** — deferred (needs macOS/`pkgbuild`).

## RC build produces the installers
- `release-candidate.yml` is split into three jobs so every merge to main attaches both installers to the prerelease:
  - **`version`** (ubuntu) computes the RC tag / `final_tag` / `manifest_version` once and exposes them as job outputs.
  - **`build-msi`** (windows-latest) stamps the manifest with the RC version, installs the WiX toolset, runs `package-msi.ps1`, and uploads the `.msi` as an artifact.
  - **`release-candidate`** (ubuntu) builds/tests, packages the extension + per-platform bundles + the Linux `.deb`, pulls in the `.msi` artifact, and publishes the prerelease with the `.deb` and `.msi` added to its assets and release notes.
- Both packaging steps pass the `CHROME_EXTENSION_ID` secret (falling back to `scripts/extension-id.txt`); all action SHAs stay pinned.

## Docs
- `docs/PRIVACY.md` — privacy policy accurate to the extension (local processing; no telemetry; only outbound traffic is opening a PDF by URL and the opt-in Cloudflare scan). Required for the listing.
- `docs/CHROME_WEB_STORE.md` — submission playbook (credentials, listing copy, permission justifications, publish flow).

## Not in this PR (follow-ups)
- Code-signing/notarization of the installers (#105), winget/Homebrew channels + `latest.json` (#110), and the VirusTotal scan gate (#111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)