### PR TITLE
Rebrand to reDACT: new name and tagline, rewritten store description, antialiased icons

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "PDF Editor",
   "version": "2.0.2",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK1fIDsukhIoTqFOKiZr6Beg2PtYsnlFkqcxMd31yjMkE7KIwFj8/tc2HoBUICzCbE4YI53TTyq//Fx1beLafT0oRL3LJSN7aMkdutz4mnkOCxVVrP8Og2tZJgp9uLH1OADxzOzhun/5Vj1PvTmDwKIwTjJ6qSN93xOpgzSS5yqiWJbpHthYpsxay5kSiOy4C6qxPKYp/u0s0pVhTjuUUjcgmrAWp/xo5Eov6vLsaonfVJVgcApdaUrBXQ3+uUnQrxR9AdVxcCZ7FL0Am9J/iJ0poha2mss2tarpbn+jZ3GQWwE52a2pNg6MjYElXczApal5b6IL/pqaICG+GQP5lQIDAQAB",
-  "description": "Edit text, redact, merge, sign, and password-protect PDFs directly in your browser. Powered by a local native host.",
+  "description": "Edit text, truly redact, merge, OCR, sign and encrypt PDFs in your browser. Processed locally \u2014 files never leave your PC.",
   "minimum_chrome_version": "116",
   "permissions": [
     "nativeMessaging",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "PDF Editor",
+  "name": "reDACT PDF Editor",
   "version": "2.0.2",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK1fIDsukhIoTqFOKiZr6Beg2PtYsnlFkqcxMd31yjMkE7KIwFj8/tc2HoBUICzCbE4YI53TTyq//Fx1beLafT0oRL3LJSN7aMkdutz4mnkOCxVVrP8Og2tZJgp9uLH1OADxzOzhun/5Vj1PvTmDwKIwTjJ6qSN93xOpgzSS5yqiWJbpHthYpsxay5kSiOy4C6qxPKYp/u0s0pVhTjuUUjcgmrAWp/xo5Eov6vLsaonfVJVgcApdaUrBXQ3+uUnQrxR9AdVxcCZ7FL0Am9J/iJ0poha2mss2tarpbn+jZ3GQWwE52a2pNg6MjYElXczApal5b6IL/pqaICG+GQP5lQIDAQAB",
   "description": "Edit text, truly redact, merge, OCR, sign and encrypt PDFs in your browser. Processed locally \u2014 files never leave your PC.",
@@ -20,7 +20,7 @@
     "type": "module"
   },
   "action": {
-    "default_title": "Open PDF Editor",
+    "default_title": "Open reDACT",
     "default_icon": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png",

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -55,13 +55,13 @@ chrome.action.onClicked.addListener((tab) => {
 chrome.runtime.onInstalled.addListener((details) => {
   chrome.contextMenus.create({
     id: 'open-link-in-editor',
-    title: 'Open link in PDF Editor',
+    title: 'Open link in reDACT',
     contexts: ['link'],
     targetUrlPatterns: ['*://*/*.pdf*', 'file://*/*.pdf'],
   });
   chrome.contextMenus.create({
     id: 'open-page-in-editor',
-    title: 'Open this PDF in PDF Editor',
+    title: 'Open this PDF in reDACT',
     contexts: ['page'],
   });
   // On a fresh install, take the user straight to the instructions if the host is not there — the
@@ -96,15 +96,15 @@ async function checkHost({ openOptionsIfMissing = false } = {}) {
 
   let badge = '';
   let colour = '';
-  let title = 'Open PDF Editor';
+  let title = 'Open reDACT';
   if (!connected) {
     badge = BADGE_MISSING;
     colour = '#b3261e';
-    title = `PDF Editor — ${hostStateSummary(probe.state)} Click for instructions.`;
+    title = `reDACT — ${hostStateSummary(probe.state)} Click for instructions.`;
   } else if (!ok) {
     badge = BADGE_STALE;
     colour = '#8a6100';
-    title = `PDF Editor — ${versionStateSummary(version.state)} `
+    title = `reDACT — ${versionStateSummary(version.state)} `
       + `Host v${probe.version}, extension v${chrome.runtime.getManifest().version}. `
       + 'Click for instructions.';
   }

--- a/extension/src/content.js
+++ b/extension/src/content.js
@@ -1,5 +1,5 @@
 // Content script: extends existing browser-based PDF viewing with an
-// "Edit in PDF Editor" entry point. It covers two cases:
+// "Edit in reDACT" entry point. It covers two cases:
 //   1. The tab itself is a PDF rendered by the browser's built-in viewer.
 //   2. The page embeds PDFs via <embed>, <object>, or <iframe>.
 // Adobe properties are left alone by the background worker's checks; this
@@ -14,7 +14,7 @@
     if (document.getElementById(BUTTON_ID)) return null;
     const button = document.createElement('button');
     button.id = BUTTON_ID;
-    button.textContent = '✏ Edit in PDF Editor';
+    button.textContent = '✏ Edit in reDACT';
     button.style.cssText = [
       'position:' + (fixed ? 'fixed' : 'absolute'),
       'z-index:2147483647',

--- a/extension/src/host-install.js
+++ b/extension/src/host-install.js
@@ -147,7 +147,7 @@ export function installSteps(platform) {
   if (platform === 'chromeos' || platform === 'android') {
     return [{
       text: 'The native host is a desktop application, and there is no build for this platform. '
-        + 'PDF Editor needs Chrome, Chromium, Edge, Brave, Vivaldi or Opera on Windows, macOS or Linux.',
+        + 'reDACT needs Chrome, Chromium, Edge, Brave, Vivaldi or Opera on Windows, macOS or Linux.',
     }];
   }
   return [{

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>PDF Editor — Options</title>
+  <title>reDACT — Options</title>
   <style>
     body { font: 14px system-ui, sans-serif; max-width: 640px; margin: 32px auto; color: #222; }
     h1 { font-size: 20px; }
@@ -27,7 +27,7 @@
   </style>
 </head>
 <body>
-  <h1>PDF Editor options</h1>
+  <h1>reDACT options</h1>
 
   <label>
     <input type="checkbox" id="auto-open" />

--- a/extension/src/viewer.css
+++ b/extension/src/viewer.css
@@ -417,7 +417,8 @@ button.danger:hover:not(:disabled) { background: #ef5443; }
 .region.highlight { border-color: #e0a800; background: rgba(255, 235, 59, 0.35); }
 
 #empty-state { align-self: center; text-align: center; max-width: 420px; }
-#empty-state h1 { font-weight: 600; }
+#empty-state h1 { font-weight: 600; margin-bottom: 2px; }
+.tagline { color: var(--muted); letter-spacing: 0.01em; margin: 0 0 14px; }
 /* Native-host trouble in the empty state: wider than the rest of it, because the guidance carries
    a shell command that must not wrap into nonsense. */
 #host-status:not(:empty) { max-width: 520px; margin-inline: auto; text-align: left; }

--- a/extension/src/viewer.html
+++ b/extension/src/viewer.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>PDF Editor</title>
+  <title>reDACT</title>
   <link rel="stylesheet" href="viewer.css" />
 </head>
 <body>
@@ -104,7 +104,8 @@
     <div id="scroll-area">
       <div id="pages"></div>
       <div id="empty-state">
-        <h1>PDF Editor</h1>
+        <h1>reDACT</h1>
+        <p class="tagline">Cut the fat. Keep the signal.</p>
         <p>Open a PDF or an image to start editing — use the button below or drag a file in. Navigating to any PDF opens it here automatically.</p>
         <button id="btn-open-empty">📂 Open a PDF or image…</button>
         <p id="host-status" class="muted"></p>

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -343,7 +343,7 @@ async function logEnvironment() {
 function downloadConsole() {
   const m = chrome.runtime.getManifest();
   const header = [
-    'Chromium PDF Editor — activity log',
+    'reDACT — activity log',
     `Extension: v${m.version}`,
     `Browser: ${browserSummary()}`,
     `Platform: ${navigator.platform || 'unknown'}`,
@@ -967,7 +967,7 @@ function updateChrome() {
   $('btn-redo').disabled = state.future.length === 0;
   if (loaded) {
     updateNav();
-    document.title = `${state.fileName} — PDF Editor`;
+    document.title = `${state.fileName} — reDACT`;
   }
   const badgesEl = $('badges');
   badgesEl.innerHTML = '';
@@ -1782,7 +1782,7 @@ function downloadComplianceReport(result) {
   code { font: 12px ui-monospace, monospace; word-break: break-all; }
 </style></head><body>
 <h1>Redaction Compliance Report</h1>
-<p class="muted">Generated ${escapeHtml(generated)} by Chromium PDF Editor v${escapeHtml(version)}.</p>
+<p class="muted">Generated ${escapeHtml(generated)} by reDACT v${escapeHtml(version)}.</p>
 <h2>Document</h2>
 <table class="meta">
   <tr><td>File</td><td>${escapeHtml(state.fileName)}</td></tr>
@@ -2387,7 +2387,7 @@ async function digitallySign() {
     try {
       setStatus('Creating certificate…', true);
       const cert = await host.call('create-cert', {
-        name: details.name || 'PDF Editor User', password: details.pw,
+        name: details.name || 'reDACT User', password: details.pw,
       });
       const blob = new Blob([base64ToBytes(cert.pfx)], { type: 'application/x-pkcs12' });
       chrome.downloads.download({
@@ -2849,7 +2849,7 @@ async function openFromBytes(bytes, name, kind) {
         // than surfacing a bare "unknown action".
         if (/unknown action/i.test(e?.message ?? '')) {
           throw new Error('Opening images needs an updated native host. Please reinstall the '
-            + 'PDF Editor native host (it was installed before image support was added), then retry.');
+            + 'reDACT native host (it was installed before image support was added), then retry.');
         }
         throw e;
       }
@@ -4439,8 +4439,13 @@ async function showAbout() {
 
   const name = document.createElement('p');
   name.className = 'about-name';
-  name.textContent = manifest.name || 'Chromium PDF Editor';
+  name.textContent = manifest.name || 'reDACT PDF Editor';
   modal.appendChild(name);
+
+  const tagline = document.createElement('p');
+  tagline.className = 'tagline';
+  tagline.textContent = 'Cut the fat. Keep the signal.';
+  modal.appendChild(tagline);
 
   if (manifest.description) {
     const desc = document.createElement('p');

--- a/scripts/generate-icons.py
+++ b/scripts/generate-icons.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Generates the extension's toolbar icons (16/48/128 px PNGs).
+"""Generates the extension's toolbar and store icons (16/48/128 px PNGs).
 
 Run once before loading the unpacked extension:
     python3 scripts/generate-icons.py
 Only the Python standard library is required.
+
+The mark is a white page with a folded corner on a red tile, carrying a black
+redaction bar -- the one feature that distinguishes this editor from every other
+PDF tool. Shapes are defined once in a 128x128 design space and rendered by
+supersampling (each output pixel averages ss*ss coverage samples), which is what
+gives the curves and the tile's rounded corners their antialiased edges.
 """
 import os
 import struct
@@ -11,48 +17,156 @@ import zlib
 
 OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "extension", "icons")
 
+TILE_TOP, TILE_BOT = (0xC9, 0x37, 0x2C), (0x9E, 0x1B, 0x13)
+SHEET_TOP, SHEET_BOT = (0xFF, 0xFF, 0xFF), (0xF1, 0xF3, 0xF5)
+FOLD = (0xC3, 0xCA, 0xD1)
+LINE = (0xAE, 0xB6, 0xBE)
+BAR = (0x11, 0x13, 0x17)
+SHADOW = (0x3A, 0x07, 0x03)
 
-def make_png(path: str, size: int) -> None:
-    """A rounded red document tile with text lines and a black redaction bar."""
+# size -> (supersample factor, draw the page detail). At 16px the fold and the
+# third line turn to mush, so that size gets a larger page and two fat bars.
+SIZES = ((128, 4, True), (48, 8, True), (16, 16, False))
+
+
+def lerp(a, b, t):
+    return tuple(a[i] + (b[i] - a[i]) * t for i in range(3))
+
+
+def rounded_rect(x, y, w, h, r):
+    """Returns a point-in-rounded-rectangle test in design space."""
+    def inside(px, py):
+        if not (x <= px <= x + w and y <= py <= y + h):
+            return False
+        dx, dy = min(px - x, x + w - px), min(py - y, y + h - py)
+        if dx < r and dy < r:
+            return (dx - r) ** 2 + (dy - r) ** 2 <= r * r
+        return True
+    return inside
+
+
+def box_blur(mask, w, radius, passes=3):
+    """Separable box blur; repeated passes approximate a gaussian well enough
+    for the page's drop shadow."""
+    buf = mask
+    for _ in range(passes):
+        mid = [0.0] * (w * w)
+        for y in range(w):
+            row = y * w
+            for x in range(w):
+                lo, hi = max(0, x - radius), min(w - 1, x + radius)
+                mid[row + x] = sum(buf[row + i] for i in range(lo, hi + 1)) / (hi - lo + 1)
+        out = [0.0] * (w * w)
+        for x in range(w):
+            for y in range(w):
+                lo, hi = max(0, y - radius), min(w - 1, y + radius)
+                out[y * w + x] = sum(mid[i * w + x] for i in range(lo, hi + 1)) / (hi - lo + 1)
+        buf = out
+    return buf
+
+
+def shapes(detailed):
+    tile = rounded_rect(2, 2, 124, 124, 28)
+    if detailed:
+        body = rounded_rect(28, 24, 72, 82, 8)
+        # The dog-ear: clip the top-right corner along x - y = 56, then paint the
+        # folded flap as the triangle just inside that cut.
+        sheet = lambda px, py: body(px, py) and (px - py) <= 56
+        fold = lambda px, py: px >= 80 and py <= 44 and (px - py) <= 56
+        bars = [(rounded_rect(40, 52, 38, 7, 3.5), LINE),
+                (rounded_rect(40, 82, 30, 7, 3.5), LINE),
+                (rounded_rect(40, 65, 48, 12, 2), BAR)]
+    else:
+        sheet = rounded_rect(20, 16, 88, 96, 9)
+        fold = lambda px, py: False
+        bars = [(rounded_rect(34, 38, 60, 14, 2), LINE),
+                (rounded_rect(34, 60, 60, 22, 2), BAR)]
+    return tile, sheet, fold, bars
+
+
+def render(size, ss, detailed):
+    """Returns PNG-ready RGBA rows (each prefixed with a zero filter byte)."""
+    w = size * ss
+    k = size / 128.0                              # design units -> output pixels
+    tile, sheet, fold, bars = shapes(detailed)
+
+    sheet_mask = [0.0] * (w * w)
+    for py in range(w):
+        y = (py + 0.5) / (ss * k)
+        for px in range(w):
+            if sheet((px + 0.5) / (ss * k), y):
+                sheet_mask[py * w + px] = 1.0
+    shadow = box_blur(sheet_mask, w, max(1, int(2.0 * ss * k)))
+    drop = int(round(2.5 * ss * k))
+
+    acc = [[0.0, 0.0, 0.0, 0.0] for _ in range(size * size)]
+    for py in range(w):
+        y = (py + 0.5) / (ss * k)
+        for px in range(w):
+            x = (px + 0.5) / (ss * k)
+            r = g = b = a = 0.0
+
+            def over(col, alpha):                 # source-over compositing
+                nonlocal r, g, b, a
+                if alpha <= 0:
+                    return
+                r = col[0] * alpha + r * (1 - alpha)
+                g = col[1] * alpha + g * (1 - alpha)
+                b = col[2] * alpha + b * (1 - alpha)
+                a = alpha + a * (1 - alpha)
+
+            if tile(x, y):
+                over(lerp(TILE_TOP, TILE_BOT, min(1.0, max(0.0, (y - 2) / 124))), 1.0)
+                sy = py - drop
+                if 0 <= sy < w:                   # shadow stays inside the tile
+                    over(SHADOW, shadow[sy * w + px] * 0.42)
+            if sheet(x, y):
+                over(lerp(SHEET_TOP, SHEET_BOT, min(1.0, max(0.0, (y - 24) / 82))), 1.0)
+                if fold(x, y):
+                    over(FOLD, 1.0)
+                for hits, col in bars:
+                    if hits(x, y):
+                        over(col, 1.0)
+
+            cell = acc[(py // ss) * size + (px // ss)]
+            cell[0] += r * a
+            cell[1] += g * a
+            cell[2] += b * a
+            cell[3] += a
+
+    n = float(ss * ss)
     rows = bytearray()
-    radius = max(2, size // 8)
-    for y in range(size):
-        rows.append(0)  # PNG row filter byte
-        for x in range(size):
-            cx = min(x, size - 1 - x)
-            cy = min(y, size - 1 - y)
-            in_corner = cx < radius and cy < radius and \
-                (cx - radius) ** 2 + (cy - radius) ** 2 > radius * radius
-            if in_corner:
-                rows += b"\x00\x00\x00\x00"
-            elif x > size * 0.62 and y < size * 0.38 and \
-                    (x - size * 0.62) > (size * 0.38 - y) * 0.9:
-                rows += b"\xff\xe0\xdb\xff"  # page-fold corner
-            elif size >= 48 and size * 0.30 < y < size * 0.42 and size * 0.18 < x < size * 0.60:
-                rows += b"\xff\xff\xff\xff"  # text line
-            elif size >= 48 and size * 0.50 < y < size * 0.62 and size * 0.18 < x < size * 0.70:
-                rows += b"\x11\x11\x11\xff"  # redaction bar
-            elif size >= 48 and size * 0.70 < y < size * 0.82 and size * 0.18 < x < size * 0.55:
-                rows += b"\xff\xff\xff\xff"  # text line
-            else:
-                rows += b"\xb3\x26\x1e\xff"  # base red
+    for i, cell in enumerate(acc):
+        if i % size == 0:
+            rows.append(0)                        # PNG row filter byte
+        alpha = cell[3] / n
+        if alpha <= 0.0001:
+            rows += b"\x00\x00\x00\x00"
+            continue
+        rows += bytes((int(round(min(255, cell[0] / cell[3]))),
+                       int(round(min(255, cell[1] / cell[3]))),
+                       int(round(min(255, cell[2] / cell[3]))),
+                       int(round(min(255, alpha * 255)))))
+    return bytes(rows)
 
-    def chunk(tag: bytes, data: bytes) -> bytes:
+
+def write_png(path, size, rows):
+    def chunk(tag, data):
         return struct.pack(">I", len(data)) + tag + data + \
             struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
 
     header = struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0)
     png = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header) + \
-        chunk(b"IDAT", zlib.compress(bytes(rows))) + chunk(b"IEND", b"")
+        chunk(b"IDAT", zlib.compress(rows, 9)) + chunk(b"IEND", b"")
     with open(path, "wb") as f:
         f.write(png)
 
 
 def main() -> None:
     os.makedirs(OUT_DIR, exist_ok=True)
-    for size in (16, 48, 128):
+    for size, ss, detailed in SIZES:
         target = os.path.join(OUT_DIR, f"icon{size}.png")
-        make_png(target, size)
+        write_png(target, size, render(size, ss, detailed))
         print(f"wrote {os.path.relpath(target)}")
 
 


### PR DESCRIPTION
Three related store-listing changes: the extension's name, its description, and its icons.

## 1. Name: PDF Editor → reDACT

"PDF Editor" is unsearchable in the Chrome Web Store and says nothing about the product. The name now leads with the feature that sets this editor apart — redaction that genuinely removes content rather than drawing a black box over it.

The manifest name keeps a descriptive suffix — **reDACT PDF Editor** — so the listing still surfaces for the obvious search terms, while the in-product name is just **reDACT**.

The tagline **"Cut the fat. Keep the signal."** goes in the two places the product introduces itself: the empty state (the first screen a user sees) and the About modal. It is not repeated across context menus or tooltips, where it would just be noise.

**Display strings only.** Deliberately unchanged, because renaming them breaks host detection for every existing install with no user-visible gain:

- the native messaging host id `com.pdfeditor.host`
- the C# namespaces (`PdfEditor.Core`, `PdfEditor.NativeHost`)
- the Windows host directory `%ProgramFiles%\PDF Editor Host`, which `extension/test/host-install.test.mjs` asserts on

## 2. Store description

**Before** (114 chars) → **after** (122 chars, limit is 132):

> ~~Edit text, redact, merge, sign, and password-protect PDFs directly in your browser. Powered by a local native host.~~
> Edit text, truly redact, merge, OCR, sign and encrypt PDFs in your browser. Processed locally — files never leave your PC.

"Powered by a local native host" spent a fifth of the character budget on an implementation detail; it's replaced by the user-facing consequence — documents never leave the machine. Adds OCR (a shipped feature that was missing), and "truly redact" distinguishes real content removal from tools that draw a black rectangle.

## 3. Icons

The generator walked the pixel grid with binary in/out tests, so every curve came out hard-stepped — the tile's rounded corners were visibly staircased at 128px, and the "page fold" read as a stray pink triangle.

Same mark (red tile, white page, black redaction bar), but shapes are now defined once in a 128×128 design space and supersampled, so each output pixel averages ss×ss coverage samples. Adds a real dog-ear fold and a soft drop shadow. The 16px variant drops the fold and the third text line — both mush at that size — for a larger page and two fatter bars.

Still stdlib-only. Costs ~4.5s in the packaging scripts that call it.

## Verification

- `node --test "extension/test/**/*.test.mjs"` — 115 pass, 0 fail
- `node scripts/check-innerhtml.mjs` — clean (the About tagline is `createElement` + `textContent`, not interpolated markup)
- `extension/manifest.json` parses; description is 122 chars, under the 132 store limit
- Icons rendered and inspected at 128, 48 and 16 (the last at 8× zoom, to check the real pixel grid)

## Notes for the author

- The name was checked against obvious collisions only. **This is not a trademark clearance** — please do a proper check before store submission, particularly since "redact" is a common word in this product category.
- `extension/icons/*.png` is gitignored and generated, so the icon change ships via `scripts/generate-icons.py` rather than as committed binaries.
- The tagline is UI-only. It is not in the manifest description, which is better spent on searchable feature terms — say if you'd rather lead the store listing with it.
- Not touched, and probably wanted before release: the README title, `docs/`, and the installer/package display names still say "PDF Editor". Happy to propagate the rename if you want it.