### PR TITLE
Fix the redaction Privacy controls silently falling back to Exact, and add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend_capability_gap.yml
+++ b/.github/ISSUE_TEMPLATE/backend_capability_gap.yml
@@ -1,0 +1,92 @@
+name: Backend capability gap
+description: A capability that does not carry across a PDF backend change, tracked against the iText decoupling work (#115).
+title: "Backend gap: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for a capability the current backend provides and a candidate backend does not —
+        or provides differently enough that the behaviour, the report shape, or the host's JSON
+        contract would change.
+
+        Background: **#115** (should the engine change) and **#116** (the abstraction seam).
+        `docs/backend-portability.md` records the structural blockers and the workarounds that
+        already exist for them.
+
+        A gap is only worth filing if a user could notice it. "The code has to be rewritten" is
+        migration work, not a capability gap.
+
+  - type: input
+    id: action
+    attributes:
+      label: Host action
+      description: The action name from MessageProcessor's dispatch table, or `—` if this is cross-cutting.
+      placeholder: redact
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Regression — the capability is lost or visibly degraded
+        - Rework — reachable, but the behaviour has to be re-derived rather than translated
+        - Infrastructure — no user-visible capability, but the migration cannot proceed without it
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: How it works today
+      description: The current implementation, and which low-level types it depends on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: gap
+    attributes:
+      label: What is missing
+      description: >
+        Be specific about what is unavailable rather than merely different. If a public API covers
+        part of it, say which part.
+    validations:
+      required: true
+
+  - type: textarea
+    id: user-impact
+    attributes:
+      label: What a user would notice
+      description: >
+        The observable difference. If the answer is "nothing, until they inspect the output",
+        say that — a silent fidelity loss is more dangerous than a visible one, not less.
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Possible approach
+      description: >
+        Options might include: a public API that covers it after all, low-level work through
+        PdfSharp, an upstream request, or accepting the regression and documenting it.
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] …
+        - [ ] Existing tests still pass, and a new test covers the gap specifically
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: How this was determined
+      description: >
+        Source read, an API probe, a compiled prototype, or a measurement. Say which — the
+        distinction matters, and the original survey got some of this wrong by assuming.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Something in the extension or the native host behaves incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If the bug involves a specific PDF, please say how it was produced (Chrome print-to-PDF,
+        Word export, a scanner, and so on). Producer-specific structure is behind a large share of
+        the defects in this project.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open …
+        2. Select …
+        3. Click …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Viewer / rendering
+        - Text editing
+        - Redaction
+        - Forms
+        - Annotations, highlights, ink
+        - Watermark / Bates / stamps
+        - Security, signing, sanitisation
+        - OCR
+        - Native host / installation
+        - Other or not sure
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: Chrome 141 / Edge 141 / Brave 1.8x
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Windows 11 24H2 / macOS 15.2 / Ubuntu 24.04
+
+  - type: input
+    id: version
+    attributes:
+      label: Extension version
+      description: Shown in the extension's Help or About panel.
+
+  - type: textarea
+    id: document
+    attributes:
+      label: Document characteristics
+      description: >
+        Encrypted? Signed? Scanned or born-digital? Which producer wrote it? Please do not attach a
+        document containing anything you would not publish — this is a public tracker.
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Native host output or console errors
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/ZanattaMichael/Chromium-PDF-Editor/security/advisories/new
+    about: Report privately through a security advisory. Please do not open a public issue for a vulnerability in redaction, sanitisation, or the native host.
+  - name: Question or idea
+    url: https://github.com/ZanattaMichael/Chromium-PDF-Editor/discussions
+    about: Ask about usage, or float an idea before it is a concrete request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a capability the extension does not have yet.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that the extension does not let you do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like it to do
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Viewer / rendering
+        - Text editing
+        - Redaction
+        - Forms
+        - Annotations, highlights, ink
+        - Watermark / Bates / stamps
+        - Security, signing, sanitisation
+        - OCR
+        - Native host / installation
+        - Other or not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you have considered
+      description: Including any workaround you are using now.

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -16,8 +16,9 @@ _Generated 2026-07-28. Source: 40 open issues (#17–#56) on `zanattamichael/chr
 sequenced after #52 so it can assert with that validator rather than reinventing one.
 
 Issues raised by this work, not in the original 40: **#72** (bare `catch {}` hides
-render failures), **#74** (ban interpolated `innerHTML` in `extension/src`). A
-client-side XSS found by the new code scanning was fixed in #73.
+render failures), **#74** (ban interpolated `innerHTML` in `extension/src`), **#146**
+(batch redaction from a configuration file, filed into Tier 6). A client-side XSS
+found by the new code scanning was fixed in #73.
 
 Two corrections to the sequencing below, learned in practice:
 
