### PR TITLE
Register the host for all Chromium browsers + host diagnostics + VirusTotal RC scan

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -199,6 +199,25 @@ jobs:
           name: pdf-editor-host-msi
           path: dist
 
+      # Scan every downloadable artifact with VirusTotal and fail before publishing if anything is
+      # flagged (#111). Runs here — after all artifacts (bundles, .deb/.rpm/Arch, .msi) are in dist/
+      # and before the tag/release steps — so a detection blocks the release. Skips with a notice if
+      # the VT_API_KEY secret isn't set, so forks/PRs without the secret aren't hard-failed.
+      - name: Scan release artifacts with VirusTotal
+        env:
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
+          # Fail only on genuine detections; the committed allowlist absorbs known heuristic FPs.
+          VT_MALICIOUS_THRESHOLD: "0"
+        run: |
+          shopt -s nullglob
+          python3 scripts/scan-virustotal.py \
+            dist/pdf-editor-bundle-*.zip \
+            dist/pdf-editor-host_*.deb \
+            dist/pdf-editor-host-*.rpm \
+            dist/pdf-editor-host-*.pkg.tar.zst \
+            dist/*.msi \
+            dist/pdf-editor-extension-*.zip
+
       - name: Create and push the release candidate tag
         run: |
           git tag "${{ needs.version.outputs.tag }}"

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -2806,7 +2806,9 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     // Enabling it records an environment snapshot as tagged diagnostic entries.
     await expect(log.locator('.console-entry.diag', { hasText: 'extension version' })).toHaveCount(1);
     await expect(log.locator('.console-entry.diag', { hasText: 'browser' })).toHaveCount(1);
-    await expect(log.locator('.console-entry.diag', { hasText: 'native host version' })).toHaveCount(1);
+    // #114: the host now answers the `diagnostics` action, so its version is reported as a
+    // "native host — Host version: <v>" row (richer than the legacy ping-only fallback).
+    await expect(log.locator('.console-entry.diag', { hasText: 'Host version' })).toHaveCount(1);
 
     // A subsequent host round-trip now carries transfer sizes and is tagged diagnostic.
     await page.click('#btn-zoom-in');

--- a/extension/src/host-diagnostics.js
+++ b/extension/src/host-diagnostics.js
@@ -1,0 +1,28 @@
+// Formats the native host's `diagnostics` response for display. Kept DOM-free so it can be unit
+// tested and reused by both the options page and the viewer's activity console. The host may be an
+// older build without the `diagnostics` action (or a field may be missing), so every row is
+// optional — absent values are dropped rather than shown as "undefined".
+
+const ROWS = [
+  ['Host version', (d) => d.version],
+  ['Runtime', (d) => d.runtime],
+  ['Operating system', (d) => d.os],
+  ['OS architecture', (d) => d.osArchitecture],
+  ['Process architecture', (d) => d.processArchitecture],
+  ['OCR available', (d) => (d.ocrAvailable === undefined ? undefined : d.ocrAvailable ? 'yes' : 'no')],
+  ['Executable', (d) => d.executablePath],
+  ['Reported at (UTC)', (d) => d.utc],
+];
+
+/** Returns `[label, value]` pairs for the fields the host actually reported. */
+export function hostDiagnosticsRows(d) {
+  if (!d || typeof d !== 'object') return [];
+  return ROWS
+    .map(([label, get]) => [label, get(d)])
+    .filter(([, value]) => value !== undefined && value !== null && value !== '');
+}
+
+/** Returns the diagnostics as `Label: value` lines (for a <pre> block or a downloaded log). */
+export function hostDiagnosticsLines(d) {
+  return hostDiagnosticsRows(d).map(([label, value]) => `${label}: ${value}`);
+}

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -45,6 +45,7 @@
     <span id="host-status">checking…</span>
     <button id="test">Re-test</button>
   </p>
+  <pre id="host-diagnostics"></pre>
   <p>If the host is not connected:</p>
   <pre>
 # Linux / macOS
@@ -52,6 +53,12 @@
 
 # Windows (PowerShell)
 .\scripts\install-host.ps1 -ExtensionId &lt;your-extension-id&gt;</pre>
+  <p>
+    The OS installer packages (<code>.deb</code>, <code>.rpm</code>, Arch <code>.pkg.tar.zst</code>,
+    and the Windows <code>.msi</code>) register the host system-wide for Chrome, Chromium, Edge,
+    Brave, Vivaldi, and Opera automatically. You can also confirm the host runs on its own with
+    <code>PdfEditor.NativeHost --diagnostics</code>.
+  </p>
   <p>
     Your extension ID is shown at <code>chrome://extensions</code> with Developer mode on.
     Full instructions are in the repository README.

--- a/extension/src/options.js
+++ b/extension/src/options.js
@@ -1,7 +1,9 @@
 import { HostClient } from './host-client.js';
