### PR TITLE
Derive the host version from the manifest, replacing #123's release-time stamp

### DIFF
--- a/.github/workflows/populate-draft-release.yml
+++ b/.github/workflows/populate-draft-release.yml
@@ -89,35 +89,6 @@ jobs:
           EOF
         shell: bash
 
-      - name: Stamp Directory.Build.props with the release version
-        # The host reports this version to the extension over `ping`, prints it for `--version` and
-        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
-        # the tag above, so without this the packages are *named* from the tag while the binary
-        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
-        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
-        # tree; this keeps them equal in a build stamped from a tag.
-        run: |
-          python3 - "$STAMP_VERSION" <<'PYEOF'
-          import re
-          import sys
-
-          version = sys.argv[1].strip()
-          if not version:
-              raise SystemExit("no version to stamp into Directory.Build.props")
-          path = "Directory.Build.props"
-          with open(path) as f:
-              props = f.read()
-          props, found = re.subn(
-              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
-          if found != 1:
-              raise SystemExit(path + " has no <Version> element to stamp")
-          with open(path, "w") as f:
-              f.write(props)
-          PYEOF
-        env:
-          STAMP_VERSION: ${{ needs.setup.outputs.manifest_version }}
-        shell: bash
-
       - name: Install the WiX toolset
         # Pin to WiX v5: v6+ require accepting the OSMF EULA non-interactively (fails with WIX7015).
         run: dotnet tool install --global wix --version 5.0.2
@@ -173,35 +144,6 @@ jobs:
           manifest["version"] = sys.argv[1]
           with open(path, "w") as f: json.dump(manifest, f, indent=2); f.write("\n")
           EOF
-
-      - name: Stamp Directory.Build.props with the release version
-        # The host reports this version to the extension over `ping`, prints it for `--version` and
-        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
-        # the tag above, so without this the packages are *named* from the tag while the binary
-        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
-        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
-        # tree; this keeps them equal in a build stamped from a tag.
-        run: |
-          python3 - "$STAMP_VERSION" <<'PYEOF'
-          import re
-          import sys
-
-          version = sys.argv[1].strip()
-          if not version:
-              raise SystemExit("no version to stamp into Directory.Build.props")
-          path = "Directory.Build.props"
-          with open(path) as f:
-              props = f.read()
-          props, found = re.subn(
-              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
-          if found != 1:
-              raise SystemExit(path + " has no <Version> element to stamp")
-          with open(path, "w") as f:
-              f.write(props)
-          PYEOF
-        env:
-          STAMP_VERSION: ${{ needs.setup.outputs.manifest_version }}
-        shell: bash
 
       - name: Package extension
         run: ./scripts/package-extension.sh dist

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -109,35 +109,6 @@ jobs:
           EOF
         shell: bash
 
-      - name: Stamp Directory.Build.props with the release-candidate version
-        # The host reports this version to the extension over `ping`, prints it for `--version` and
-        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
-        # the tag above, so without this the packages are *named* from the tag while the binary
-        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
-        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
-        # tree; this keeps them equal in a build stamped from a tag.
-        run: |
-          python3 - "$STAMP_VERSION" <<'PYEOF'
-          import re
-          import sys
-
-          version = sys.argv[1].strip()
-          if not version:
-              raise SystemExit("no version to stamp into Directory.Build.props")
-          path = "Directory.Build.props"
-          with open(path) as f:
-              props = f.read()
-          props, found = re.subn(
-              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
-          if found != 1:
-              raise SystemExit(path + " has no <Version> element to stamp")
-          with open(path, "w") as f:
-              f.write(props)
-          PYEOF
-        env:
-          STAMP_VERSION: ${{ needs.version.outputs.manifest_version }}
-        shell: bash
-
       - name: Install the WiX toolset
         # Pin to WiX v5: v6+ require accepting the Open Source Maintenance Fee (OSMF) EULA,
         # which cannot be done non-interactively and fails the build with WIX7015. v5 is the
@@ -186,14 +157,9 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Build
-        run: dotnet build --configuration Release
-      - name: Test
-        # Excludes the timing-based performance guards: this solution-wide run executes the suites
-        # in parallel on a shared runner, so their budgets would measure contention and fail at
-        # random. Performance is gated by the dedicated `perf` job in ci.yml instead.
-        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Performance"
-
+      # Stamped before anything is compiled: Directory.Build.props reads the version out of
+      # manifest.json, so a build that ran first would bake in the committed number and the
+      # packagers below could reuse those stale outputs.
       - name: Stamp manifest.json with the release-candidate version
         run: |
           python3 - "${{ needs.version.outputs.manifest_version }}" <<'EOF'
@@ -209,34 +175,13 @@ jobs:
               f.write("\n")
           EOF
 
-      - name: Stamp Directory.Build.props with the release-candidate version
-        # The host reports this version to the extension over `ping`, prints it for `--version` and
-        # `--diagnostics`, and the extension compares the two. Only manifest.json is stamped from
-        # the tag above, so without this the packages are *named* from the tag while the binary
-        # inside them still carries whatever the tree said -- a package called 2.0.2 shipping a host
-        # that reports 2.0.0. extension/test/version-sync.test.mjs keeps the two files equal in the
-        # tree; this keeps them equal in a build stamped from a tag.
-        run: |
-          python3 - "$STAMP_VERSION" <<'PYEOF'
-          import re
-          import sys
-
-          version = sys.argv[1].strip()
-          if not version:
-              raise SystemExit("no version to stamp into Directory.Build.props")
-          path = "Directory.Build.props"
-          with open(path) as f:
-              props = f.read()
-          props, found = re.subn(
-              r"<Version>[^<]*</Version>", "<Version>" + version + "</Version>", props, count=1)
-          if found != 1:
-              raise SystemExit(path + " has no <Version> element to stamp")
-          with open(path, "w") as f:
-              f.write(props)
-          PYEOF
-        env:
-          STAMP_VERSION: ${{ needs.version.outputs.manifest_version }}
-        shell: bash
+      - name: Build
+        run: dotnet build --configuration Release
+      - name: Test
+        # Excludes the timing-based performance guards: this solution-wide run executes the suites
+        # in parallel on a shared runner, so their budgets would measure contention and fail at
+        # random. Performance is gated by the dedicated `perf` job in ci.yml instead.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Performance"
 
       - name: Package extension
         id: package

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -159,6 +159,83 @@ jobs:
             dist/pdf-editor-extension-*.zip
             dist/pdf-editor-bundle-*.zip
 
+  # Write the released version back to extension/manifest.json on the default branch.
+  #
+  # The stamp above lives only in the runner's checkout, so before this job the committed manifest
+  # never moved: it still said 2.0.0 while v2.0.2 was the shipped release. Everything derived from
+  # it inherited that — a host built from a clean checkout reported 2.0.0, and an unpacked
+  # extension loaded from the repo showed 2.0.0 in chrome://extensions no matter how many releases
+  # had gone out. Syncing it here keeps the repository's own number equal to the last thing
+  # actually shipped.
+  #
+  # A separate job, deliberately: it must not sit between `package` and the Chrome Web Store
+  # deploy, and a push that loses a race is not a reason to fail a release that already shipped.
+  # Pushing with GITHUB_TOKEN does not fire another workflow (GitHub's anti-recursion rule), so
+  # this commit does not cut a release candidate of its own.
+  sync-manifest-version:
+    needs: package
+    # Final releases only. A prerelease (every RC) is not what the repository should claim to be.
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false && needs.package.outputs.version != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: "3.x"
+
+      - name: Sync extension/manifest.json to the released version
+        env:
+          RELEASE_VERSION: ${{ needs.package.outputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          python3 - "$RELEASE_VERSION" <<'EOF'
+          import json
+          import sys
+
+          path = "extension/manifest.json"
+          with open(path) as f:
+              manifest = json.load(f)
+          released = tuple(int(p) for p in sys.argv[1].split("."))
+          committed = tuple(int(p) for p in manifest["version"].split("."))
+          # Never walk the number backwards: the default branch may already carry a later version
+          # than the release being published (a hotfix promoted out of order, or a manual bump).
+          if committed >= released:
+              print(f"manifest.json is already at {manifest['version']}; leaving it alone.")
+              sys.exit(0)
+          manifest["version"] = sys.argv[1]
+          with open(path, "w") as f:
+              json.dump(manifest, f, indent=2)
+              f.write("\n")
+          print(f"manifest.json: {'.'.join(map(str, committed))} -> {sys.argv[1]}")
+          EOF
+
+          if git diff --quiet -- extension/manifest.json; then
+            echo "Nothing to sync."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add extension/manifest.json
+          git commit -m "Sync extension/manifest.json to released v$RELEASE_VERSION"
+
+          # Someone may have pushed while the release was building; rebase and retry rather than
+          # failing a release whose artifacts are already out.
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:$DEFAULT_BRANCH"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto $DEFAULT_BRANCH."
+            git fetch origin "$DEFAULT_BRANCH"
+            git rebase "origin/$DEFAULT_BRANCH" || { git rebase --abort; break; }
+          done
+          echo "::warning::Could not sync extension/manifest.json to v$RELEASE_VERSION on $DEFAULT_BRANCH; bump it by hand."
+
   publish-to-chrome-web-store:
     needs: package
     # Only a non-prerelease Release (the manual "promote" step) deploys to the store;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,16 +5,29 @@
     <AnalysisLevel>latest-recommended</AnalysisLevel>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- The version the native host reports to the extension (over the `ping` action, and on
-         the command line via its version and diagnostics flags) and the one the extension checks
-         itself against. Without it every assembly here defaults to 1.0.0.0, so a host built from a
-         2.0.0 tree and shipped in a package *named* 2.0.0 told the browser it was 1.0.0.0.
+  <!-- The version the native host reports to the extension (over the `ping` action, and on the
+       command line via its version and diagnostics flags) and the one the extension checks itself
+       against. Without it every assembly here defaults to 1.0.0.0.
 
-         extension/manifest.json is the single source of truth for the release version (the .deb,
-         .rpm, Arch and MSI packagers all read their version out of it), so this must be kept equal
-         to it. extension/test/version-sync.test.mjs fails if the two ever drift. -->
-    <Version>2.0.0</Version>
+       extension/manifest.json is the single source of truth for the release version, and it is
+       read here rather than copied, because a copy does not survive the release. Both release
+       workflows stamp the computed version into manifest.json alone; the packagers then read their
+       package version out of it and `dotnet publish` the host. A hardcoded <Version> here was never
+       stamped by anything, so every package was *named* with its release version while the binary
+       inside reported the number last committed to this file — 2.0.0 for every release since.
+
+       MSBuild cannot parse JSON, but it can read the file and match the field, which is enough for
+       a value this shape. extension/test/version-sync.test.mjs guards the derivation. -->
+  <PropertyGroup>
+    <ManifestJsonPath>$(MSBuildThisFileDirectory)extension/manifest.json</ManifestJsonPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="Exists('$(ManifestJsonPath)')">
+    <!-- Matches the quoted "version" field, then the number inside it. "manifest_version" and
+         "minimum_chrome_version" do not match: the pattern anchors on the opening quote, and
+         neither is a quoted numeric value. -->
+    <ManifestVersionField>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(ManifestJsonPath)')), '"version"\s*:\s*"[0-9.]+"'))</ManifestVersionField>
+    <Version Condition="'$(ManifestVersionField)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(ManifestVersionField)', '[0-9.]+'))</Version>
   </PropertyGroup>
 
 </Project>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PDF Editor",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK1fIDsukhIoTqFOKiZr6Beg2PtYsnlFkqcxMd31yjMkE7KIwFj8/tc2HoBUICzCbE4YI53TTyq//Fx1beLafT0oRL3LJSN7aMkdutz4mnkOCxVVrP8Og2tZJgp9uLH1OADxzOzhun/5Vj1PvTmDwKIwTjJ6qSN93xOpgzSS5yqiWJbpHthYpsxay5kSiOy4C6qxPKYp/u0s0pVhTjuUUjcgmrAWp/xo5Eov6vLsaonfVJVgcApdaUrBXQ3+uUnQrxR9AdVxcCZ7FL0Am9J/iJ0poha2mss2tarpbn+jZ3GQWwE52a2pNg6MjYElXczApal5b6IL/pqaICG+GQP5lQIDAQAB",
   "description": "Edit text, redact, merge, sign, and password-protect PDFs directly in your browser. Powered by a local native host.",
   "minimum_chrome_version": "116",

--- a/extension/test/version-sync.test.mjs
+++ b/extension/test/version-sync.test.mjs
@@ -1,16 +1,19 @@
-// Guards the one version number this project actually has, against the two files that must agree
+// Guards the one version number this project actually has, against the files that must agree
 // on it. Run with: node --test extension/test/version-sync.test.mjs
 //
-// extension/manifest.json is the source of truth: package-deb.sh, package-rpm.sh, package-arch.sh
-// and package-msi.ps1 all read their package version out of it. Directory.Build.props has to carry
-// the same number separately, because MSBuild cannot read JSON — that is the drift this guards.
+// extension/manifest.json is the source of truth. Both release workflows stamp the computed
+// release version into it and nothing else; package-deb.sh, package-rpm.sh, package-arch.sh,
+// package-bundle.sh and package-msi.ps1 all read their package version out of it; and
+// Directory.Build.props derives the assembly version from it, which is what the host reports
+// to the extension over `ping`.
 //
-// It is worth a test because the failure is silent in both directions. Before Directory.Build.props
-// set a version at all, every assembly defaulted to 1.0.0.0: the .deb was *named* 2.0.0, installed
-// cleanly, connected, and told the extension it was v1.0.0.0. Nothing failed; the number was just
-// wrong everywhere it was shown. Now that the extension compares the two (host-version.js), a drift
-// in the other direction is worse — it puts a "your host is out of date" warning in front of users
-// whose host is perfectly current.
+// It is worth a test because the failure is silent in every direction. Before
+// Directory.Build.props set a version at all, every assembly defaulted to 1.0.0.0: the .deb was
+// *named* 2.0.0, installed cleanly, connected, and told the extension it was v1.0.0.0. Then it
+// carried a hardcoded <Version> that no workflow ever stamped, which is the same bug wearing a
+// different number — packages named with their release version, containing a host that reported
+// whatever was last committed. Nothing fails either way; the number is just wrong everywhere it
+// is shown, and host-version.js compares only major.minor, so the drift raises no banner.
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -19,28 +22,88 @@ import test from 'node:test';
 const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
 
 const manifestVersion = JSON.parse(repoFile('extension/manifest.json')).version;
+const props = repoFile('Directory.Build.props');
+
+// Every workflow that stamps a release version and then builds something shipped.
+const RELEASE_WORKFLOWS = [
+  '.github/workflows/release-candidate.yml',
+  '.github/workflows/release-extension.yml',
+  '.github/workflows/populate-draft-release.yml',
+];
 
 test('the extension manifest carries a plain numeric version', () => {
   // parseVersion() in host-version.js rejects anything else, which would make every install
-  // "unknown" instead of checked.
-  assert.match(manifestVersion, /^\d+(\.\d+)*$/);
+  // "unknown" instead of checked. Up to four parts: a release candidate stamps "2.0.3.51".
+  assert.match(manifestVersion, /^\d+(\.\d+){0,3}$/);
 });
 
-test('Directory.Build.props pins the assembly version to the manifest’s', () => {
-  const props = repoFile('Directory.Build.props');
-  const match = /<Version>([^<]*)<\/Version>/.exec(props);
-  assert.ok(match, 'Directory.Build.props has no <Version> — the host would report 1.0.0.0');
+test('Directory.Build.props derives the assembly version from the manifest', () => {
+  assert.match(
+    props, /ManifestJsonPath[\s\S]*extension\/manifest\.json/,
+    'Directory.Build.props no longer reads extension/manifest.json — the assembly version would '
+    + 'stop tracking the release version');
+  assert.match(
+    props, /<Version Condition=/,
+    'Directory.Build.props should set <Version> only when the manifest could be read, so a build '
+    + 'from a checkout without it still has a defined version');
+});
+
+test('Directory.Build.props hardcodes no version of its own', () => {
+  // The bug this replaced: a literal <Version>2.0.0</Version> that no workflow stamped, so every
+  // release shipped packages named correctly around a host reporting 2.0.0. A literal here would
+  // reintroduce it silently, because it would still *look* right on the release it was written.
+  const literal = /<Version>\s*\d+(\.\d+)*\s*<\/Version>/.exec(props);
   assert.equal(
-    match[1].trim(), manifestVersion,
-    'Directory.Build.props <Version> and extension/manifest.json version have drifted; the host '
-    + 'would report a version the extension flags as a mismatch');
+    literal, null,
+    `Directory.Build.props hardcodes a version (${literal?.[0]}); derive it from the manifest `
+    + 'instead — nothing stamps this file at release time');
+});
+
+test('no workflow stamps a version into Directory.Build.props', () => {
+  // A release-time substitution into this file was the other way to fix the same bug, and it is
+  // the one that breaks now: it matched a literal <Version>…</Version>, which the derivation
+  // above no longer contains, and it exits non-zero when it finds nothing to replace. Stamping
+  // the manifest is the whole job — the props file follows from it.
+  for (const wf of RELEASE_WORKFLOWS) {
+    assert.doesNotMatch(
+      repoFile(wf), /Stamp Directory\.Build\.props/,
+      `${wf} stamps Directory.Build.props; it derives its version from the manifest instead, and `
+      + 'a substitution step there fails the release when it finds no literal to replace');
+  }
 });
 
 test('the packagers all read the version from the manifest, not a copy of their own', () => {
-  // If one of these ever grew its own hardcoded version, the guard above would still pass while
+  // If one of these ever grew its own hardcoded version, the guards above would still pass while
   // the package name and the binary inside it disagreed.
-  for (const script of ['scripts/package-deb.sh', 'scripts/package-rpm.sh', 'scripts/package-arch.sh']) {
+  for (const script of [
+    'scripts/package-deb.sh', 'scripts/package-rpm.sh',
+    'scripts/package-arch.sh', 'scripts/package-bundle.sh',
+  ]) {
     assert.match(repoFile(script), /manifest\.json/, `${script} should derive VERSION from the manifest`);
   }
   assert.match(repoFile('scripts/package-msi.ps1'), /manifest\.json/);
+});
+
+test('the release workflows stamp the manifest before anything is built', () => {
+  // Directory.Build.props reads the manifest at evaluation time, so within a job that packages,
+  // a compile that runs before the stamp bakes in the committed version and the packagers can
+  // reuse those outputs. Jobs that only build and test (release-extension.yml's `verify`) never
+  // stamp and are not part of this — they check out separately and ship nothing.
+  const jobsOf = (yaml) => {
+    const body = yaml.slice(yaml.indexOf('\njobs:\n'));
+    // Job names sit at exactly two spaces of indent; everything up to the next one is that job.
+    return body.split(/\n {2}(?=[a-z][\w-]*:\n)/).slice(1);
+  };
+  for (const wf of RELEASE_WORKFLOWS) {
+    const stamping = jobsOf(repoFile(wf)).filter((job) => job.includes('Stamp manifest.json'));
+    assert.ok(stamping.length > 0, `${wf} should stamp manifest.json with the release version`);
+    for (const job of stamping) {
+      const stamp = job.indexOf('Stamp manifest.json');
+      const compile = job.search(/dotnet (build|publish|test)|\.\/scripts\/package-/);
+      assert.ok(
+        compile === -1 || compile > stamp,
+        `${wf}: ${job.slice(0, job.indexOf(':'))} compiles before stamping the manifest, so its `
+        + 'assemblies would carry the committed version rather than the release version');
+    }
+  }
 });


### PR DESCRIPTION
Split out of #124 per #154. One commit.

**This removes three steps that #123 just merged.** That is the part worth reviewing, so it is stated first rather than buried.

## The defect

The release version was computed and stamped into `extension/manifest.json`, and nowhere else. `Directory.Build.props` carried a hardcoded version element set to `2.0.0` that **no workflow or script had ever written**.

Every packager — `package-deb.sh`, `package-rpm.sh`, `package-arch.sh`, `package-bundle.sh`, `package-msi.ps1` — reads its package version out of the manifest, and then `dotnet publish`es the host at the props version. So every shipped package was *named* with its release version while the native host inside it reported `2.0.0`. `host-version.js` compares only major and minor, deliberately, so the drift never raised a banner; the number was simply wrong everywhere it was displayed. #152 is the open question of whether that comparison should stay as narrow now the number is trustworthy.

## Two fixes for one bug, and why they collide

#123 merged while #124 was open and fixed the same defect the other way: it kept the literal version element and added three steps — two in `populate-draft-release.yml`, one in `release-candidate.yml` — that regex-substitute into it at release time.

This branch removes the literal and derives the version from the manifest instead. MSBuild cannot parse JSON, but it can read the file and match the field, which is enough for a value of this shape.

**They cannot coexist.** #123's substitution matches a bare version element; the derived one carries a `Condition` attribute, so the pattern finds nothing — and the step raises `SystemExit` when the replacement count is not exactly 1. Left in place, they would fail every release build, loudly, at the first stamp step. So this PR deletes them.

**Nothing #123 achieved is lost.** Its goal was that a built package's host report the release version rather than the committed one, and it reached that by writing the number into a second file at release time. Deriving reaches the same result from the one file every release workflow already stamps — and additionally covers what a release-time stamp cannot: a build from a plain checkout, where the props file said `2.0.0` regardless of which release the tree sat on.

If you would rather keep #123's approach, this PR is the thing to drop; they are alternatives, not complements.

## What else changes

**The stamp has to precede compilation**, since the version is now read at evaluation time. In `release-candidate.yml` it sat after `Build` and `Test`, so the assemblies would have been compiled at the committed version and the packagers could have reused those outputs. It moves ahead of `Build`. Both jobs in `populate-draft-release.yml` already stamped before compiling, so they needed the removals and no reordering.

**The committed manifest was the other half of the complaint.** Nothing ever wrote it back after a release, so it still said `2.0.0` while `v2.0.2` was the shipped release: a host built from a clean checkout reported 2.0.0, and an unpacked extension loaded from the repository showed 2.0.0 in `chrome://extensions` however many releases had gone out. It moves to `2.0.2`, and `release-extension.yml` gains a `sync-manifest-version` job that writes the released version back to the default branch on every **final** (non-prerelease) release.

**That job is the one change here that has CI write to the default branch**, and deserves the closest look after the removals. It runs beside the Chrome Web Store deploy rather than in front of it, so it cannot block a deploy; it refuses to move the number backwards; it rebases and retries on a lost race and then warns rather than failing a release whose artifacts have already shipped; and a `GITHUB_TOKEN` push does not fire another workflow, so the commit does not cut a release candidate of its own. If you would rather bump the manifest by hand, that job is the only thing to drop — the rest of the fix stands without it.

## Testing

The derivation was confirmed against a real build rather than only asserted in a test. With the manifest temporarily set to `9.8.7.65`, `PdfEditor.NativeHost.AssemblyInfo.cs` came back carrying `AssemblyVersionAttribute("9.8.7.65")` — which also exercises the four-part release-candidate form. On the restored manifest, the built host reports `2.0.2.0` where it previously reported `2.0.0.0`; re-confirmed on this branch against current `main`.

640 .NET tests and 115 extension tests pass. All three release workflows are YAML-validated after the step removals.

**`version-sync.test.mjs` guarded the literal, not the invariant.** It passed throughout this bug: it asserted the props file and the manifest carried the same string, and they did — both said `2.0.0`, because neither was ever updated. It now asserts that the props file reads the manifest, that it hardcodes no version of its own, that no workflow stamps the props file, and that no job which packages compiles before it stamps. The ordering guard was negative-checked by reinstating the old step order and confirming it fails and names the offending job.

## Not addressed

`host-version.js` still compares only major and minor. Left alone deliberately: widening it is a user-visible change to the upgrade experience, and it belongs in its own review rather than riding along in an infrastructure fix. Filed as #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV5c2TRxLJZ3E6gNXenvBB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VV5c2TRxLJZ3E6gNXenvBB)_