@@ -122,11 +123,21 @@ not breaking structure once the others are stable.
 - **#48 — Auditable redaction report**
 - **#49 — Redaction recovery-resistance guarantees (tests/verification)**
 - **#51 — Undo/redo cross-operation atomicity**
+- **#146 — Batch redaction across many documents from a configuration file**
 
 Do #49 before shipping #48's "redaction complete" messaging — an audit report is only
 trustworthy once recovery-resistance is verified. #51 (undo/redo atomicity) is
 higher-risk correctness work that benefits from the regression suite (Tier 2) being in
 place first.
+
+#146 comes last in this tier, and deliberately so: it applies the same redaction to a
+whole directory unattended, which multiplies whatever the single-document path gets
+wrong. It needs #49's recovery-resistance verification first, and it should emit #48's
+report per document rather than inventing a second reporting format. Four pieces are
+missing before it can be built — regex matching in `TextTools` (with a bounded
+evaluation, since the patterns arrive from a file), a `--batch` entry point beside
+`HostDiagnostics.TryRunCli`, config parsing that names the offending rule when it
+rejects one, and the multi-document orchestration itself.
 
 ## Tier 7 — Diff / review tooling
 
@@ -160,7 +171,7 @@ since both touch the same image-import pipeline.
 3. **Text/font fidelity**: #29, #28, #34, #35, #32, #33, #31
 4. **Rendering/geometry**: #36, #38, #40, #37, #39, #45
 5. **Forms**: #42, #43, #44, #17
-6. **Redaction/undo**: #49, #48, #51
+6. **Redaction/undo**: #49, #48, #51, #146
 7. **Diff tooling**: #46, #47
 8. **Performance**: #50
 9. **New features**: #25, #26, #55, #27, #30, #41

--- a/e2e/tests/viewer.spec.js
+++ b/e2e/tests/viewer.spec.js
@@ -385,7 +385,7 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await page.close();
   });
 