+import { hostDiagnosticsLines } from './host-diagnostics.js';
 
 const autoOpen = document.getElementById('auto-open');
 const status = document.getElementById('host-status');
+const diag = document.getElementById('host-diagnostics');
 
 {
   const value = await chrome.storage.sync.get({ autoOpen: true });
@@ -15,10 +17,17 @@ autoOpen.addEventListener('change', () => {
 async function test() {
   status.textContent = 'checking…';
   status.className = '';
+  diag.textContent = '';
   try {
-    const result = await new HostClient().call('ping');
+    const client = new HostClient();
+    const result = await client.call('ping');
     status.textContent = `✓ connected (host v${result.version ?? '?'})`;
     status.className = 'ok';
+    // Pull the richer host self-report too. Tolerate an older host that predates the action.
+    try {
+      const lines = hostDiagnosticsLines(await client.call('diagnostics'));
+      diag.textContent = lines.join('\n');
+    } catch { /* host has no 'diagnostics' action — the ping status is enough */ }
   } catch (e) {
     status.textContent = `✗ ${e.message}`;
     status.className = 'bad';

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -6,6 +6,7 @@ import { runFormScript } from './formScript.js';
 import { ActivityLog, formatTime } from './activity-log.js';
 import { displayToPage, pageToDisplay } from './geometry.js';
 import { formatBuildInfo, loadBuildMeta } from './build-info.js';
+import { hostDiagnosticsLines } from './host-diagnostics.js';
 
 const host = new HostClient();
 
@@ -315,10 +316,22 @@ async function logEnvironment() {
   activity.add('info', 'browser', browserSummary(), { diagnostic: true });
   activity.add('info', 'platform', navigator.platform || 'unknown', { diagnostic: true });
   try {
-    const pong = await host.call('ping');
-    activity.add('info', 'native host version', pong?.version ?? 'unknown', { diagnostic: true });
+    // Prefer the host's full self-report; fall back to ping's version on an older host.
+    let logged = false;
+    try {
+      for (const line of hostDiagnosticsLines(await host.call('diagnostics'))) {
+        activity.add('info', 'native host', line, { diagnostic: true });
+        logged = true;
+      }
+    } catch {
+      // Host predates the 'diagnostics' action; fall through to ping below.
+    }
+    if (!logged) {
+      const pong = await host.call('ping');
+      activity.add('info', 'native host version', pong?.version ?? 'unknown', { diagnostic: true });
+    }
   } catch {
-    // A failed ping is already logged by the host.call wrapper; nothing to add.
+    // A failed call is already logged by the host.call wrapper; nothing to add.
   }
 }
 

--- a/extension/test/host-diagnostics.test.mjs
+++ b/extension/test/host-diagnostics.test.mjs
@@ -1,0 +1,45 @@
+// Unit tests for the native-host diagnostics formatting (see extension/src/host-diagnostics.js).
+// Run with: node --test extension/test/host-diagnostics.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hostDiagnosticsRows, hostDiagnosticsLines } from '../src/host-diagnostics.js';
+
+const full = {
+  host: 'com.pdfeditor.host',
+  version: '2.0.1.46',
+  runtime: '.NET 8.0.29',
+  os: 'Ubuntu 24.04.4 LTS',
+  osArchitecture: 'X64',
+  processArchitecture: 'X64',
+  ocrAvailable: true,
+  executablePath: '/opt/pdf-editor-host/PdfEditor.NativeHost',
+  utc: '2026-08-08T10:46:51Z',
+};
+
+test('a full diagnostics response renders every field as Label: value lines', () => {
+  const lines = hostDiagnosticsLines(full);
+  assert.ok(lines.includes('Host version: 2.0.1.46'));
+  assert.ok(lines.includes('Runtime: .NET 8.0.29'));
+  assert.ok(lines.includes('Operating system: Ubuntu 24.04.4 LTS'));
+  assert.ok(lines.includes('OCR available: yes'));
+  assert.ok(lines.includes('Executable: /opt/pdf-editor-host/PdfEditor.NativeHost'));
+});
+
+test('ocrAvailable=false renders as "no", not a blank or "false"', () => {
+  const lines = hostDiagnosticsLines({ ...full, ocrAvailable: false });
+  assert.ok(lines.includes('OCR available: no'));
+});
+
+test('missing fields are dropped, not shown as "undefined"', () => {
+  const rows = hostDiagnosticsRows({ version: '2.0.0' });
+  assert.deepEqual(rows, [['Host version', '2.0.0']]);
+  assert.ok(!hostDiagnosticsLines({ version: '2.0.0' }).some((l) => l.includes('undefined')));
+});
+
+test('a null/empty/non-object response yields no rows rather than throwing', () => {
+  assert.deepEqual(hostDiagnosticsRows(null), []);
+  assert.deepEqual(hostDiagnosticsRows(undefined), []);
+  assert.deepEqual(hostDiagnosticsRows('nope'), []);
+  assert.deepEqual(hostDiagnosticsLines({}), []);
+});

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -196,14 +196,20 @@ case "$(uname -s)" in
       "$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
       "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts"
       "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+      "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts"
+      "$HOME/Library/Application Support/com.operasoftware.Opera/NativeMessagingHosts"
     )
     ;;
   *)
+    # Per-user manifest dirs for the common Chromium-based browsers. Registering all of them is
+    # harmless (each browser reads only its own) and means the host works whichever one is used.
     TARGETS=(
       "$HOME/.config/google-chrome/NativeMessagingHosts"
       "$HOME/.config/chromium/NativeMessagingHosts"
       "$HOME/.config/microsoft-edge/NativeMessagingHosts"
       "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+      "$HOME/.config/vivaldi/NativeMessagingHosts"
+      "$HOME/.config/opera/NativeMessagingHosts"
     )
     ;;
 esac

--- a/scripts/linux-manifest-dirs.sh
+++ b/scripts/linux-manifest-dirs.sh
@@ -1,0 +1,17 @@
+# Shared list of system-wide native-messaging manifest directories for the common Chromium-based
+# browsers on Linux, sourced by the .deb / .rpm / Arch packagers so they register the host in the
+# same set of places. Each browser reads only its own directory and ignores the others, so shipping
+# the manifest to all of them is safe and means the host connects no matter which browser is
+# installed. Paths are relative (no leading slash) so each packager can prefix its build root.
+#
+# Firefox is intentionally omitted: it uses a different manifest schema (allowed_extensions with an
+# add-on ID, not allowed_origins with a chrome-extension:// origin) and a different location.
+LINUX_MANIFEST_DIRS=(
+  "etc/opt/chrome/native-messaging-hosts"        # Google Chrome (Brave also reads this path)
+  "etc/chromium/native-messaging-hosts"          # Chromium (distro packages) and Vivaldi (legacy)
+  "etc/chromium-browser/native-messaging-hosts"  # older Ubuntu/Debian chromium-browser package
+  "etc/opt/edge/native-messaging-hosts"          # Microsoft Edge
+  "etc/opt/brave/native-messaging-hosts"         # Brave (current builds use their own path)
+  "etc/opt/vivaldi/native-messaging-hosts"       # Vivaldi
+  "etc/opt/opera/native-messaging-hosts"         # Opera
+)

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -15,6 +15,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/linux-manifest-dirs.sh
+source "$REPO_ROOT/scripts/linux-manifest-dirs.sh"
 OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
 mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
@@ -51,14 +53,17 @@ dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
 chmod 0755 "$PKGDIR$INSTALL_DIR/$EXE"
 
 # Native-messaging manifest, pinned to the extension ID and pointing at the installed binary.
-# Chrome reads /etc/opt/chrome/... ; Chromium reads /etc/chromium/... -- register both.
 render_manifest() {
   sed -e "s|__HOST_PATH__|$INSTALL_DIR/$EXE|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
     "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
 }
-for dir in "etc/opt/chrome/native-messaging-hosts" "etc/chromium/native-messaging-hosts"; do
+# Register for every common Chromium-based browser (see linux-manifest-dirs.sh). Each manifest is
+# marked as a pacman backup file (accumulated in BACKUP_LINES) so an upgrade won't clobber edits.
+BACKUP_LINES=""
+for dir in "${LINUX_MANIFEST_DIRS[@]}"; do
   mkdir -p "$PKGDIR/$dir"
   render_manifest > "$PKGDIR/$dir/$HOST_NAME.json"
+  BACKUP_LINES+="backup = $dir/$HOST_NAME.json"$'\n'
 done
 
 # .PKGINFO -- package metadata pacman reads. size is the installed byte total.
@@ -77,11 +82,8 @@ arch = x86_64
 license = MIT
 EOF
 
-# Mark the two manifests as pacman backup/config files so an upgrade doesn't clobber local edits.
-{
-  echo "backup = etc/opt/chrome/native-messaging-hosts/$HOST_NAME.json"
-  echo "backup = etc/chromium/native-messaging-hosts/$HOST_NAME.json"
-} >> "$PKGDIR/.PKGINFO"
+# Mark every registered manifest as a pacman backup file so an upgrade doesn't clobber local edits.
+printf '%s' "$BACKUP_LINES" >> "$PKGDIR/.PKGINFO"
 
 # .MTREE -- a gzip-compressed mtree manifest of every packaged file (makepkg's exact options),
 # listing .PKGINFO and the payload tree but not .MTREE itself.

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -10,6 +10,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/linux-manifest-dirs.sh
+source "$REPO_ROOT/scripts/linux-manifest-dirs.sh"
 OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
 mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
@@ -41,12 +43,14 @@ dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
 chmod 0755 "$DEBROOT$INSTALL_DIR/$EXE"
 
 # Native-messaging manifest, pinned to the extension ID and pointing at the installed binary.
-# Chrome reads /etc/opt/chrome/... ; Chromium reads /etc/chromium/... — register both.
 render_manifest() {
   sed -e "s|__HOST_PATH__|$INSTALL_DIR/$EXE|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
     "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
 }
-for dir in "etc/opt/chrome/native-messaging-hosts" "etc/chromium/native-messaging-hosts"; do
+# System-wide manifest dirs for the common Chromium-based browsers. Each browser reads only its
+# own dir and ignores the rest, so shipping to all of them is safe and means the host works no
+# matter which browser is installed. (Firefox uses a different manifest schema — omitted.)
+for dir in "${LINUX_MANIFEST_DIRS[@]}"; do
   mkdir -p "$DEBROOT/$dir"
   render_manifest > "$DEBROOT/$dir/$HOST_NAME.json"
 done

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -15,6 +15,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/linux-manifest-dirs.sh
+source "$REPO_ROOT/scripts/linux-manifest-dirs.sh"
 OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
 mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
@@ -51,14 +53,17 @@ dotnet publish "$REPO_ROOT/src/PdfEditor.NativeHost" \
 chmod 0755 "$BUILDROOT$INSTALL_DIR/$EXE"
 
 # Native-messaging manifest, pinned to the extension ID and pointing at the installed binary.
-# Chrome reads /etc/opt/chrome/... ; Chromium reads /etc/chromium/... -- register both.
 render_manifest() {
   sed -e "s|__HOST_PATH__|$INSTALL_DIR/$EXE|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
     "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
 }
-for dir in "etc/opt/chrome/native-messaging-hosts" "etc/chromium/native-messaging-hosts"; do
+# Register for every common Chromium-based browser (see linux-manifest-dirs.sh). Each %config
+# line for the spec's %files section is accumulated here so `dnf remove` reclaims them all.
+CONFIG_FILES=""
+for dir in "${LINUX_MANIFEST_DIRS[@]}"; do
   mkdir -p "$BUILDROOT/$dir"
   render_manifest > "$BUILDROOT/$dir/$HOST_NAME.json"
+  CONFIG_FILES+="%config /$dir/$HOST_NAME.json"$'\n'
 done
 
 # RPM spec. %install copies the pre-staged buildroot into rpmbuild's own buildroot; there is
@@ -83,8 +88,7 @@ cp -a %{_sourcedir}/buildroot/. %{buildroot}/
 
 %files
 $INSTALL_DIR
-%config /etc/opt/chrome/native-messaging-hosts/$HOST_NAME.json
-%config /etc/chromium/native-messaging-hosts/$HOST_NAME.json
+$CONFIG_FILES
 
 %changelog
 * $(LC_ALL=C date '+%a %b %d %Y') PDF Editor <noreply@users.noreply.github.com> - $RPM_VERSION-1

--- a/scripts/scan-virustotal.py
+++ b/scripts/scan-virustotal.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Submit release artifacts to VirusTotal and fail the build on real detections (#111).
+
+Runs on the release-candidate build after the downloadable artifacts are built. For each file it:
+  1. Queries VirusTotal by SHA-256 first (no upload if VT has already seen the file — saves quota).
+  2. Uploads only when unseen, using the large-file endpoint for files over 32 MB, then polls
+     until the analysis completes.
+  3. Counts `malicious` / `suspicious` engine verdicts, ignoring engines on a reviewed allowlist.
+  4. Prints a per-engine summary + the VT report URL (to the log and the GitHub job summary).
+  5. Exits non-zero if any file's malicious count (or suspicious, when enabled) exceeds the threshold.
+
+Config (all optional except the key):
+  VT_API_KEY               VirusTotal API key. Absent  -> the scan is SKIPPED with a notice
+                           (mirrors how the Chrome Web Store deploy degrades), never a hard fail.
+  VT_MALICIOUS_THRESHOLD   Max allowed malicious engines per file before failing. Default 0.
+  VT_FAIL_ON_SUSPICIOUS    "true" to also count `suspicious` verdicts toward the threshold.
+  scripts/virustotal-allowlist.txt   One engine name per line (# comments) whose verdicts are
+                           ignored — so a single flaky heuristic engine can't block every release.
+
+Usage: scan-virustotal.py <file> [<file> ...]
+
+Deliberately dependency-free (urllib only) so it needs no pip install on the runner. Run
+`scan-virustotal.py --self-test` to exercise the pure evaluation logic without a network/key.
+"""
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+import hashlib
+import uuid
+
+VT_API = "https://www.virustotal.com/api/v3"
+LARGE_FILE_BYTES = 32 * 1024 * 1024  # VT's standard upload cap; above this use the upload_url endpoint.
+POLL_INTERVAL_S = 20
+POLL_TIMEOUT_S = 600
+
+
+def load_allowlist(path):
+    """Engine names whose verdicts we ignore (reviewed known false-positives)."""
+    names = set()
+    if path and os.path.isfile(path):
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.split("#", 1)[0].strip()
+                if line:
+                    names.add(line)
+    return names
+
+
+def evaluate(results, allowlist, threshold, fail_on_suspicious):
+    """Pure decision function over VT's last_analysis_results dict.
+
+    Returns (malicious, suspicious, failed) where malicious/suspicious are the lists of engine
+    names that flagged the file (excluding allowlisted engines), and failed is the gate decision.
+    """
+    malicious, suspicious = [], []
+    for engine, verdict in (results or {}).items():
+        if engine in allowlist:
+            continue
+        category = (verdict or {}).get("category")
+        if category == "malicious":
+            malicious.append(engine)
+        elif category == "suspicious":
+            suspicious.append(engine)
+    counted = len(malicious) + (len(suspicious) if fail_on_suspicious else 0)
+    return sorted(malicious), sorted(suspicious), counted > threshold
+
+
+def _request(method, url, api_key, data=None, headers=None, timeout=120):
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("x-apikey", api_key)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (fixed https host)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _multipart_upload(url, api_key, file_path):
+    """POSTs the file as multipart/form-data (field name 'file'); returns the parsed JSON."""
+    boundary = uuid.uuid4().hex
+    with open(file_path, "rb") as f:
+        payload = f.read()
+    name = os.path.basename(file_path)
+    body = b"".join([
+        f"--{boundary}\r\n".encode(),
+        f'Content-Disposition: form-data; name="file"; filename="{name}"\r\n'.encode(),
+        b"Content-Type: application/octet-stream\r\n\r\n",
+        payload,
+        f"\r\n--{boundary}--\r\n".encode(),
+    ])
+    headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+    return _request("POST", url, api_key, data=body, headers=headers, timeout=600)
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def analysis_results_for(path, api_key):
+    """Returns VT's last_analysis_results for a file, uploading + polling if VT hasn't seen it."""
+    digest = sha256(path)
+    try:
+        report = _request("GET", f"{VT_API}/files/{digest}", api_key)
+        return digest, report["data"]["attributes"].get("last_analysis_results", {})
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise  # a real error (auth/quota) — surface it
+
+    # Unseen by VT: upload (large files need a one-time upload URL), then poll the analysis.
+    size = os.path.getsize(path)
+    if size > LARGE_FILE_BYTES:
+        upload_url = _request("GET", f"{VT_API}/files/upload_url", api_key)["data"]
+    else:
+        upload_url = f"{VT_API}/files"
+    analysis_id = _multipart_upload(upload_url, api_key, path)["data"]["id"]
+
+    deadline = time.time() + POLL_TIMEOUT_S
+    while time.time() < deadline:
+        analysis = _request("GET", f"{VT_API}/analyses/{analysis_id}", api_key)
+        if analysis["data"]["attributes"]["status"] == "completed":
+            break
+        time.sleep(POLL_INTERVAL_S)
+    else:
+        raise TimeoutError(f"VirusTotal analysis for {os.path.basename(path)} did not complete in time.")
+
+    report = _request("GET", f"{VT_API}/files/{digest}", api_key)
+    return digest, report["data"]["attributes"].get("last_analysis_results", {})
+
+
+def emit(line, summary_lines):
+    print(line)
+    summary_lines.append(line)
+
+
+def main(argv):
+    if argv == ["--self-test"]:
+        return self_test()
+
+    files = argv
+    if not files:
+        print("usage: scan-virustotal.py <file> [<file> ...]", file=sys.stderr)
+        return 2
+
+    api_key = os.environ.get("VT_API_KEY", "").strip()
+    if not api_key:
+        print("::notice::VT_API_KEY not set — skipping the VirusTotal scan. "
+              "Set the secret to enable release binary scanning (#111).")
+        return 0
+
+    threshold = int(os.environ.get("VT_MALICIOUS_THRESHOLD", "0"))
+    fail_on_suspicious = os.environ.get("VT_FAIL_ON_SUSPICIOUS", "").lower() == "true"
+    allowlist = load_allowlist(os.path.join(os.path.dirname(__file__), "virustotal-allowlist.txt"))
+
+    summary = ["# VirusTotal scan", ""]
+    failures = []
+    for path in files:
+        name = os.path.basename(path)
+        try:
+            digest, results = analysis_results_for(path, api_key)
+        except Exception as e:  # network/quota/timeout — report which file and fail loudly.
+            emit(f"- ❌ `{name}`: scan error: {e}", summary)
+            failures.append(name)
+            continue
+        malicious, suspicious, failed = evaluate(results, allowlist, threshold, fail_on_suspicious)
+        url = f"https://www.virustotal.com/gui/file/{digest}"
+        verdict = "❌ FAIL" if failed else "✅ clean"
+        emit(f"- {verdict} [`{name}`]({url}) — "
+             f"{len(malicious)} malicious, {len(suspicious)} suspicious "
+             f"(threshold {threshold}{', +suspicious' if fail_on_suspicious else ''})", summary)
+        if malicious:
+            emit(f"    - malicious engines: {', '.join(malicious)}", summary)
+        if suspicious:
+            emit(f"    - suspicious engines: {', '.join(suspicious)}", summary)
+        if failed:
+            failures.append(name)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as f:
+            f.write("\n".join(summary) + "\n")
+
+    if failures:
+        print(f"::error::VirusTotal flagged {len(failures)} artifact(s): {', '.join(failures)}",
+              file=sys.stderr)
+        return 1
+    print("All artifacts passed the VirusTotal scan.")
+    return 0
+
+
+def self_test():
+    """Exercises the pure evaluate() gate — no network, no key needed."""
+    clean = {"EngineA": {"category": "undetected"}, "EngineB": {"category": "harmless"}}
+    m, s, failed = evaluate(clean, set(), 0, False)
+    assert (m, s, failed) == ([], [], False), (m, s, failed)
+
+    flagged = {"BadHeuristic": {"category": "malicious"}, "EngineB": {"category": "harmless"}}
+    m, s, failed = evaluate(flagged, set(), 0, False)
+    assert m == ["BadHeuristic"] and failed is True, (m, s, failed)
+
+    # Allowlisted engine's malicious verdict is ignored.
+    m, s, failed = evaluate(flagged, {"BadHeuristic"}, 0, False)
+    assert m == [] and failed is False, (m, s, failed)
+
+    # Threshold tolerates up to N malicious engines.
+    two = {"E1": {"category": "malicious"}, "E2": {"category": "malicious"}}
+    assert evaluate(two, set(), 2, False)[2] is False
+    assert evaluate(two, set(), 1, False)[2] is True
+
+    # Suspicious only counts when explicitly enabled.
+    susp = {"E1": {"category": "suspicious"}}
+    assert evaluate(susp, set(), 0, False)[2] is False
+    assert evaluate(susp, set(), 0, True)[2] is True
+
+    # Empty / missing results never fail.
+    assert evaluate({}, set(), 0, True)[2] is False
+    assert evaluate(None, set(), 0, True)[2] is False
+    print("scan-virustotal self-test: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/virustotal-allowlist.txt
+++ b/scripts/virustotal-allowlist.txt
@@ -1,0 +1,15 @@
+# VirusTotal engine allowlist for the release binary scan (#111).
+#
+# One antivirus engine name (exactly as VirusTotal reports it) per line. A `malicious` or
+# `suspicious` verdict from an engine listed here is IGNORED when deciding whether to fail the
+# build. This exists so a single flaky heuristic engine can't block every release — unsigned,
+# self-contained .NET binaries routinely trip heuristic/ML engines with false positives.
+#
+# Keep this list SHORT and REVIEWED: only add an engine after confirming (via its VT report /
+# vendor) that the detection on our artifacts is a generic-heuristic false positive, and add a
+# comment saying why + when. Any engine NOT listed here still fails the build on a detection.
+#
+# Format: the exact engine name, e.g.
+#   SecureAge        # generic ML/heuristic FP on unsigned self-contained .NET single-file, 2026-08
+#
+# (Empty by default — add entries only with justification.)

--- a/src/PdfEditor.NativeHost/HostDiagnostics.cs
+++ b/src/PdfEditor.NativeHost/HostDiagnostics.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using PdfEditor.Core;
+
+namespace PdfEditor.NativeHost;
+
+/// <summary>
+/// Self-reported health/environment of the native messaging host: version, .NET runtime, OS,
+/// architecture, where the executable lives, and which optional capabilities are available. It is
+/// exposed two ways — as the <c>diagnostics</c> message action (so the extension can show it when
+/// the host connects) and as a command-line mode (<c>PdfEditor.NativeHost --diagnostics</c>) so a
+/// user can confirm the host runs at all, independently of the browser. Deliberately carries no
+/// personal data (no user name, home path, or machine name).
+/// </summary>
+public static class HostDiagnostics
+{
+    private static readonly JsonSerializerOptions CliJson = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>Collects the diagnostic snapshot returned by both the action and the CLI.</summary>
+    public static object Collect() => new
+    {
+        host = "com.pdfeditor.host",
+        version = typeof(HostDiagnostics).Assembly.GetName().Version?.ToString() ?? "unknown",
+        runtime = RuntimeInformation.FrameworkDescription,
+        os = RuntimeInformation.OSDescription,
+        osArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+        processArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+        executablePath = Environment.ProcessPath ?? "unknown",
+        ocrAvailable = OcrTool.CanOcr,
+        utc = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture),
+    };
+
+    /// <summary>
+    /// If <paramref name="args"/> requests diagnostics (the first argument is <c>--diagnostics</c>,
+    /// <c>--selftest</c>, or <c>--version</c>), writes the snapshot as pretty JSON to
+    /// <paramref name="output"/> and returns an exit code; otherwise returns <c>null</c> so the
+    /// caller proceeds with the normal native-messaging loop. A real browser launch passes the
+    /// calling extension's origin (e.g. <c>chrome-extension://…</c>) as the first argument, never
+    /// one of these flags, so this never intercepts a genuine host session.
+    /// </summary>
+    public static int? TryRunCli(string[] args, TextWriter output)
+    {
+        if (args.Length == 0) return null;
+        switch (args[0])
+        {
+            case "--diagnostics":
+            case "--selftest":
+            case "--version":
+                output.WriteLine(JsonSerializer.Serialize(Collect(), CliJson));
+                return 0;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/PdfEditor.NativeHost/MessageProcessor.cs
+++ b/src/PdfEditor.NativeHost/MessageProcessor.cs
@@ -46,6 +46,7 @@ public static class MessageProcessor
     private static object Dispatch(string action, JsonObject p) => action switch
     {
         "ping" => new { pong = true, version = typeof(MessageProcessor).Assembly.GetName().Version?.ToString() },
+        "diagnostics" => HostDiagnostics.Collect(),
         "info" => Info(p),
         "render" => Render(p),
         "redact" => Redact(p),

--- a/src/PdfEditor.NativeHost/Program.cs
+++ b/src/PdfEditor.NativeHost/Program.cs
@@ -1,5 +1,11 @@
 using PdfEditor.NativeHost;
 
+// `PdfEditor.NativeHost --diagnostics` (or --version/--selftest) prints an environment snapshot
+// and exits, so a user can confirm the host runs without involving the browser. A real browser
+// launch passes the extension origin as the first arg, so this never intercepts a host session.
+var cliExit = HostDiagnostics.TryRunCli(args, Console.Out);
+if (cliExit.HasValue) return cliExit.Value;
+
 // Chrome launches this host and speaks the native messaging protocol over stdio.
 // Anything written to stdout must be a framed message, so diagnostics go to stderr.
 var stdin = Console.OpenStandardInput();

--- a/tests/PdfEditor.NativeHost.Tests/HostDiagnosticsTests.cs
+++ b/tests/PdfEditor.NativeHost.Tests/HostDiagnosticsTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace PdfEditor.NativeHost.Tests;
+
+/// <summary>Covers the host self-diagnostics (the 'diagnostics' action and the CLI mode).</summary>
+public class HostDiagnosticsTests
+{
+    private static JsonObject Handle(string action)
+    {
+        var request = JsonNode.Parse(JsonSerializer.Serialize(new { id = "d1", action }))!.AsObject();
+        var frame = Assert.Single(MessageProcessor.Handle(request.ToJsonString()));
+        return JsonNode.Parse(frame)!.AsObject();
+    }
+
+    [Fact]
+    public void DiagnosticsAction_ReportsHostAndRuntime()
+    {
+        var r = Handle("diagnostics");
+        Assert.True(r["ok"]!.GetValue<bool>());
+        var result = r["result"]!.AsObject();
+        Assert.Equal("com.pdfeditor.host", result["host"]!.GetValue<string>());
+        Assert.False(string.IsNullOrWhiteSpace(result["version"]!.GetValue<string>()));
+        Assert.Contains(".NET", result["runtime"]!.GetValue<string>());
+        Assert.False(string.IsNullOrWhiteSpace(result["os"]!.GetValue<string>()));
+        // ocrAvailable is a bool either way; just assert the field is present and typed.
+        Assert.NotNull(result["ocrAvailable"]);
+        Assert.IsType<bool>(result["ocrAvailable"]!.GetValue<bool>());
+    }
+
+    [Theory]
+    [InlineData("--diagnostics")]
+    [InlineData("--selftest")]
+    [InlineData("--version")]
+    public void TryRunCli_WithFlag_WritesJsonAndReturnsZero(string flag)
+    {
+        var writer = new StringWriter();
+        int? exit = HostDiagnostics.TryRunCli(new[] { flag }, writer);
+        Assert.Equal(0, exit);
+        var doc = JsonNode.Parse(writer.ToString())!.AsObject();
+        Assert.Equal("com.pdfeditor.host", doc["host"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void TryRunCli_WithNoArgs_ReturnsNull_SoTheHostLoopRuns()
+    {
+        var writer = new StringWriter();
+        Assert.Null(HostDiagnostics.TryRunCli(Array.Empty<string>(), writer));
+        Assert.Equal("", writer.ToString());
+    }
+
+    [Fact]
+    public void TryRunCli_WithBrowserOrigin_ReturnsNull_SoARealLaunchIsNotIntercepted()
+    {
+        // Chrome launches the host with the calling extension's origin as argv[0].
+        var writer = new StringWriter();
+        Assert.Null(HostDiagnostics.TryRunCli(
+            new[] { "chrome-extension://ikbkielkpaloojhibinmcfbeekhkdblc/" }, writer));
+        Assert.Equal("", writer.ToString());
+    }
+}


### PR DESCRIPTION
This branch carries two independent changes (the second was stacked on top after the first was opened).

---

# Part A — Native host browser coverage + diagnostics

Prompted by a real report: after installing the `.deb`, the extension showed **"Specified native messaging host not found"** in a non-Chrome Chromium browser. Two root causes, both fixed here.

## 1. The installers only registered Chrome + Chromium
The `.deb`/`.rpm`/Arch packages wrote the native-messaging manifest to just `/etc/opt/chrome/...` and `/etc/chromium/...`, so Brave/Edge/Vivaldi/Opera (and the older Ubuntu `chromium-browser`) never found it.

- **`scripts/linux-manifest-dirs.sh`** (new) — one shared list of system-wide manifest dirs for **Chrome, Chromium, chromium-browser, Edge, Brave, Vivaldi, Opera**. All three Linux packagers source it, so coverage stays consistent. Each browser reads only its own dir, so shipping to all is harmless; the `.rpm` marks them all `%config` and the Arch package marks them all `backup` so removal/upgrade behave.
- **`install-host.sh`** — the user-level installer gains Vivaldi and Opera on Linux and macOS.
- Firefox is intentionally excluded (different manifest schema: `allowed_extensions` + add-on ID, not `allowed_origins`).

Verified by building all three packages and inspecting them (`dpkg-deb -c`, `rpm -qcp`, and the Arch `.PKGINFO` `backup =` lines) — all seven browser paths present in each.

_Note: the packages still pin `allowed_origins` to the published extension ID; an **unpacked** extension has a different ID and needs its own manifest — that's expected and separate from this browser-coverage fix._

## 2. No diagnostics from the host itself
- **`HostDiagnostics.cs`** reports host version, .NET runtime, OS, architecture, executable path, and OCR availability — **no personal data** (no user/home/machine name). Exposed two ways:
  - a new **`diagnostics`** message action, and
  - a **CLI mode**: `PdfEditor.NativeHost --diagnostics` (also `--version` / `--selftest`) prints the snapshot and exits, so a user can confirm the host runs at all without the browser. A genuine browser launch passes the extension origin as `argv[0]`, so the CLI check never intercepts a host session.
- The **options page** shows the self-report under the connection status; the **viewer's diagnostic console** (opt-in, #97) logs it. `host-diagnostics.js` formats it (DOM-free, unit-tested), and both callers tolerate an older host without the action.

---

# Part B — Scan release artifacts with VirusTotal and gate the RC (#111)

Every downloadable release-candidate artifact is now scanned with VirusTotal before the prerelease is published; a genuine detection fails the build.

- **`scripts/scan-virustotal.py`** (new, dependency-free — `urllib` only, no pip on the runner). For each file it: queries VT by SHA-256 first (no upload if VT has already seen the file, saving quota); uploads only when unseen (using the large-file `upload_url` endpoint for files over 32 MB) and polls until analysis completes; counts `malicious`/`suspicious` verdicts while ignoring allowlisted engines; prints a per-engine summary + VT report URL to the log and the GitHub job summary; and exits non-zero when a file exceeds the threshold.
- **`scripts/virustotal-allowlist.txt`** (new) — reviewed per-engine allowlist so one flaky heuristic engine can't block every release (unsigned self-contained .NET binaries routinely trip heuristic/ML engines). Empty by default; entries require a justification comment.
- **`.github/workflows/release-candidate.yml`** — a new **Scan release artifacts with VirusTotal** step runs after all artifacts (per-platform bundles, `.deb`/`.rpm`/Arch, `.msi`, extension zip) are staged in `dist/` and **before** the tag/release steps, so a detection blocks the release. Threshold is `0` malicious. If `VT_API_KEY` isn't set the step **skips with a notice** (mirroring how the Chrome Web Store deploy degrades), so forks/PRs without the secret aren't hard-failed.

**Config:** `VT_API_KEY` (required to run; absent → skip), `VT_MALICIOUS_THRESHOLD` (default `0`), `VT_FAIL_ON_SUSPICIOUS` (`true` to also count suspicious).

Pure gate logic (`evaluate()`) is covered by a network-free self-test: `python3 scripts/scan-virustotal.py --self-test` (passing).

---

## Tests
- `HostDiagnosticsTests` — the action returns host/runtime/OS/ocr; `TryRunCli` returns 0 and emits JSON for each flag, and returns `null` for no-args and for a `chrome-extension://` origin.
- `host-diagnostics.test.mjs` — formatting, `ocrAvailable:false` → "no", missing fields dropped, null/non-object → no rows. (Extension suite: 64 passing.)
- `scan-virustotal.py --self-test` — the `evaluate()` gate: clean passes; a detection fails; allowlisted engine ignored; threshold tolerance; suspicious only when enabled; empty/None never fail.

The `package-msi-dry-run` / `package-linux-installers-dry-run` CI jobs build all four OS installers on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)