### PR TITLE
Fix RC MSI build: pin WiX to v5 and fail on tool errors

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -110,7 +110,10 @@ jobs:
         shell: bash
 
       - name: Install the WiX toolset
-        run: dotnet tool install --global wix
+        # Pin to WiX v5: v6+ require accepting the Open Source Maintenance Fee (OSMF) EULA,
+        # which cannot be done non-interactively and fails the build with WIX7015. v5 is the
+        # last release that builds freely without it, and reads our v4-schema .wxs unchanged.
+        run: dotnet tool install --global wix --version 5.0.2
 
       - name: Build the Windows MSI
         env:

--- a/scripts/package-msi.ps1
+++ b/scripts/package-msi.ps1
@@ -32,6 +32,9 @@ Write-Host "Publishing native host (win-x64, self-contained)..."
 dotnet publish (Join-Path $repoRoot "src\PdfEditor.NativeHost") `
     --configuration Release --runtime win-x64 --self-contained true `
     -p:PublishSingleFile=false --output $hostDir --nologo -v q
+# $ErrorActionPreference = "Stop" does not catch a native tool's non-zero exit, so check it
+# explicitly -- otherwise the script sails past a failed publish and reports a build it never made.
+if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE." }
 
 # Render the native-messaging manifest with a relative exe path and the pinned allowed origin.
 $template = Get-Content (Join-Path $PSScriptRoot "com.pdfeditor.host.json.template") -Raw
@@ -47,6 +50,7 @@ Write-Host "Building $msiPath ..."
 wix build (Join-Path $repoRoot "installer\windows\PdfEditorHost.wxs") `
     -d "Version=$version" -d "HostDir=$hostDir" -d "ManifestJson=$manifestJson" `
     -o $msiPath
+if ($LASTEXITCODE -ne 0) { throw "wix build failed with exit code $LASTEXITCODE." }
 
 Write-Host "Built: $msiPath"
 Write-Host "Extension ID pinned: $extensionId"


### PR DESCRIPTION
The `build-msi` job in the RC workflow failed on `main`.

## Cause
`dotnet tool install --global wix` installs the latest WiX (**v7**), which refuses to build without accepting the Open Source Maintenance Fee (OSMF) EULA — impossible to do non-interactively — so `wix build` errored with `WIX7015`:

```
wix.exe : error WIX7015: You must accept the Open Source Maintenance Fee (OSMF) EULA to use WiX Toolset v7.
```

A second, latent bug hid it: PowerShell's `$ErrorActionPreference = "Stop"` does **not** catch a native tool's non-zero exit, so `package-msi.ps1` printed `Built: …` and the pinned-ID line even though `wix` had already failed. The job only went red because GitHub's shell wrapper propagated the last non-zero `$LASTEXITCODE`.

## Fix
- **Pin WiX to `5.0.2`** in the install step. v5 is the last release that builds freely without the OSMF EULA, and it reads our existing v4-schema `.wxs` unchanged.
- **Harden `package-msi.ps1`**: check `$LASTEXITCODE` after both `dotnet publish` and `wix build` and `throw` on failure, so a real failure stops the script instead of reporting a build it never made.

The CA analyzer warnings in the log are non-fatal (the publish succeeded) and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_