### PR TITLE
Release 2.0.3: drop the redundant tabs permission, and stamp the host's version from the release tag

### DIFF
--- a/.github/workflows/populate-draft-release.yml
+++ b/.github/workflows/populate-draft-release.yml
@@ -89,6 +89,35 @@ jobs:
           EOF
         shell: bash
 
+      - name: Stamp Directory.Build.props with the release version
+        # The host reports this version to the extension over `ping`, prints it for `--version` and
+        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
+        # the tag above, so without this the packages are *named* from the tag while the binary
+        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
+        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
+        # tree; this keeps them equal in a build stamped from a tag.
+        run: |
+          python3 - "$STAMP_VERSION" <<'PYEOF'
+          import re
+          import sys
+
+          version = sys.argv[1].strip()
+          if not version:
+              raise SystemExit("no version to stamp into Directory.Build.props")
+          path = "Directory.Build.props"
+          with open(path) as f:
+              props = f.read()
+          props, found = re.subn(
+              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
+          if found != 1:
+              raise SystemExit(path + " has no <Version> element to stamp")
+          with open(path, "w") as f:
+              f.write(props)
+          PYEOF
+        env:
+          STAMP_VERSION: ${{ needs.setup.outputs.manifest_version }}
+        shell: bash
+
       - name: Install the WiX toolset
         # Pin to WiX v5: v6+ require accepting the OSMF EULA non-interactively (fails with WIX7015).
         run: dotnet tool install --global wix --version 5.0.2
@@ -144,6 +173,35 @@ jobs:
           manifest["version"] = sys.argv[1]
           with open(path, "w") as f: json.dump(manifest, f, indent=2); f.write("\n")
           EOF
+
+      - name: Stamp Directory.Build.props with the release version
+        # The host reports this version to the extension over `ping`, prints it for `--version` and
+        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
+        # the tag above, so without this the packages are *named* from the tag while the binary
+        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
+        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
+        # tree; this keeps them equal in a build stamped from a tag.
+        run: |
+          python3 - "$STAMP_VERSION" <<'PYEOF'
+          import re
+          import sys
+
+          version = sys.argv[1].strip()
+          if not version:
+              raise SystemExit("no version to stamp into Directory.Build.props")
+          path = "Directory.Build.props"
+          with open(path) as f:
+              props = f.read()
+          props, found = re.subn(
+              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
+          if found != 1:
+              raise SystemExit(path + " has no <Version> element to stamp")
+          with open(path, "w") as f:
+              f.write(props)
+          PYEOF
+        env:
+          STAMP_VERSION: ${{ needs.setup.outputs.manifest_version }}
+        shell: bash
 
       - name: Package extension
         run: ./scripts/package-extension.sh dist

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -109,6 +109,35 @@ jobs:
           EOF
         shell: bash
 
+      - name: Stamp Directory.Build.props with the release-candidate version
+        # The host reports this version to the extension over `ping`, prints it for `--version` and
+        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
+        # the tag above, so without this the packages are *named* from the tag while the binary
+        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
+        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
+        # tree; this keeps them equal in a build stamped from a tag.
+        run: |
+          python3 - "$STAMP_VERSION" <<'PYEOF'
+          import re
+          import sys
+
+          version = sys.argv[1].strip()
+          if not version:
+              raise SystemExit("no version to stamp into Directory.Build.props")
+          path = "Directory.Build.props"
+          with open(path) as f:
+              props = f.read()
+          props, found = re.subn(
+              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
+          if found != 1:
+              raise SystemExit(path + " has no <Version> element to stamp")
+          with open(path, "w") as f:
+              f.write(props)
+          PYEOF
+        env:
+          STAMP_VERSION: ${{ needs.version.outputs.manifest_version }}
+        shell: bash
+
       - name: Install the WiX toolset
         # Pin to WiX v5: v6+ require accepting the Open Source Maintenance Fee (OSMF) EULA,
         # which cannot be done non-interactively and fails the build with WIX7015. v5 is the
@@ -179,6 +208,35 @@ jobs:
               json.dump(manifest, f, indent=2)
               f.write("\n")
           EOF
+
+      - name: Stamp Directory.Build.props with the release-candidate version
+        # The host reports this version to the extension over `ping`, prints it for `--version` and
+        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
+        # the tag above, so without this the packages are *named* from the tag while the binary
+        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
+        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
+        # tree; this keeps them equal in a build stamped from a tag.
+        run: |
+          python3 - "$STAMP_VERSION" <<'PYEOF'
+          import re
+          import sys
+
+          version = sys.argv[1].strip()
+          if not version:
+              raise SystemExit("no version to stamp into Directory.Build.props")
+          path = "Directory.Build.props"
+          with open(path) as f:
+              props = f.read()
+          props, found = re.subn(
+              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
+          if found != 1:
+              raise SystemExit(path + " has no <Version> element to stamp")
+          with open(path, "w") as f:
+              f.write(props)
+          PYEOF
+        env:
+          STAMP_VERSION: ${{ needs.version.outputs.manifest_version }}
+        shell: bash
 
       - name: Package extension
         id: package

--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -77,10 +77,15 @@ installed and link to the install instructions.
 | `downloads` | Save edited PDFs and the redaction/compliance reports to the user's computer. |
 | `storage` | Persist user preferences (activity-console state, optional Cloudflare credentials) locally. |
 | `contextMenus` | Right-click actions (Edit, Redact, Highlight, etc.) on selected text and pages. |
-| `webNavigation` / `tabs` | Detect when the user navigates to a PDF so the editor can offer to open it, and open the editor in a tab. |
+| `webNavigation` | Detect when the user navigates to a PDF so the editor can offer to open it. One top-frame-only listener, restricted to `.pdf` URLs, and only while the user leaves `autoOpen` on. |
 | `host_permissions: <all_urls>` | PDFs can live on **any** site; the content script must run everywhere to detect them and show the "Edit in PDF Editor" control. It reads only enough to recognise a PDF; it does not collect page content. |
 
-> **Minimise if you can.** `<all_urls>` + `tabs` + `webNavigation` draw the most scrutiny. If the
+> **No `tabs` permission.** `chrome.tabs.create()` and `chrome.tabs.update()` need no permission at
+> all, and the only sensitive `Tab` property the extension reads — `tab.url`, in
+> `extension/src/background.js` — is already populated by the `<all_urls>` host permission. `tabs`
+> was therefore redundant and has been dropped; do not add it back without a call site that needs it.
+
+> **Minimise if you can.** `<all_urls>` + `webNavigation` draw the most scrutiny. If the
 > "detect a PDF on any page" feature can tolerate `activeTab`/narrower matches, consider it — but
 > the current auto-detect-anywhere behaviour does need broad access, so justify it as above.
 

--- a/docs/RELEASE_NOTES_2.0.2.md
+++ b/docs/RELEASE_NOTES_2.0.2.md
@@ -1,0 +1,103 @@
+# PDF Editor 2.0.2
+
+2.0.1 shipped native-host installers for every OS. 2.0.2 is about the gap that left: a package
+could install perfectly and the browser still not find the host — and nothing in the extension
+said so. This release fixes the packaging faults that caused it, and makes the extension diagnose
+the rest instead of failing silently.
+
+The editing features are unchanged from 2.0.0.
+
+## Highlights
+
+- **The Linux packages now register with every Chromium browser you might actually be running.**
+  The manifest went to 7 directories, all of them stable channels. It now goes to 18: the beta and
+  dev channels of Chrome, Edge, Brave and Opera, Brave's and Vivaldi's alternate paths, and Chrome
+  for Testing. Chromium compiles its native-messaging directory in and treats every channel as a
+  separate product, so Chrome Beta and Edge Dev were reading a directory the package never wrote
+  to.
+- **Snap and flatpak browsers have a supported route.** Those are sandboxed away from `/etc`, so no
+  system-wide registration can ever reach them. The packages now ship
+  **`pdf-editor-host-register`**, which registers the host per-user across the plain `~/.config`,
+  snap and flatpak layouts, prints the `flatpak override` command a flatpak browser needs, and
+  removes what it wrote with `--uninstall`.
+- **The Windows MSI installs where every instruction says it does.** It was built as a 32-bit
+  package, so Windows Installer redirected it to `C:\Program Files (x86)` and put its registry keys
+  under `WOW6432Node` — while the README, the extension's guidance and the installer's own
+  registration script all pointed at `C:\Program Files\PDF Editor Host`. The MSI is now x64, and
+  the build fails if it ever isn't.
+- **The extension tells you when the host isn't there, and what to do about it.** A failed
+  connection is now sorted into *not installed*, *installed but not allowed for this extension*,
+  and *installed but won't start* — three states the browser reports in near-identical words that
+  need completely different fixes — each with numbered, copyable, per-platform commands. The
+  toolbar icon carries a badge while the host is unreachable, and the viewer's empty state says so
+  where you hit it rather than only in a settings page you'd have to find.
+- **The host reports a real version, and a mismatch is named before you hit it.** An out-of-date
+  host answers a ping perfectly well and then does nothing useful for anything added since it was
+  built. The options page now shows both versions and flags the mismatch.
+
+## Improvements & fixes
+
+- **Packages declare their runtime dependencies and self-test on install.** A self-contained .NET
+  build still needs the system ICU and OpenSSL; without them the host exits immediately and the
+  browser reports it exactly like a host that was never installed. The `.deb` declared no
+  dependencies at all. All three Linux packages now run the host once at install time and print the
+  exact remedy if it doesn't start.
+- **`pdf-editor-host` is on your `PATH`.** The packages symlink the host into `/usr/bin`, which
+  a sandboxed browser is far likelier to be permitted to execute, and which makes
+  `pdf-editor-host --diagnostics` available without involving a browser at all.
+- **Flatpak gets a path flatpak will actually share.** Flatpak reserves `/usr`, `/etc`, `/app`,
+  `/dev` and `/proc` and refuses to bind-mount anything inside them, so a manifest naming
+  `/usr/bin/pdf-editor-host` pointed a flatpak browser at a file it does not have — and the
+  `flatpak override` command we shipped named a reserved path, which failed the whole command and
+  granted nothing. Flatpak registrations now use `/opt`, which flatpak does not reserve.
+- **A stale per-user manifest is diagnosed instead of blamed on your extension ID.** Chromium reads
+  `~/.config/...` before `/etc`, so an old `install-host.sh <id>` keeps winning long after a correct
+  package is installed. The extension now tells you to *remove* it; the previous advice — re-register
+  for your ID — wrote the shadowing file rather than removing it.
+- **Every shipped PowerShell script is invoked through an explicit execution-policy bypass.**
+  Windows client editions default to `Restricted`, under which the commands we published were
+  refused before their first line ran.
+- **`register-host.ps1` ships inside the MSI.** It previously existed only in a source checkout,
+  so the instructions pointed at a file an installer user did not have.
+- **Copyable diagnostics carry the guidance too**, so a bug report includes the diagnosis rather
+  than just the symptom.
+
+## Release guards
+
+None of this is observable without installing a package — the browser says
+`Specified native messaging host not found.` whether the manifest is missing, in a directory that
+browser doesn't read, or naming a path the package doesn't ship. So the release now proves it:
+
+- `verify-linux-package.sh` unpacks each built `.deb` / `.rpm` / `.pkg.tar.zst` and checks the
+  manifest is in every directory, identical across them, pinned to the right extension ID, and
+  pointing at a path the package ships as an executable.
+- `verify-msi.ps1` does the same for the MSI, including that it is a 64-bit package installing
+  under the 64-bit Program Files.
+- A CI job installs the real `.deb`, launches a browser with the extension loaded and **no**
+  registration of its own, and renders a PDF through whatever the package left behind. This is
+  what caught the missing Chrome for Testing directory.
+
+All three run before artifacts are attached to a release.
+
+## Installing / upgrading
+
+- **From the Chrome Web Store:** update the extension, then reinstall the host package for your
+  platform to pick up the wider browser coverage. The options page's **Native host** section will
+  tell you if the two are out of step.
+- **Snap or flatpak browser:** install the package for your distro, then run
+  `pdf-editor-host-register` and follow the `flatpak override` line it prints.
+- **Already installed the Windows MSI?** The old one installed to `C:\Program Files (x86)`. It
+  still works there and every command we document finds either location; to move it, uninstall
+  from *Apps & features* and install the 2.0.2 MSI.
+- **Host connects but a feature does nothing?** That is the version mismatch this release added a
+  check for — install the host package matching your extension version.
+
+## Notes
+
+- Firefox is still not covered — it uses a different native-messaging manifest format.
+- The OS packages pin to the published Chrome Web Store extension ID. A developer-mode/unpacked
+  build has a different ID: register it with
+  `pdf-editor-host-register --extension-id <your-id>` (Linux) or
+  `register-host.ps1 -ExtensionId <your-id>` (Windows).
+
+**Full changelog:** #122 (since 2.0.1).

--- a/docs/RELEASE_NOTES_2.0.3.md
+++ b/docs/RELEASE_NOTES_2.0.3.md
@@ -1,0 +1,49 @@
+# PDF Editor 2.0.3
+
+A small release with no changes to editing. 2.0.3 drops a browser permission the extension never
+needed, and fixes the version number the host reports about itself.
+
+## Highlights
+
+- **The extension no longer asks for the `tabs` permission.** It was never required. The two tabs
+  APIs the extension calls — opening the editor in a new tab, and redirecting a PDF navigation into
+  it — need no permission at all, and the one piece of tab information it reads (the address of the
+  PDF you asked it to open) is already covered by the site access it holds. Chrome was being asked
+  for a capability that went unused. Everything behaves exactly as before; the extension simply
+  requests less.
+- **The host reports its real version.** The version number was stamped into the extension at
+  release time but never into the host binary, so the 2.0.2 packages were *named* 2.0.2 while the
+  host inside them still answered **2.0.0** — on the options page, to `pdf-editor-host --version`
+  and in `--diagnostics`. The release now stamps both from the same tag.
+
+## About that version number
+
+If you installed the 2.0.2 host, its **Native host** section reads `Host v2.0.0` next to
+`extension v2.0.2`. Nothing is wrong with that install: it is a correct 2.0.2 host that
+misreports its own version, and the mismatch check compares major and minor only, so it was never
+flagged. Installing the 2.0.3 package corrects the number.
+
+The reason it is worth a release rather than a note: the comparison is what puts a *"your host is
+out of date"* warning in front of users, and at the next minor version a host that under-reports
+itself by two patch levels would start failing that check while being perfectly current.
+
+## Installing / upgrading
+
+- **From the Chrome Web Store:** the extension updates itself. Because 2.0.3 *removes* a
+  permission and adds none, Chrome applies the update silently — there is no prompt to accept and
+  nothing to re-approve.
+- **Host package:** optional. A 2.0.2 host works correctly with the 2.0.3 extension; reinstall only
+  if you want the reported version to be right. Anyone installing fresh gets the correct number.
+- **Coming from 2.0.1 or earlier:** install the host package for your platform — 2.0.2 is the
+  release that fixed native-host detection on Linux and moved the Windows MSI to
+  `C:\Program Files\PDF Editor Host`. See the [2.0.2 notes](RELEASE_NOTES_2.0.2.md).
+
+## Notes
+
+- Firefox is still not covered — it uses a different native-messaging manifest format.
+- The OS packages pin to the published Chrome Web Store extension ID. A developer-mode/unpacked
+  build has a different ID: register it with
+  `pdf-editor-host-register --extension-id <your-id>` (Linux) or
+  `register-host.ps1 -ExtensionId <your-id>` (Windows).
+
+**Full changelog:** #123 (since 2.0.2).

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,8 +10,7 @@
     "downloads",
     "storage",
     "webNavigation",
-    "contextMenus",
-    "tabs"
+    "contextMenus"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/extension/test/manifest-permissions.test.mjs
+++ b/extension/test/manifest-permissions.test.mjs
@@ -1,0 +1,57 @@
+// Guards the permission list against creep. Run with:
+//   node --test extension/test/manifest-permissions.test.mjs
+//
+// The Chrome Web Store rejects a version that asks for a permission it does not need, and every
+// permission here has to be justified by hand in the dashboard at submission time. That makes an
+// unused entry expensive in a way a normal unused declaration is not: it costs a review cycle, and
+// the reviewer finds it before we do.
+//
+// `tabs` is the specific mistake this exists to prevent a second time. It looks required — the
+// service worker calls chrome.tabs.create() and chrome.tabs.update(), and reads tab.url — but none
+// of that needs it. create/update need no permission at all, and `tabs` only gates the sensitive
+// Tab properties (url, title, favIconUrl), which Chrome also populates for any tab matched by a
+// host permission. We hold <all_urls>, so tab.url arrives either way; verified in a real browser
+// with the permission removed. It was declared for years and never did anything except draw
+// scrutiny to the submission.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+
+const manifest = JSON.parse(repoFile('extension/manifest.json'));
+
+// Each of these is backed by a call site that stops working without it.
+const EXPECTED = {
+  nativeMessaging: 'chrome.runtime.connectNative in src/host-client.js — the extension does nothing without the host',
+  downloads: 'chrome.downloads.download in src/viewer.js — saved PDF, redaction report, activity log, signing certificate',
+  storage: 'chrome.storage.sync/local in src/options.js, src/background.js and src/viewer.js',
+  webNavigation: 'chrome.webNavigation.onBeforeNavigate in src/background.js — the auto-open-a-PDF feature',
+  contextMenus: 'chrome.contextMenus.create in src/background.js — the two right-click entries',
+};
+
+test('the manifest declares every permission it needs and nothing else', () => {
+  assert.deepEqual(
+    [...manifest.permissions].sort(), Object.keys(EXPECTED).sort(),
+    'the permission list changed; a new entry needs a call site that fails without it, and a store '
+    + 'justification written for it — see docs/CHROME_WEB_STORE.md §4');
+});
+
+test('the manifest does not ask for the tabs permission', () => {
+  // Called out separately from the list above so the failure names the reason rather than just
+  // showing a diff of two arrays.
+  assert.ok(
+    !manifest.permissions.includes('tabs'),
+    'tabs is redundant: chrome.tabs.create/update need no permission, and tab.url is already '
+    + 'populated by the <all_urls> host permission. Declaring it only adds review scrutiny.');
+});
+
+test('the permissions the store scrutinises most are still the ones we justified', () => {
+  // <all_urls> is what the content script needs to spot a PDF on an arbitrary page. If it is ever
+  // narrowed, the justification in docs/CHROME_WEB_STORE.md has to be rewritten to match.
+  assert.deepEqual(manifest.host_permissions, ['<all_urls>']);
+  assert.ok(
+    manifest.content_scripts.every((entry) => entry.matches.includes('<all_urls>')),
+    'the content script match pattern and the host permission have to tell the same story');
+});


### PR DESCRIPTION
Retargeted from 2.0.2 to **2.0.3**. `v2.0.2` was published from `main` on 28 Aug before this branch merged, so its content shipped without the version fix below — that fix now repairs something already released rather than preventing it.

## Drop the `tabs` permission

The Chrome Web Store rejects a version that requests a permission it does not need, and `tabs` was one. Nothing in the extension requires it:

- `chrome.tabs.create()` and `chrome.tabs.update()` — the only tabs APIs the service worker calls — need no permission at all.
- `tabs` gates the sensitive `Tab` properties. The only one read anywhere is `tab.url`, at `background.js:49` and `:130`, both guarded by `looksLikePdfUrl`. Chrome also populates those for any tab matched by a host permission, and we hold the all-URLs pattern &lt;all_urls&gt;.

Verified rather than assumed — the extension was loaded unpacked with the permission removed, and its service worker was asked directly:

- `chrome.permissions.getAll()` returned permissions `["contextMenus","downloads","nativeMessaging","storage","webNavigation"]` and a single granted origin, &lt;all_urls&gt;. `tabs` was **not** granted.
- `chrome.tabs.query({})` on that same worker still returned `url: "https://example.com/some/doc.pdf"` and `title: "example.com/some/doc.pdf"` for the matching tab.

So `tab.url` and `tab.title` still arrive. No behaviour change; the submission asks for one fewer of the three permissions reviewers scrutinise most, and because the update only *removes* a permission Chrome applies it silently, with no prompt for users to accept.

`extension/test/manifest-permissions.test.mjs` holds the list to the call sites that back it, so a permission cannot reappear without a justification being written for it. It fails 2 of its 3 tests with `tabs` restored.

## Stamping `Directory.Build.props`

Both release workflows rewrite `extension/manifest.json` from the tag before packaging, and the packagers read the package version out of it. Nothing touched `Directory.Build.props`, where the host's assembly version comes from.

That is not hypothetical any more. `v2.0.2` shipped from `main` at `59a27f2`, which has no such step, so the published packages are named 2.0.2 around a host that reports **2.0.0** — on the options page, to `--version` and in `--diagnostics`. Those installs are otherwise correct, and the mismatch check compares major.minor so it was never flagged, but the number shown is wrong and the next minor bump would put a spurious "your host is out of date" warning in front of current users.

Added as a separate step after each existing manifest stamp rather than folded into it, so the working path is untouched, and it fails loudly on an empty version or a missing &lt;Version&gt; element rather than silently writing an empty one. Four sites: the MSI and packaging jobs of `populate-draft-release.yml` and `release-candidate.yml`. `release-extension.yml` is left alone — it only builds the extension zip.

## Release notes

`docs/RELEASE_NOTES_2.0.3.md` covers the two changes above. `docs/RELEASE_NOTES_2.0.2.md` is kept as written — it is the body of a release that has already gone out, and editing it would make the file disagree with the published notes.

## Testing

Locally: `node --test "extension/test/**/*.test.mjs"` — 112 pass (109 + 3 new); `node scripts/check-innerhtml.mjs` — clean. Plus the unpacked-browser check above, and the guard test verified in both directions.

In CI, all 30 checks pass on `ec8ff70`. The one worth naming is **`package-install-e2e`**: it installs the real `.deb`, launches a browser with the extension loaded and no registration of its own, and renders a PDF end to end — independent confirmation that dropping `tabs` did not break the `tab.url` reads.

## Cutting the release

Unchanged and still manual: merge this, create an empty **draft** Release tagged `v2.0.3` with these notes as the body, run **Populate draft release** with that tag, review the attached binaries, then publish. Publishing is what deploys to the Chrome Web Store, so it stays a human step.

Order matters for the store submission: the manifest change only reaches the Web Store through a build, so the `v2.0.3` draft must be created **after** this merges — otherwise the zip is built from a `main` that still declares `tabs`, and the submission will not match the permission justifications filed against it.