-  test('redaction: "Apply to all" sets the Privacy level on existing marked areas (#privacy)', async () => {
+  test('redaction: the Privacy slider governs areas that were already marked (#privacy)', async () => {
     const file = fixture('privacy-all.pdf', [[
       { text: 'SECRET', x: 72, y: 700 },
       { text: 'PUBLIC', x: 320, y: 700 },
@@ -398,12 +398,13 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     await expect(page.locator('#redact-list li')).toContainText('#1 p1');
     await expect(page.locator('#redact-list li')).not.toContainText('Full line');
 
-    // Raise Privacy to Full line and push it onto the existing area.
+    // Raise Privacy to Full line. Marking first and choosing the level afterwards is the ordinary
+    // order of work, so the already-marked area has to follow the slider rather than keep the
+    // weaker level it was drawn under — otherwise the box silently comes back exact.
     await page.locator('#redact-intensity').evaluate((el) => {
       el.value = '3';
       el.dispatchEvent(new Event('input'));
     });
-    await page.click('#redact-apply-all');
     await expect(page.locator('#redact-list li')).toContainText('Full line');
 
     await page.click('#redact-apply');
@@ -510,8 +511,8 @@ test.describe('PDF Editor end-to-end (extension + native host)', () => {
     const page = await openViewerWith(file);
 
     await ui(page, '#tool-redact');
-    // Privacy intensity 3 = "Full line". Set it before marking so the box captures the level;
-    // "Apply to all" would also push it onto existing boxes.
+    // Privacy intensity 3 = "Full line". The order does not matter — the slider governs areas
+    // marked before it moves as well as after — but here it is chosen up front.
     await page.locator('#redact-intensity').evaluate((el) => {
       el.value = '3';
       el.dispatchEvent(new Event('input'));

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -682,7 +682,6 @@ body.drag-over::after {
 .redact-privacy-label { display: block; margin-bottom: 4px; }
 #redact-intensity { display: block; width: 100%; box-sizing: border-box; margin: 0; }
 #redact-privacy-hint { font-size: 11px; margin: 0 0 8px; }
-#redact-privacy-hint button { margin-top: 4px; font-size: 12px; }
 
 /* Visual diff (#46/#47). */
 .compare-jump { background: none; border: none; padding: 0; color: var(--accent-2, #1a73e8); cursor: pointer; text-decoration: underline; font: inherit; }

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -135,8 +135,7 @@
           <input id="redact-intensity" type="range" min="0" max="4" step="1" value="0"
             aria-label="Redaction privacy intensity" />
         </label>
-        <div id="redact-privacy-hint" class="muted">New areas use this level; press “Apply to all” to change existing ones.
-          <button id="redact-apply-all" type="button">Apply to all</button></div>
+        <div id="redact-privacy-hint" class="muted">Applies to every marked area, including ones already drawn.</div>
         <div class="actions">
           <button id="redact-preview" disabled>👁 Preview</button>
           <button id="redact-apply" class="danger" disabled>Apply redaction</button>

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -4348,15 +4348,15 @@ function wire() {
   $('redact-apply').addEventListener('click', () => applyRedaction());
   $('redact-clear').addEventListener('click', () => { state.regions = []; drawRegions(); });
   // Privacy intensity: 0 exact, 1 merge adjacent boxes, 2 round widths, 3 full line, 4 textured.
+  // The slider governs every marked area, not just the ones drawn after it moves. Snapshotting the
+  // level at mark time left the common order of work — mark the areas, then decide how private the
+  // boxes should be — applying the old, weaker level while the control read the new one, so the
+  // boxes came back wrapping the text exactly and the merging and rounding appeared not to work.
   $('redact-intensity').addEventListener('input', (e) => {
-    $('redact-intensity-label').textContent = REDACT_INTENSITY[Number(e.target.value)] ?? 'Exact';
-  });
-  // "Apply to all" sets every already-marked area to the current Privacy level (global override).
-  $('redact-apply-all').addEventListener('click', () => {
-    if (state.regions.length === 0) { toast('No marked areas to update.'); return; }
-    for (const r of state.regions) r.intensity = redactIntensity();
+    const level = Number(e.target.value);
+    $('redact-intensity-label').textContent = REDACT_INTENSITY[level] ?? 'Exact';
+    for (const r of state.regions) r.intensity = level;
     drawRegions();
-    toast(`Set all marked areas to “${REDACT_INTENSITY[redactIntensity()]}”.`);
   });
   $('redact-search-btn').addEventListener('click', searchAndMarkRedactions);
   $('redact-search-text').addEventListener('keydown', (e) => {

--- a/src/PdfEditor.Core/RedactionBox.cs
+++ b/src/PdfEditor.Core/RedactionBox.cs
@@ -25,6 +25,11 @@ public static class RedactionBox
     private const float Grid = 72f;
     private const float Margin = 18f;
 
+    // The least a quantized box may grow. Rounding a raw width up to the grid can widen it by
+    // almost nothing — a 71pt run lands on 72 — leaving a box that still traces the text and
+    // reports its length, which is the mode's whole reason to exist.
+    private const float MinWiden = Grid / 2f;
+
     /// <summary>
     /// Prepares the boxes for a given privacy intensity (0–3): 0 leaves them exact; 1 merges
     /// adjacent boxes on a line (so two redactions split by a space read as one, hiding the word
@@ -139,7 +144,10 @@ public static class RedactionBox
     {
         float left = crop.GetLeft(), right = crop.GetRight();
         float pageWidth = Math.Max(r.Width, right - left);
-        float width = Math.Clamp(MathF.Ceiling(r.Width / Grid) * Grid, r.Width, pageWidth);
+        // Quantizing r.Width + MinWiden rather than r.Width keeps the bucketing — widths within one
+        // band still collapse onto a single value — while guaranteeing the box clears the text by at
+        // least half a grid step, so it can never come back hugging the glyphs it covers.
+        float width = Math.Clamp(MathF.Ceiling((r.Width + MinWiden) / Grid) * Grid, r.Width, pageWidth);
         // min(r.X, right - width) slides the box left just enough to fit; clamping to [left, r.X]
         // keeps it on the page while guaranteeing the original stays fully covered.
         float x = Math.Clamp(Math.Min(r.X, right - width), left, r.X);

--- a/tests/PdfEditor.Core.Tests/RedactionBoxTests.cs
+++ b/tests/PdfEditor.Core.Tests/RedactionBoxTests.cs
@@ -38,13 +38,42 @@ public class RedactionBoxTests
     public void Expand_Quantize_RoundsWidthUpToTheGrid_KeepingTheLeftEdge()
     {
         byte[] pdf = TestPdfs.WithText(("secret", 72, 700, 12));
-        var region = new RectRegion(1, 72, 700, 40, 12); // 40pt -> rounds up to 72 (1 inch)
+        var region = new RectRegion(1, 72, 700, 40, 12);
 
         var r = Assert.Single(RedactionBox.Expand(pdf, new[] { region },
             RedactionBox.LengthObfuscation.Quantize));
 
-        Assert.Equal(72f, r.X, 1f);          // left edge preserved
-        Assert.Equal(72f, r.Width, 1f);      // rounded up to the grid
+        Assert.Equal(72f, r.X, 1f);           // left edge preserved
+        Assert.Equal(144f, r.Width, 1f);      // widened, and landing on a grid step
+        Assert.Equal(0f, r.Width % 72f, 1f);
+    }
+
+    [Theory]
+    // Widths that sit just under a grid step are the ones that used to come back barely touched:
+    // 71pt rounded to 72, a box a hair wider than the word it covered, which is the Exact
+    // behaviour wearing the Rounded label (#118).
+    [InlineData(1f)]
+    [InlineData(35f)]
+    [InlineData(36f)]
+    [InlineData(70f)]
+    [InlineData(71f)]
+    [InlineData(72f)]
+    [InlineData(143f)]
+    [InlineData(200f)]
+    public void Expand_Quantize_AlwaysClearsTheTextByHalfAGridStep(float width)
+    {
+        byte[] pdf = TestPdfs.WithText(("secret", 72, 700, 12));
+        var region = new RectRegion(1, 72, 700, width, 12);
+
+        var r = Assert.Single(RedactionBox.Expand(pdf, new[] { region },
+            RedactionBox.LengthObfuscation.Quantize));
+
+        // A box that traces the glyphs still reports their length, whatever the mode is called.
+        Assert.True(r.Width >= width + 36f,
+            $"a {width}pt box widened only to {r.Width}pt, close enough to still trace the text");
+        Assert.Equal(0f, r.Width % 72f, 1f);
+        Assert.True(r.X <= region.X && r.X + r.Width >= region.X + region.Width,
+            "the widened box must still cover the original");
     }
 
     [Fact]
@@ -68,12 +97,13 @@ public class RedactionBoxTests
     {
         byte[] pdf = TestPdfs.WithText(("x", 72, 700, 12));
         var shortR = new RectRegion(1, 72, 700, 20, 12);
-        var longR = new RectRegion(1, 72, 700, 60, 12);
+        var longR = new RectRegion(1, 72, 700, 34, 12);
 
         var a = Assert.Single(RedactionBox.Expand(pdf, new[] { shortR }, RedactionBox.LengthObfuscation.Quantize));
         var b = Assert.Single(RedactionBox.Expand(pdf, new[] { longR }, RedactionBox.LengthObfuscation.Quantize));
 
-        // 20pt and 60pt both round up to one grid step — the length is no longer distinguishable.
+        // Two lengths inside one band come back as the same box — which is the whole point of
+        // bucketing, and survives widening the box to clear the text.
         Assert.Equal(a.Width, b.Width, 1f);
     }
 
@@ -131,6 +161,21 @@ public class RedactionBoxTests
 
         Assert.Equal(72f, merged.X, 1f);
         Assert.Equal(160f, merged.X + merged.Width, 1f);
+    }
+
+    [Fact]
+    public void Prepare_Intensity2_MergesAndThenRoundsTheJoinedBox()
+    {
+        // Both halves of level 2 have to fire: the two words become one box, and that box is
+        // widened past the text rather than left wrapping it.
+        byte[] pdf = TestPdfs.WithText(("x", 72, 700, 12));
+        var regions = new[] { new RectRegion(1, 72, 700, 40, 12), new RectRegion(1, 120, 700, 40, 12) };
+
+        var r = Assert.Single(RedactionBox.Prepare(pdf, regions, 2));
+
+        Assert.Equal(72f, r.X, 1f);
+        Assert.True(r.Width >= 88f + 36f, "the merged 88pt box should be widened, not traced");
+        Assert.Equal(0f, r.Width % 72f, 1f);
     }
 
     [Fact]


### PR DESCRIPTION
Split out of #124 per #154. Three commits, no dependency on the other two pieces.

## The Privacy controls fell back to Exact (closes #118)

Reported as the Privacy levels sometimes not merging or rounding, and instead coming back wrapping the text exactly. That is the *Exact* behaviour wearing another label. Two independent defects, both fixed.

**Worth being precise about what leaked**, because the two failing levels are not equally serious. The marked text is removed from the document at every level; the level governs only the shape of the box drawn over it. So *Merge words* and *Rounded* falling back to *Exact* leaked the box's shape and the removed text's length. ***Full line* falling back to *Exact* is materially worse** — that level exists to cover the whole line, and a box around just the marked phrase means the rest of the line stayed readable in the document. #153 covers saying so in the release notes.

### The slider snapshotted its level at mark time

`markRegion` stamped `region.intensity` with whatever the slider read when the area was drawn, and `MessageProcessor.Redact` prefers that per-region value over the global one on the payload.

The ordinary order of work — mark the areas, then decide how private the boxes should be — therefore left every area on the older, weaker level while the control read "Rounded". Whether the fix fired depended entirely on whether the slider moved before or after the marking, which is why it looked intermittent rather than broken.

The host also groups regions by their *effective* level before preparing each group, so a set with mixed levels could never merge across the groups either.

The slider now governs every marked area. That makes "Apply to all" redundant, and it is removed.

### `RedactionBox.Quantize` could widen by almost nothing

Rounding the raw width up to the 72pt grid widens a box by however far it happens to sit below the next grid line. A 71pt run landed on 72 — a box a hair wider than the word beneath it, which is *Exact* in all but name.

The issue suspected the failing case was a width landing exactly on a multiple. That case is real but measure-zero; landing just under one is common, and is what users were hitting.

It now quantizes `r.Width + Grid / 2`, which keeps the bucketing — widths inside one band still collapse onto a single value, so the box width still says nothing about the text length — while guaranteeing the box clears the text by at least half a grid step.

## Issue templates

The repository had no `.github/ISSUE_TEMPLATE/` at all, so every issue arrived as free-form prose.

| File | Purpose |
| --- | --- |
| `config.yml` | Keeps blank issues enabled; routes security reports to advisories and questions to discussions. |
| `bug_report.yml` | What happened, steps, area dropdown, browser, OS, extension version, document characteristics, native host logs. |
| `feature_request.yml` | Problem, proposal, area, alternatives considered. |
| `backend_capability_gap.yml` | For the backend decoupling work: host action, severity, how it works today, what is missing, what a user would notice, possible approach, acceptance criteria, and **how this was determined**. |

That last field is the one worth keeping. It forces the difference between "the docs imply this is missing" and "I compiled a prototype and watched it fail" to be stated on the issue rather than inferred from tone. Issues #125–#145 and #151 follow that shape.

## Plan update

`ACTION_PLAN.md` gains #146 (batch redaction from a configuration file) under Tier 6, last in the tier and behind #49 — applying one rule set to a whole directory unattended multiplies whatever the single-document path gets wrong. Its four prerequisites are #147–#150.

## Testing

```
dotnet test PdfEditor.sln
node --test extension/test/*.mjs
```

640 passed, 0 failed across the .NET projects; 112 passed in the extension suite. Verified on this branch standing alone against `main`, not only as part of #124.

`RedactionBoxTests` gains a theory over the awkward widths (1, 35, 36, 70, 71, 72, 143, 200) asserting the expanded box exceeds the original by at least 36pt and still lands on the grid, plus an intensity-2 test that both merging and rounding fire on one box. The existing bucket test moves to two widths that share a band under the new boundaries. The e2e test that used to click "Apply to all" now asserts the slider reaches an already-marked area on its own.

## Note for review

**A privacy control that snapshots its value is a privacy defect, not a UX one.** The slider showed one level while a weaker one was pending, and weaker is the direction that leaks. That is why the fix makes the slider live rather than making the mismatch more visible to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV5c2TRxLJZ3E6gNXenvBB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VV5c2TRxLJZ3E6gNXenvBB)_