### PR TITLE
Fix RC MSI build: split file + registry components (WIX0230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,66 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  package-linux-installers-dry-run:
+    # Proves the Linux host installers (scripts/package-deb.sh / package-rpm.sh / package-arch.sh)
+    # still build. release-candidate.yml is the only workflow that builds them for real and it runs
+    # solely on push to main, so without this job a broken packaging script would only surface after
+    # merge on the RC run. Builds all three (.deb / .rpm / .pkg.tar.zst) on every push/PR.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: "3.x"
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "8.0.x"
+      - name: Install Linux packaging tooling (rpm + Arch package format)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rpm libarchive-tools zstd
+      - name: Build the Linux host installers (.deb / .rpm / Arch .pkg.tar.zst)
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: |
+          ./scripts/package-deb.sh dist
+          ./scripts/package-rpm.sh dist
+          ./scripts/package-arch.sh dist
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pdf-editor-host-linux-installers-dry-run
+          path: |
+            dist/pdf-editor-host_*.deb
+            dist/pdf-editor-host-*.rpm
+            dist/pdf-editor-host-*.pkg.tar.zst
+          if-no-files-found: error
+          retention-days: 7
+
+  package-msi-dry-run:
+    # Proves the Windows MSI build (installer/windows/PdfEditorHost.wxs + scripts/package-msi.ps1)
+    # still compiles. An MSI can only be built on Windows and release-candidate.yml -- the only
+    # workflow that builds it for real -- runs solely on push to main, so without this job a broken
+    # .wxs (bad GUID, schema error, WiX version gotcha) would only surface *after* merge, on the RC
+    # run. This runs the same script on every push/PR so those errors are caught at review time.
+    # WiX is pinned to v5: v6+ require accepting the OSMF EULA, which can't be done non-interactively.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "8.0.x"
+      - name: Install the WiX toolset
+        run: dotnet tool install --global wix --version 5.0.2
+      - name: Build the MSI
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: ./scripts/package-msi.ps1 -OutputDir dist
+        shell: pwsh
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pdf-editor-host-msi-dry-run
+          path: dist/*.msi
+          if-no-files-found: error
+          retention-days: 7
+
   test-bundles:
     # Builds the all-in-one bundle (browser extension + self-contained native host +
     # install scripts) for every desktop platform and uploads each as a downloadable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: ["**"]
   pull_request:
 
+# All jobs only build, test, and upload artifacts -- none write repository contents, so the
+# token is held to read-only. (Artifact upload uses the Actions API, not `contents`.)
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/installer/windows/PdfEditorHost.wxs
+++ b/installer/windows/PdfEditorHost.wxs
@@ -32,9 +32,15 @@
       <Files Include="$(var.HostDir)\**" />
     </ComponentGroup>
 
-    <!-- The native-messaging manifest + the registry pointers that register it with each browser. -->
-    <Component Id="NativeMessagingRegistration" Directory="INSTALLFOLDER" Guid="*">
-      <File Id="HostManifestJson" Source="$(var.ManifestJson)" Name="com.pdfeditor.host.json" />
+    <!-- The native-messaging manifest, installed beside the exe. WiX v4+ forbids an
+         auto-generated ("*") GUID on a component that mixes a file with registry keypaths, so
+         the file and the registry pointers live in separate components with explicit GUIDs. -->
+    <Component Id="HostManifestFile" Directory="INSTALLFOLDER" Guid="037AC306-713B-4F09-B191-1421152B1CB9">
+      <File Id="HostManifestJson" Source="$(var.ManifestJson)" Name="com.pdfeditor.host.json" KeyPath="yes" />
+    </Component>
+
+    <!-- The registry pointers that register the manifest with each Chromium-based browser. -->
+    <Component Id="NativeMessagingRegistration" Directory="INSTALLFOLDER" Guid="2F7AC6A1-C7AF-441C-8C29-B73A2B97A4C8">
       <RegistryValue Root="HKLM" Key="SOFTWARE\Google\Chrome\NativeMessagingHosts\com.pdfeditor.host"
                      Type="string" Value="[INSTALLFOLDER]com.pdfeditor.host.json" KeyPath="yes" />
       <RegistryValue Root="HKLM" Key="SOFTWARE\Chromium\NativeMessagingHosts\com.pdfeditor.host"
@@ -47,6 +53,7 @@
 
     <Feature Id="Main" Title="PDF Editor Native Host" Level="1">
       <ComponentGroupRef Id="HostFiles" />
+      <ComponentRef Id="HostManifestFile" />
       <ComponentRef Id="NativeMessagingRegistration" />
     </Feature>
   </Package>


### PR DESCRIPTION
Follow-up to #112. With WiX pinned to v5 the toolset now runs, but `wix build` fails on the `.wxs` itself:

```
installer\windows\PdfEditorHost.wxs(36) : error WIX0230: The Component/@Guid attribute's value '*'
is not valid for this component ... Components with registry keypaths and files cannot use an
automatically generated guid.
```

## Cause
`NativeMessagingRegistration` had `Guid="*"` (auto-generated) but contained **both** the manifest `File` and four registry keypaths. WiX v4+ can't derive a stable auto-GUID for a component that mixes a file with registry keypaths.

## Fix
Split it into two components, each referenced by the feature:
- **`HostManifestFile`** — the `com.pdfeditor.host.json` file (file keypath).
- **`NativeMessagingRegistration`** — the four browser registry pointers (registry keypath).

Both carry explicit fixed GUIDs (deterministic across upgrades), so the auto-GUID criteria no longer apply. Install/uninstall behavior is unchanged — the same file and registry values ship, just in two components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkKqRKPeof6HWjXgDmUVBx)_