### PR TITLE
Deploy to the Edge Add-ons store, and fix a live native-messaging bug found along the way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
         # a packaging failure. The suite picks it up via PDF_EDITOR_DEB.
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: ./scripts/package-deb.sh dist
       - name: Install the package and run the extension against it
         working-directory: e2e
@@ -201,21 +202,24 @@ jobs:
       - name: Build the Linux host installers (.deb / .rpm / Arch .pkg.tar.zst)
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: |
           ./scripts/package-deb.sh dist
           ./scripts/package-rpm.sh dist
           ./scripts/package-arch.sh dist
       - name: Note how to use these dry-run packages
-        # These artifacts pin the host to whichever extension ID the build used (the
-        # CHROME_EXTENSION_ID secret, else the committed scripts/extension-id.txt = the published
-        # Web Store ID). Anyone downloading them to test against a developer-mode/unpacked extension
-        # (a different ID) must re-register — spell that out in the job summary so it isn't a mystery.
+        # These artifacts pin the host to whichever extension IDs the build used (the
+        # CHROME_EXTENSION_ID/EDGE_EXTENSION_ID secrets, else the committed scripts/extension-id.txt
+        # and edge-extension-id.txt = the published Web Store IDs). Anyone downloading them to test
+        # against a developer-mode/unpacked extension (a different ID) must re-register — spell that
+        # out in the job summary so it isn't a mystery.
         run: |
           pinned="${CHROME_EXTENSION_ID:-$(tr -d '[:space:]' < scripts/extension-id.txt)}"
+          pinned_edge="${EDGE_EXTENSION_ID:-$(tr -d '[:space:]' < scripts/edge-extension-id.txt)}"
           {
             echo "## Linux host installers (dry run)"
             echo "These \`.deb\`/\`.rpm\`/\`.pkg.tar.zst\` packages register the native host for the"
-            echo "extension ID **\`$pinned\`** only."
+            echo "extension IDs **\`$pinned\`** (Chrome) and **\`$pinned_edge\`** (Edge) only."
             echo ""
             echo "To use them with a **developer-mode / unpacked** extension (which has a different"
             echo "ID), after installing the package run:"
@@ -227,6 +231,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pdf-editor-host-linux-installers-dry-run
@@ -255,6 +260,7 @@ jobs:
       - name: Build the MSI
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: ./scripts/package-msi.ps1 -OutputDir dist
         shell: pwsh
       - name: Verify the MSI registers the native messaging host
@@ -265,26 +271,32 @@ jobs:
         # extension. This reads the MSI's own tables and checks each of those.
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         shell: pwsh
         run: |
           $id = $env:CHROME_EXTENSION_ID
           if (-not $id) { $id = (Get-Content scripts/extension-id.txt -Raw).Trim() }
+          $edgeId = $env:EDGE_EXTENSION_ID
+          if (-not $edgeId) { $edgeId = (Get-Content scripts/edge-extension-id.txt -Raw).Trim() }
           $msi = (Get-ChildItem dist/*.msi | Select-Object -First 1).FullName
-          ./scripts/verify-msi.ps1 $msi -ExpectedExtensionId $id
+          ./scripts/verify-msi.ps1 $msi -ExpectedExtensionId $id -ExpectedEdgeExtensionId $edgeId
       - name: Note how to use this dry-run package
-        # Same caveat as the Linux dry-run job: the MSI pins the host to one extension ID, so a
-        # developer-mode/unpacked extension (different ID) must re-register per-user afterward.
+        # Same caveat as the Linux dry-run job: the MSI pins the host to two extension IDs, so a
+        # developer-mode/unpacked extension (a different ID) must re-register per-user afterward.
         shell: pwsh
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: |
           $pinned = $env:CHROME_EXTENSION_ID
           if (-not $pinned) { $pinned = (Get-Content scripts/extension-id.txt -Raw).Trim() }
-          # Single-quoted lines so backticks/backslashes are literal markdown; only the ID line
-          # interpolates, via string concatenation, to avoid PowerShell backtick-escape surprises.
+          $pinnedEdge = $env:EDGE_EXTENSION_ID
+          if (-not $pinnedEdge) { $pinnedEdge = (Get-Content scripts/edge-extension-id.txt -Raw).Trim() }
+          # Single-quoted lines so backticks/backslashes are literal markdown; only the ID lines
+          # interpolate, via string concatenation, to avoid PowerShell backtick-escape surprises.
           $lines = @(
             '## Windows MSI (dry run)',
-            'This `.msi` registers the native host for the extension ID **`' + $pinned + '`** only.',
+            'This `.msi` registers the native host for the extension IDs **`' + $pinned + '`** (Chrome) and **`' + $pinnedEdge + '`** (Edge) only.',
             '',
             'To use it with a **developer-mode / unpacked** extension (a different ID), after',
             'installing the MSI run the helper it puts next to the host:',

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Build the Windows MSI
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: ./scripts/package-msi.ps1 -OutputDir dist
         shell: pwsh
 
@@ -126,12 +127,15 @@ jobs:
         # someone installs the package, so it is checked before the MSI is published.
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         shell: pwsh
         run: |
           $id = $env:CHROME_EXTENSION_ID
           if (-not $id) { $id = (Get-Content scripts/extension-id.txt -Raw).Trim() }
+          $edgeId = $env:EDGE_EXTENSION_ID
+          if (-not $edgeId) { $edgeId = (Get-Content scripts/edge-extension-id.txt -Raw).Trim() }
           $msi = (Get-ChildItem dist/*.msi | Select-Object -First 1).FullName
-          ./scripts/verify-msi.ps1 $msi -ExpectedExtensionId $id
+          ./scripts/verify-msi.ps1 $msi -ExpectedExtensionId $id -ExpectedEdgeExtensionId $edgeId
 
       - name: Upload the MSI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -203,6 +207,7 @@ jobs:
         # (.pkg.tar.zst). Same self-contained host + pinned native-messaging manifest in each.
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: |
           ./scripts/package-deb.sh dist
           ./scripts/package-rpm.sh dist
@@ -213,9 +218,10 @@ jobs:
         # messaging host not found" -- so nothing about a broken registration shows up until
         # someone installs the package and tries it. This unpacks each one and checks the manifest
         # is in every directory a supported browser reads, is identical across them, pins the right
-        # extension ID, and points at an executable the package actually ships.
+        # extension IDs, and points at an executable the package actually ships.
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          EDGE_EXTENSION_ID: ${{ secrets.EDGE_EXTENSION_ID }}
         run: |
           ./scripts/verify-linux-package.sh \
             dist/pdf-editor-host_*.deb \

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_to_store:
-        description: "Also upload the package to the Chrome Web Store (requires CHROME_* secrets)"
+        description: "Also upload the package to the Chrome Web Store and Microsoft Edge Add-ons store (requires the respective CHROME_*/EDGE_* secrets)"
         type: boolean
         default: false
 
@@ -116,6 +116,18 @@ jobs:
         with:
           name: pdf-editor-extension-v${{ steps.package.outputs.version }}
           path: ${{ steps.package.outputs.zip_path }}
+          if-no-files-found: error
+
+      # Same package, minus manifest.json's "key": the Microsoft Edge Add-ons store's validator
+      # rejects a submission whose manifest has one (see package-edge-extension.sh). Built from the
+      # Chrome zip above rather than from extension/ directly so the two can never drift apart.
+      - name: Package Edge extension
+        id: package_edge
+        run: ./scripts/package-edge-extension.sh "${{ steps.package.outputs.zip_path }}" dist
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pdf-editor-extension-edge-v${{ steps.package_edge.outputs.version }}
+          path: ${{ steps.package_edge.outputs.edge_zip_path }}
           if-no-files-found: error
 
       - name: Package all-in-one bundles (extension + native host, per platform)
@@ -286,3 +298,100 @@ jobs:
             --client-id "$CLIENT_ID" \
             --client-secret "$CLIENT_SECRET" \
             --refresh-token "$REFRESH_TOKEN"
+
+  publish-to-edge-add-ons-store:
+    needs: package
+    # Same trigger as the Chrome Web Store deploy: only a non-prerelease Release (the manual
+    # "promote" step), or an explicit workflow_dispatch opt-in.
+    if: ${{ github.event.inputs.publish_to_store == 'true' || needs.package.outputs.is_prerelease == 'false' }}
+    runs-on: ubuntu-latest
+    environment: edge-add-ons-store
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: pdf-editor-extension-edge-v${{ needs.package.outputs.version }}
+          path: dist
+      - name: Check Microsoft Edge Add-ons credentials are configured
+        id: creds
+        env:
+          PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          API_KEY: ${{ secrets.EDGE_API_KEY }}
+        run: |
+          if [[ -n "$PRODUCT_ID" && -n "$CLIENT_ID" && -n "$API_KEY" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Microsoft Edge Add-ons upload — EDGE_PRODUCT_ID/EDGE_CLIENT_ID/EDGE_API_KEY secrets are not all set. The packaged zip is still available as a build artifact for manual upload."
+          fi
+      # Talks to the Edge Add-ons submission API (v1.1) directly with curl rather than a
+      # third-party package or Action, matching how the Chrome Web Store step above avoids a
+      # GitHub Marketplace Action -- one fewer opaque external dependency in a release pipeline.
+      # v1.1 auth is just two headers (no OAuth token exchange, unlike the superseded v1 API):
+      # https://learn.microsoft.com/microsoft-edge/extensions/update/api/using-addons-api
+      - name: Upload (and publish) to the Microsoft Edge Add-ons store
+        if: steps.creds.outputs.configured == 'true'
+        env:
+          PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          API_KEY: ${{ secrets.EDGE_API_KEY }}
+        run: |
+          set -euo pipefail
+          zip_path=$(ls dist/*.zip | head -1)
+          base="https://api.addons.microsoftedge.microsoft.com/v1/products/$PRODUCT_ID"
+
+          # operation_id <headers-file> -- the Location header's value IS the operation ID (not a
+          # URL to follow); ${v##*/} also tolerates it arriving as a path/URL, harmlessly.
+          operation_id() {
+            local v
+            v="$(grep -i '^Location:' "$1" | tr -d '\r' | awk '{print $2}')"
+            echo "${v##*/}"
+          }
+
+          # poll <endpoint-template-with-%s> <operation-id> -- polls until the operation leaves
+          # "InProgress". Edge's docs give no fixed SLA for package processing; 30 tries * 10s is a
+          # generous 5-minute budget before failing loudly rather than hanging the job forever.
+          poll() {
+            local url status body
+            url="$(printf "$1" "$2")"
+            for _ in $(seq 1 30); do
+              body="$(curl -sS -H "Authorization: ApiKey $API_KEY" -H "X-ClientID: $CLIENT_ID" "$url")"
+              status="$(echo "$body" | jq -r '.status // empty' 2>/dev/null)"
+              case "$status" in
+                Succeeded|Completed) echo "$status"; return 0 ;;
+                Failed|Rejected) echo "error: operation failed: $body" >&2; return 1 ;;
+              esac
+              sleep 10
+            done
+            echo "error: operation did not finish in time: $body" >&2
+            return 1
+          }
+
+          echo "Uploading $zip_path..."
+          headers="$(mktemp)"
+          curl -sS -X POST -H "Authorization: ApiKey $API_KEY" -H "X-ClientID: $CLIENT_ID" \
+            -H "Content-Type: application/zip" --data-binary "@$zip_path" \
+            -D "$headers" -o /dev/null "$base/submissions/draft/package"
+          upload_op="$(operation_id "$headers")"
+          if [[ -z "$upload_op" ]]; then
+            echo "error: upload did not return an operation Location header:" >&2
+            cat "$headers" >&2
+            exit 1
+          fi
+          echo "Upload accepted (operation $upload_op), polling..."
+          poll "$base/submissions/draft/package/operations/%s" "$upload_op"
+          echo "Upload processed."
+
+          echo "Publishing the draft submission..."
+          curl -sS -X POST -H "Authorization: ApiKey $API_KEY" -H "X-ClientID: $CLIENT_ID" \
+            -H "Content-Type: application/json" -d '{}' \
+            -D "$headers" -o /dev/null "$base/submissions"
+          publish_op="$(operation_id "$headers")"
+          if [[ -z "$publish_op" ]]; then
+            echo "error: publish did not return an operation Location header:" >&2
+            cat "$headers" >&2
+            exit 1
+          fi
+          echo "Publish accepted (operation $publish_op), polling..."
+          poll "$base/submissions/operations/%s" "$publish_op"
+          echo "Published."

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ It builds the `.deb` (or reuses one via `PDF_EDITOR_DEB=/path/to.deb`), installs
 tests, and purges the package again afterwards, pass or fail. Installing needs root, so it uses
 `sudo` when you are not already root, and it refuses to run over an existing install rather than
 removing a host you use. It works because the extension's manifest `key` pins its ID to the
-published Web Store one even when loaded unpacked — the same ID the package writes into
-`allowed_origins`.
+published Chrome Web Store one even when loaded unpacked (in any Chromium-based browser, not
+just Chrome) — one of the two IDs the package writes into `allowed_origins`.
 
 CI runs it as the `package-install-e2e` job. The `.deb` is the only one of the three Linux
 packages an Ubuntu runner can install; the `.rpm` and Arch packages are checked structurally
@@ -428,11 +428,15 @@ a missing runtime library is reported at install time rather than discovered in 
 
 > [!IMPORTANT]
 > These packages pin the host's `allowed_origins` to the **published Chrome Web Store
-> extension ID** (`ikbkielkpaloojhibinmcfbeekhkdblc`). They work only for the extension
-> installed **from the Web Store**, which has that exact ID.
+> extension ID** (`cbmfodojjlfppljbdebmpbcppngkkibi`) **and Microsoft Edge Add-ons ID**
+> (`kcppllhgnfmdbmglohgmabipeikopfhb`). They work only for the extension installed **from
+> one of those stores**, which has one of those exact IDs.
 >
 > A **developer-mode / unpacked** extension — including one loaded to test the dry-run
-> packages built by CI — gets a *different*, machine-specific ID, so the pinned origin will
+> packages built by CI — gets the ID the manifest's `key` computes to (the same one in every
+> Chromium-based browser, Edge included, since `key` — not the browser — determines the ID),
+> which matches the pinned Chrome ID above and so still connects. A **custom-built or
+> re-keyed** extension gets a *different*, machine-specific ID, so the pinned origins will
 > not match and the host connection is refused ("Specified native messaging host not found"
 > or a rejected connection). Two ways to fix it:
 >

--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -24,10 +24,17 @@ checklist for all of that.
 
 ## 1. One-time account + registration
 
-1. Create/enter a **Chrome Web Store developer account** (one-time US$5 fee) at
-   <https://chrome.google.com/webstore/devconsole>.
-2. Upload the packaged zip once (from a build artifact or `./scripts/package-extension.sh`) to
-   **register the item** and obtain its **Extension ID**. (You can save it as a draft.)
+- [x] **Done.** The item is registered: extension ID `cbmfodojjlfppljbdebmpbcppngkkibi`, committed
+      at `scripts/extension-id.txt` and used everywhere the native-messaging packages pin
+      `allowed_origins` to it. If you ever need to redo this from scratch:
+
+  1. Create/enter a **Chrome Web Store developer account** (one-time US$5 fee) at
+     <https://chrome.google.com/webstore/devconsole>.
+  2. Upload the packaged zip once (from a build artifact or `./scripts/package-extension.sh`) to
+     **register the item** and obtain its **Extension ID**. (You can save it as a draft.)
+  3. Update `scripts/extension-id.txt` to the ID the store assigned, and re-run
+     `node --test "extension/test/**/*.test.mjs"` — `host-install.test.mjs` checks
+     `extension/src/host-install.js`'s `PINNED_EXTENSION_ID` stays in sync with it.
 
 ## 2. API credentials for automated publishing
 

--- a/docs/EDGE_ADD_ONS_STORE.md
+++ b/docs/EDGE_ADD_ONS_STORE.md
@@ -1,0 +1,115 @@
+# Publishing to the Microsoft Edge Add-ons store
+
+This project automates the upload the same way it does for Chrome (see
+[`CHROME_WEB_STORE.md`](CHROME_WEB_STORE.md)): `.github/workflows/release-extension.yml` packages
+`extension/` into a store-ready zip and, on a published (non-prerelease) GitHub Release, uploads
+**and publishes** it to the Edge Add-ons store via Microsoft's REST API (v1.1) — plain `curl` calls
+in the `publish-to-edge-add-ons-store` job, not a third-party package or Action, matching how the
+Chrome step avoids one too. What that automation needs is three repo secrets. This document is the
+checklist for that, and for what is deliberately *not* automated.
+
+---
+
+## 0. One-time account + registration — done
+
+- [x] **Registered.** Store ID `0RDCKF3D4DH2`, extension ID (CRXID)
+      `kcppllhgnfmdbmglohgmabipeikopfhb`, committed at `scripts/edge-extension-id.txt` and used
+      everywhere the native-messaging packages pin `allowed_origins` to it (alongside Chrome's ID).
+
+If you ever need to redo this from scratch: create/enter a **Microsoft Partner Center developer
+account** (one-time US$19 fee) at <https://partner.microsoft.com/dashboard/registration>, then
+submit the packaged zip once (`./scripts/package-edge-extension.sh <chrome-zip> dist` — see
+below for why it needs the Chrome zip, not `extension/` directly) to register the item and obtain
+its **Product ID**, **Store ID** and **extension (CRX) ID**. Update
+`scripts/edge-extension-id.txt` to the new CRXID, and re-run
+`node --test "extension/test/**/*.test.mjs"` — `host-install.test.mjs` cross-checks it against
+`extension/src/host-install.js`'s `EDGE_PINNED_EXTENSION_ID`.
+
+## 1. Why the Edge package differs from the Chrome one
+
+`extension/manifest.json` carries a `"key"` field, and it has to stay: it is what makes an
+**unpacked** load of this extension get the exact same ID as the published Chrome Web Store build,
+in every Chromium-based browser (Edge included) — see the README's "Browser end-to-end tests"
+section and `extension/src/host-install.js`. Removing it would silently break that, and the
+`package-install-e2e` suite along with it.
+
+Edge's own submission validator, though, **rejects any package whose `manifest.json` has a `"key"`
+property at all** — Edge already knows this extension's ID from when it was first registered (see
+above), so the field would be redundant even if Edge allowed it.
+
+Both are satisfied by never editing the source manifest at all: `scripts/package-edge-extension.sh`
+takes the already-built Chrome zip (from `package-extension.sh`) and re-packages it with `"key"`
+stripped from the copy — so the two zips are byte-for-byte identical except for that one line, and
+can never drift apart in any other way. `release-extension.yml`'s `package` job builds both from
+the same run.
+
+## 2. API credentials for automated publishing
+
+The workflow needs three repo secrets, from Partner Center's **Publish API** access page
+(<https://partner.microsoft.com/dashboard/microsoftedge/> → your extension → **API access**):
+
+1. Generate a **Client ID** and **API Key** (Partner Center's v1.1 API auth — just two header
+   values, no OAuth token exchange, unlike Chrome's flow or Edge's older v1 API).
+2. Note the **Product ID** from the extension's Partner Center overview page (`2219de73-...` —
+   *not* the Store ID or the CRXID; the API addresses submissions by Product ID).
+3. Add these as GitHub **repository secrets** (they gate the `publish-to-edge-add-ons-store` job):
+   - `EDGE_PRODUCT_ID`
+   - `EDGE_CLIENT_ID`
+   - `EDGE_API_KEY`
+
+   > If any secret is missing, the job skips gracefully and leaves the packaged zip as a build
+   > artifact for manual upload (see the workflow's "Check … credentials are configured" step).
+
+**Not secrets, and not needed by the pipeline at all:**
+- The **Store ID** (`0RDCKF3D4DH2`) only matters for the public listing URL
+  (`https://microsoftedge.microsoft.com/addons/detail/0RDCKF3D4DH2`); nothing in CI reads it.
+- The **public key** Partner Center showed alongside the CRXID at registration has no operational
+  role anywhere — Edge's validator forbids `"key"` in the manifest, so nothing ever embeds it. It
+  was useful for one thing only: confirming the CRXID Partner Center reported really does hash from
+  that key (standard Chromium extension-ID algorithm — SHA-256 of the DER-encoded key, first 16
+  bytes, nibble-mapped to a-p), which is how `scripts/edge-extension-id.txt` was verified before
+  being committed.
+
+## 3. Store listing content
+
+Reuse the same summary/description/category as the Chrome listing (see
+[`CHROME_WEB_STORE.md`](CHROME_WEB_STORE.md) §3) — there is no reason for the two stores to say
+something different about the same extension. Same graphics too; Partner Center accepts the same
+1280×800 screenshots and 128×128 icon Chrome does.
+
+## 4. Permission justifications
+
+Same permissions, same justifications as [`CHROME_WEB_STORE.md`](CHROME_WEB_STORE.md) §4 — Edge is
+Chromium-based and reads the same `manifest.json`. Partner Center's review form asks for them in a
+different shape than the Chrome dashboard does, but the answers do not change.
+
+## 5. Publish
+
+Two paths, mirroring Chrome's:
+
+- **Automated:** publish a **non-prerelease GitHub Release** whose tag sets the version (e.g.
+  `v2.0.0`). The workflow packages, uploads and publishes to both stores. (Release-candidate tags
+  are prereleases and stop before either store step.)
+- **Manual:** download the `pdf-editor-extension-edge-v<version>.zip` build artifact (or run
+  `./scripts/package-extension.sh dist && ./scripts/package-edge-extension.sh dist/pdf-editor-extension-v<version>.zip dist`)
+  and upload it in Partner Center, then submit for certification.
+
+## 6. After first submission
+
+- Certification review is typically faster than Chrome's, but native-messaging + broad host access
+  still tend to prompt reviewer questions — answer with the justifications above and the
+  native-host explanation (the host is **not** distributed through the Add-ons store; link to the
+  install scripts / bundle).
+- Bump `manifest.json` `version` for every subsequent submission, same as Chrome (the release tag
+  stamps it in CI, once, for both packages).
+
+## 7. Not done here: native messaging for Edge users
+
+The host is already registered into Edge's own OS-specific native-messaging locations by every
+installer (`HKCU:\...\Microsoft\Edge\...` on Windows, `/etc/opt/edge*/native-messaging-hosts` on
+Linux — see `installer/windows/PdfEditorHost.wxs` and `scripts/linux-manifest-dirs.sh`), and the
+manifest's `allowed_origins` lists both the Chrome and Edge extension IDs (see
+`scripts/com.pdfeditor.host.json.template`), so a user who installs the OS package and the
+published Edge extension should already be able to connect. This document is scoped to the store
+listing and its automation, not to auditing that end-to-end connection on a real Edge install —
+worth doing once Edge's listing is actually live.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "reDACT PDF Editor",
   "version": "2.0.2",
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK1fIDsukhIoTqFOKiZr6Beg2PtYsnlFkqcxMd31yjMkE7KIwFj8/tc2HoBUICzCbE4YI53TTyq//Fx1beLafT0oRL3LJSN7aMkdutz4mnkOCxVVrP8Og2tZJgp9uLH1OADxzOzhun/5Vj1PvTmDwKIwTjJ6qSN93xOpgzSS5yqiWJbpHthYpsxay5kSiOy4C6qxPKYp/u0s0pVhTjuUUjcgmrAWp/xo5Eov6vLsaonfVJVgcApdaUrBXQ3+uUnQrxR9AdVxcCZ7FL0Am9J/iJ0poha2mss2tarpbn+jZ3GQWwE52a2pNg6MjYElXczApal5b6IL/pqaICG+GQP5lQIDAQAB",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnCJtKqFQacaY0uHvI7We7kYlDq+uL4gX3nRSnSKAOKlOO5tyOzvSc4D5mCMb6qIDBBOzwiOZR2MBizmMTY/cqRf/1wZALr0g4+ZqNFiUpZYXDlLeiuR8KgjTU+25qYPFJQuuGlhnUGu4P43lYl6YRDOb+kUFjRyKRcZ4emCu93VLm3/hS1DfWjz65HT0kp8sGfwGBnTnLhJqGiHzavQmTFFvXp4c3Zu/ndx4XRlyp9f3dY3w0F3f5IQCLhsRLwt1zOpWcrYYij9heqsfZk6Pom8D+FEDCoIfjmat75Xn6gP5CDx6WItsrmi2xZOifMibCxzcDoc/IoIRHCczFZ154QIDAQAB",
   "description": "Edit text, truly redact, merge, OCR, sign and encrypt PDFs in your browser. Processed locally \u2014 files never leave your PC.",
   "minimum_chrome_version": "116",
   "permissions": [

--- a/extension/src/host-install.js
+++ b/extension/src/host-install.js
@@ -11,7 +11,11 @@
 // the viewer and the service worker alike.
 
 /** The pinned Chrome Web Store ID. The manifest "key" forces this ID even when loaded unpacked. */
-export const PINNED_EXTENSION_ID = 'ikbkielkpaloojhibinmcfbeekhkdblc';
+export const PINNED_EXTENSION_ID = 'cbmfodojjlfppljbdebmpbcppngkkibi';
+
+/** The pinned Microsoft Edge Add-ons ID. Edge's own validator forbids a manifest "key", so this
+ *  one is not enforced by loading the extension unpacked — only the published Edge build has it. */
+export const EDGE_PINNED_EXTENSION_ID = 'kcppllhgnfmdbmglohgmabipeikopfhb';
 
 export const RELEASES_URL = 'https://github.com/ZanattaMichael/Chromium-PDF-Editor/releases/latest';
 
@@ -307,13 +311,13 @@ export function hostInstallGuide({ state, platform, extensionId = '', error = ''
 
     case HOST_STATE.FORBIDDEN:
       // Two different faults produce the identical browser message, and the usual advice is wrong
-      // for one of them. If this extension is the pinned Web Store build, the OS package's own
-      // manifest *does* list it -- so the manifest the browser actually read is a different,
-      // staler one. Chromium reads the per-user directory in preference to the system-wide one,
-      // so an earlier `install-host.sh <some-other-id>` keeps winning long after a correct
-      // package is installed, and telling someone to "re-register, your ID is not the pinned
-      // one" misdescribes their machine.
-      if (extensionId && extensionId === PINNED_EXTENSION_ID) {
+      // for one of them. If this extension is a pinned Web Store build (Chrome or Edge), the OS
+      // package's own manifest *does* list it -- so the manifest the browser actually read is a
+      // different, staler one. Chromium reads the per-user directory in preference to the
+      // system-wide one, so an earlier `install-host.sh <some-other-id>` keeps winning long after
+      // a correct package is installed, and telling someone to "re-register, your ID is not the
+      // pinned one" misdescribes their machine.
+      if (extensionId && [PINNED_EXTENSION_ID, EDGE_PINNED_EXTENSION_ID].includes(extensionId)) {
         guide.detail = 'This is the published build, and the OS packages pin their manifest to '
           + `exactly this ID (${extensionId}) — so the manifest the browser read is not the `
           + 'package’s. A per-user manifest from an earlier install takes precedence over the '
@@ -326,8 +330,9 @@ export function hostInstallGuide({ state, platform, extensionId = '', error = ''
         break;
       }
       guide.detail = 'A host is registered, but the manifest’s allowed_origins does not list '
-        + `this extension (${extensionId || 'unknown ID'}). The OS packages pin the published Web `
-        + 'Store ID, so a developer-mode or self-built extension needs its own registration.';
+        + `this extension (${extensionId || 'unknown ID'}). The OS packages pin the published `
+        + 'Chrome and Edge Web Store IDs, so a developer-mode or self-built extension needs its '
+        + 'own registration.';
       guide.steps = [
         reRegisterStep(platform, extensionId || '<your-extension-id>'),
         { text: 'Quit this browser completely and start it again.' },

--- a/extension/test/host-install.test.mjs
+++ b/extension/test/host-install.test.mjs
@@ -1,12 +1,26 @@
 // Unit tests for the native-host install diagnosis (see extension/src/host-install.js).
 // Run with: node --test extension/test/host-install.test.mjs
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
-  HOST_STATE, PINNED_EXTENSION_ID, classifyHostError, detectPlatform,
+  EDGE_PINNED_EXTENSION_ID, HOST_STATE, PINNED_EXTENSION_ID, classifyHostError, detectPlatform,
   hostInstallGuide, hostInstallGuideLines, hostStateSummary,
 } from '../src/host-install.js';
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+
+// The algorithm Chromium uses to derive an extension's ID from its manifest "key": SHA-256 of the
+// DER-encoded public key, first 16 bytes, each nibble mapped to a-p.
+function crxIdFromKey(base64Key) {
+  const digest = createHash('sha256').update(Buffer.from(base64Key, 'base64')).digest();
+  return [...digest.subarray(0, 16)]
+    .map((b) => String.fromCharCode(97 + (b >> 4)) + String.fromCharCode(97 + (b & 0xf)))
+    .join('');
+}
 
 // A stand-in for the ID an unpacked, developer-mode extension gets: 32 characters from a-p,
 // and deliberately not the pinned Web Store one the OS packages register.
@@ -228,8 +242,32 @@ test('hostInstallGuide tolerates being called with nothing', () => {
   assert.deepEqual(hostInstallGuideLines(null), []);
 });
 
-test('the pinned ID is a well-formed extension ID', () => {
-  // The packages pin allowed_origins to exactly this; a typo here would be invisible until a
+test('the pinned IDs are well-formed extension IDs', () => {
+  // The packages pin allowed_origins to exactly these; a typo here would be invisible until a
   // browser silently refused the connection.
   assert.match(PINNED_EXTENSION_ID, /^[a-p]{32}$/);
+  assert.match(EDGE_PINNED_EXTENSION_ID, /^[a-p]{32}$/);
+  assert.notEqual(PINNED_EXTENSION_ID, EDGE_PINNED_EXTENSION_ID);
+});
+
+test('the pinned IDs agree with every other copy of them in the repo', () => {
+  // Four independent copies of the same two IDs exist, by nature of what each one is: this
+  // constant (used for the extension's own diagnostics), the committed default the native-host
+  // packagers/registration scripts fall back to, and extension/manifest.json's "key" (which
+  // determines the *actual* ID Chromium assigns an unpacked load of this extension). None of
+  // them derive from each other, so nothing stops them drifting apart silently -- which is
+  // exactly what happened here before this test existed (see git history around this line).
+  assert.equal(
+    PINNED_EXTENSION_ID, repoFile('scripts/extension-id.txt').trim(),
+    'PINNED_EXTENSION_ID must match scripts/extension-id.txt');
+  assert.equal(
+    EDGE_PINNED_EXTENSION_ID, repoFile('scripts/edge-extension-id.txt').trim(),
+    'EDGE_PINNED_EXTENSION_ID must match scripts/edge-extension-id.txt');
+
+  const manifestKey = JSON.parse(repoFile('extension/manifest.json')).key;
+  assert.ok(manifestKey, 'extension/manifest.json must have a "key" -- see host-install.js');
+  assert.equal(
+    crxIdFromKey(manifestKey), PINNED_EXTENSION_ID,
+    'extension/manifest.json\'s "key" must compute to PINNED_EXTENSION_ID, or an unpacked load '
+    + 'gets an ID the native-host packages never allow');
 });

--- a/installer/windows/PdfEditorHost.wxs
+++ b/installer/windows/PdfEditorHost.wxs
@@ -13,7 +13,8 @@
     HostDir       published win-x64 self-contained host folder (harvested)
     ManifestJson  path to the rendered com.pdfeditor.host.json (allowed_origins pinned)
     RegisterScript  path to scripts/register-host.ps1 (per-user re-registration helper)
-    ExtensionIdFile path to a file holding the pinned extension ID, shipped next to the script
+    ExtensionIdFile path to a file holding the pinned Chrome extension ID, shipped next to the script
+    EdgeExtensionIdFile path to a file holding the pinned Edge extension ID, shipped next to the script
 -->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="PDF Editor Native Host"
@@ -47,13 +48,14 @@
 
     <!-- The per-user re-registration helper, installed next to the host so someone who installed
          the MSI (and therefore has no repository checkout) can still run it. The MSI pins
-         allowed_origins to the published Web Store ID; a developer-mode extension has a different
-         ID and needs a per-user manifest, which Chromium reads from HKCU in preference to the HKLM
-         values below. extension-id.txt carries the ID this MSI was built with so the script
-         defaults to the same one. -->
+         allowed_origins to the published Chrome and Edge Web Store IDs; a developer-mode extension
+         has a different ID and needs a per-user manifest, which Chromium reads from HKCU in
+         preference to the HKLM values below. extension-id.txt / edge-extension-id.txt carry the
+         IDs this MSI was built with so the script defaults to the same ones. -->
     <Component Id="HostRegisterTools" Directory="INSTALLFOLDER" Guid="E45AB775-539D-4B94-923C-1741789D36E4">
       <File Id="RegisterHostPs1" Source="$(var.RegisterScript)" Name="register-host.ps1" KeyPath="yes" />
       <File Id="PinnedExtensionId" Source="$(var.ExtensionIdFile)" Name="extension-id.txt" />
+      <File Id="PinnedEdgeExtensionId" Source="$(var.EdgeExtensionIdFile)" Name="edge-extension-id.txt" />
     </Component>
 
     <!-- The registry pointers that register the manifest with each Chromium-based browser.

--- a/scripts/com.pdfeditor.host.json.template
+++ b/scripts/com.pdfeditor.host.json.template
@@ -4,6 +4,7 @@
   "path": "__HOST_PATH__",
   "type": "stdio",
   "allowed_origins": [
-    "chrome-extension://__EXTENSION_ID__/"
+    "chrome-extension://__EXTENSION_ID__/",
+    "chrome-extension://__EDGE_EXTENSION_ID__/"
   ]
 }

--- a/scripts/edge-extension-id.txt
+++ b/scripts/edge-extension-id.txt
@@ -1,0 +1,1 @@
+kcppllhgnfmdbmglohgmabipeikopfhb

--- a/scripts/extension-id.txt
+++ b/scripts/extension-id.txt
@@ -1,1 +1,1 @@
-ikbkielkpaloojhibinmcfbeekhkdblc
+cbmfodojjlfppljbdebmpbcppngkkibi

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -6,8 +6,9 @@
 # on PATH as /usr/bin/pdf-editor-host, and registers it system-wide with Chrome/Chromium by
 # shipping the native-messaging manifest as a package-owned file (`pacman -R` cleans it up). The
 # manifest points at the /usr/bin launcher rather than at /opt, because a sandboxed browser is far
-# more likely to be permitted to execute it there. allowed_origins is pinned to the extension ID
-# (from $CHROME_EXTENSION_ID, else scripts/extension-id.txt).
+# more likely to be permitted to execute it there. allowed_origins is pinned to the Chrome and Edge
+# extension IDs (from $CHROME_EXTENSION_ID/$EDGE_EXTENSION_ID, else
+# scripts/extension-id.txt/edge-extension-id.txt).
 #
 # It also ships /usr/bin/pdf-editor-host-register, the per-user helper for the two cases no
 # system-wide manifest can reach: snap/flatpak browsers, and a developer-mode extension whose ID
@@ -35,6 +36,15 @@ if [[ -z "$EXTENSION_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
 fi
 if [[ -z "$EXTENSION_ID" ]]; then
   echo "error: no extension ID (set CHROME_EXTENSION_ID or scripts/extension-id.txt)" >&2
+  exit 1
+fi
+
+EDGE_ID="${EDGE_EXTENSION_ID:-}"
+if [[ -z "$EDGE_ID" && -f "$REPO_ROOT/scripts/edge-extension-id.txt" ]]; then
+  EDGE_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/edge-extension-id.txt")"
+fi
+if [[ -z "$EDGE_ID" ]]; then
+  echo "error: no Edge extension ID (set EDGE_EXTENSION_ID or scripts/edge-extension-id.txt)" >&2
   exit 1
 fi
 
@@ -72,16 +82,19 @@ find "$PKGDIR$INSTALL_DIR" -type f \( -name '*.so' -o -name 'createdump' \) -exe
 mkdir -p "$PKGDIR/usr/bin"
 ln -sf "$INSTALL_DIR/$EXE" "$PKGDIR$LAUNCH_PATH"
 
-# Per-user registration helper, plus the extension ID this package was built with so the helper
-# defaults to the same one.
+# Per-user registration helper, plus the extension IDs this package was built with so the helper
+# defaults to the same ones.
 install -Dm0755 "$REPO_ROOT/scripts/register-host.sh" "$PKGDIR$REGISTER_PATH"
 install -d -m0755 "$PKGDIR$SHARE_DIR"
 printf '%s\n' "$EXTENSION_ID" > "$PKGDIR$SHARE_DIR/extension-id"
 chmod 0644 "$PKGDIR$SHARE_DIR/extension-id"
+printf '%s\n' "$EDGE_ID" > "$PKGDIR$SHARE_DIR/edge-extension-id"
+chmod 0644 "$PKGDIR$SHARE_DIR/edge-extension-id"
 
-# Native-messaging manifest, pinned to the extension ID and pointing at the launcher symlink.
+# Native-messaging manifest, pinned to both extension IDs and pointing at the launcher symlink.
 render_manifest() {
   sed -e "s|__HOST_PATH__|$LAUNCH_PATH|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+    -e "s|__EDGE_EXTENSION_ID__|$EDGE_ID|" \
     "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
 }
 # Register for every common Chromium-based browser (see linux-manifest-dirs.sh). Each manifest is
@@ -102,6 +115,7 @@ post_install() {
   echo "PDF Editor native messaging host installed."
   echo "  host:     $LAUNCH_PATH -> $INSTALL_DIR/$EXE"
   echo "  allowed:  chrome-extension://$EXTENSION_ID/"
+  echo "            chrome-extension://$EDGE_ID/"
   if "$LAUNCH_PATH" --version >/dev/null 2>&1; then
     echo "  self-test: OK"
   else
@@ -159,7 +173,8 @@ echo "Building $PKG_PATH ..."
 
 echo
 echo "Built: $PKG_PATH ($(du -h "$PKG_PATH" | cut -f1))"
-echo "Extension ID pinned: $EXTENSION_ID"
+echo "Extension ID pinned:      $EXTENSION_ID"
+echo "Edge extension ID pinned: $EDGE_ID"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "arch_path=$PKG_PATH" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -4,8 +4,8 @@
 # The package installs the self-contained host under /opt/pdf-editor-host, exposes it on PATH as
 # /usr/bin/pdf-editor-host, and registers it system-wide with Chrome/Chromium by shipping the
 # native-messaging manifest as a package-owned file — so `apt remove` cleans it up automatically.
-# The manifest's allowed_origins is pinned to the extension ID (from $CHROME_EXTENSION_ID, else
-# scripts/extension-id.txt).
+# The manifest's allowed_origins is pinned to the Chrome and Edge extension IDs (from
+# $CHROME_EXTENSION_ID/$EDGE_EXTENSION_ID, else scripts/extension-id.txt/edge-extension-id.txt).
 #
 # Three things decide whether the browser actually finds the host, and all three are handled here:
 #   1. the manifest has to sit in the directory that browser build reads (see linux-manifest-dirs.sh);
@@ -34,6 +34,15 @@ if [[ -z "$EXTENSION_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
 fi
 if [[ -z "$EXTENSION_ID" ]]; then
   echo "error: no extension ID (set CHROME_EXTENSION_ID or scripts/extension-id.txt)" >&2
+  exit 1
+fi
+
+EDGE_ID="${EDGE_EXTENSION_ID:-}"
+if [[ -z "$EDGE_ID" && -f "$REPO_ROOT/scripts/edge-extension-id.txt" ]]; then
+  EDGE_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/edge-extension-id.txt")"
+fi
+if [[ -z "$EDGE_ID" ]]; then
+  echo "error: no Edge extension ID (set EDGE_EXTENSION_ID or scripts/edge-extension-id.txt)" >&2
   exit 1
 fi
 
@@ -71,14 +80,17 @@ ln -sf "$INSTALL_DIR/$EXE" "$DEBROOT$LAUNCH_PATH"
 # Per-user registration helper — the only way to reach snap/flatpak browsers, and the escape hatch
 # for a developer-mode extension whose ID differs from the pinned one.
 install -Dm0755 "$REPO_ROOT/scripts/register-host.sh" "$DEBROOT$REGISTER_PATH"
-# Record the ID this package was built with, so the helper defaults to the same one.
+# Record the IDs this package was built with, so the helper defaults to the same ones.
 install -d -m0755 "$DEBROOT$SHARE_DIR"
 printf '%s\n' "$EXTENSION_ID" > "$DEBROOT$SHARE_DIR/extension-id"
 chmod 0644 "$DEBROOT$SHARE_DIR/extension-id"
+printf '%s\n' "$EDGE_ID" > "$DEBROOT$SHARE_DIR/edge-extension-id"
+chmod 0644 "$DEBROOT$SHARE_DIR/edge-extension-id"
 
-# Native-messaging manifest, pinned to the extension ID and pointing at the launcher symlink.
+# Native-messaging manifest, pinned to both extension IDs and pointing at the launcher symlink.
 render_manifest() {
   sed -e "s|__HOST_PATH__|$LAUNCH_PATH|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+    -e "s|__EDGE_EXTENSION_ID__|$EDGE_ID|" \
     "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
 }
 # System-wide manifest dirs for the common Chromium-based browsers. Each browser reads only its
@@ -131,6 +143,7 @@ echo "PDF Editor native messaging host installed."
 echo "  host:     $LAUNCH_PATH -> $INSTALL_DIR/$EXE"
 echo "  manifest: $HOST_NAME.json, registered for Chrome, Chromium, Edge, Brave, Vivaldi and Opera"
 echo "  allowed:  chrome-extension://$EXTENSION_ID/"
+echo "            chrome-extension://$EDGE_ID/"
 
 if "$LAUNCH_PATH" --version >/dev/null 2>&1; then
   echo "  self-test: OK"
@@ -180,7 +193,8 @@ dpkg-deb --root-owner-group --build "$DEBROOT" "$DEB_PATH" >/dev/null
 
 echo
 echo "Built: $DEB_PATH ($(du -h "$DEB_PATH" | cut -f1))"
-echo "Extension ID pinned: $EXTENSION_ID"
+echo "Extension ID pinned:      $EXTENSION_ID"
+echo "Edge extension ID pinned: $EDGE_ID"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "deb_path=$DEB_PATH" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/package-edge-extension.sh
+++ b/scripts/package-edge-extension.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Repackages an already-built Chrome Web Store zip (see package-extension.sh) into an Edge
+# Add-ons-ready one: byte-for-byte identical except manifest.json's "key" is removed.
+#
+# The committed extension/manifest.json keeps "key" -- it pins the extension's ID to the
+# published Chrome Web Store one even when loaded unpacked (see the README's "Browser end-to-end
+# tests" section and extension/src/host-install.js), which the package-install e2e suite and the
+# native-messaging host packages both depend on. But the Microsoft Edge Add-ons store's own
+# validator rejects any package whose manifest.json has a "key" property at all, and Edge itself
+# already knows the extension's ID from its own first registration (see docs/EDGE_ADD_ONS_STORE.md)
+# -- so the field serves no purpose in an Edge submission and cannot be present in one. Rather than
+# strip it from the shared source manifest (which would break the ID-pinning above for everyone),
+# only the copy destined for Edge has it removed, at packaging time.
+#
+# Usage: ./scripts/package-edge-extension.sh <chrome-zip-path> [output-dir]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHROME_ZIP="${1:?Usage: $0 <chrome-zip-path> [output-dir]}"
+OUTPUT_DIR="${2:-$REPO_ROOT/dist}"
+
+if [[ ! -f "$CHROME_ZIP" ]]; then
+  echo "error: no such file: $CHROME_ZIP" >&2
+  exit 1
+fi
+CHROME_ZIP="$(cd "$(dirname "$CHROME_ZIP")" && pwd)/$(basename "$CHROME_ZIP")"
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+VERSION=$(python3 -c "import json; print(json.load(open('$REPO_ROOT/extension/manifest.json'))['version'])")
+EDGE_ZIP_PATH="$OUTPUT_DIR/pdf-editor-extension-edge-v${VERSION}.zip"
+rm -f "$EDGE_ZIP_PATH"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "Unpacking $(basename "$CHROME_ZIP")..."
+unzip -q "$CHROME_ZIP" -d "$STAGE"
+
+echo "Removing manifest.json's \"key\" (Edge's validator rejects a manifest that has one)..."
+python3 - "$STAGE/manifest.json" <<'EOF'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as f:
+    manifest = json.load(f)
+if "key" not in manifest:
+    sys.exit(f"error: {path} has no \"key\" to remove -- is this already an Edge package?")
+del manifest["key"]
+with open(path, "w") as f:
+    json.dump(manifest, f, indent=2)
+    f.write("\n")
+EOF
+
+echo "Packaging Edge extension v${VERSION}..."
+(
+  cd "$STAGE"
+  zip -X -r -q "$EDGE_ZIP_PATH" . \
+    -x ".*" \
+    -x "*.map" \
+    -x "**/.DS_Store"
+)
+
+echo "Verifying manifest.json sits at the zip root and has no \"key\"..."
+if ! unzip -l "$EDGE_ZIP_PATH" | awk '{print $4}' | grep -qx "manifest.json"; then
+  echo "error: manifest.json is not at the root of $EDGE_ZIP_PATH" >&2
+  exit 1
+fi
+if unzip -p "$EDGE_ZIP_PATH" manifest.json | python3 -c 'import json,sys; sys.exit(1 if "key" in json.load(sys.stdin) else 0)'; then
+  :
+else
+  echo "error: $EDGE_ZIP_PATH still has manifest.json[\"key\"]" >&2
+  exit 1
+fi
+
+echo
+echo "Packaged: $EDGE_ZIP_PATH ($(du -h "$EDGE_ZIP_PATH" | cut -f1))"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+  echo "edge_zip_path=${EDGE_ZIP_PATH}" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/package-msi.ps1
+++ b/scripts/package-msi.ps1
@@ -5,10 +5,11 @@
 # not built in the Linux dev box.
 #
 # It publishes the self-contained win-x64 host, renders the native-messaging manifest with the
-# pinned extension ID (the manifest's "path" is relative to itself, which Chrome allows on Windows),
-# and invokes `wix build` against installer/windows/PdfEditorHost.wxs. The MSI also ships
-# register-host.ps1 and the pinned extension ID next to the host, so an installed-from-MSI user can
-# re-register per-user for a developer-mode extension without a repository checkout.
+# pinned Chrome and Edge extension IDs (the manifest's "path" is relative to itself, which Chrome
+# allows on Windows), and invokes `wix build` against installer/windows/PdfEditorHost.wxs. The MSI
+# also ships register-host.ps1 and the pinned extension IDs next to the host, so an
+# installed-from-MSI user can re-register per-user for a developer-mode extension without a
+# repository checkout.
 #
 # Usage: .\scripts\package-msi.ps1 [-OutputDir dist]
 param(
@@ -19,12 +20,19 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 
 $version = (Get-Content (Join-Path $repoRoot "extension\manifest.json") -Raw | ConvertFrom-Json).version
 
-# Pinned extension ID: $env:CHROME_EXTENSION_ID wins, else the committed extension-id.txt.
+# Pinned extension IDs: $env:CHROME_EXTENSION_ID / $env:EDGE_EXTENSION_ID win, else the committed
+# extension-id.txt / edge-extension-id.txt.
 $extensionId = $env:CHROME_EXTENSION_ID
 if (-not $extensionId) {
     $extensionId = (Get-Content (Join-Path $PSScriptRoot "extension-id.txt") -Raw).Trim()
 }
 if (-not $extensionId) { throw "No extension ID (set CHROME_EXTENSION_ID or provide extension-id.txt)." }
+
+$edgeExtensionId = $env:EDGE_EXTENSION_ID
+if (-not $edgeExtensionId) {
+    $edgeExtensionId = (Get-Content (Join-Path $PSScriptRoot "edge-extension-id.txt") -Raw).Trim()
+}
+if (-not $edgeExtensionId) { throw "No Edge extension ID (set EDGE_EXTENSION_ID or provide edge-extension-id.txt)." }
 
 $stage = Join-Path ([System.IO.Path]::GetTempPath()) ("pdfeditor-msi-" + [guid]::NewGuid())
 $hostDir = Join-Path $stage "host"
@@ -38,15 +46,17 @@ dotnet publish (Join-Path $repoRoot "src\PdfEditor.NativeHost") `
 # explicitly -- otherwise the script sails past a failed publish and reports a build it never made.
 if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE." }
 
-# Render the native-messaging manifest with a relative exe path and the pinned allowed origin.
+# Render the native-messaging manifest with a relative exe path and the pinned allowed origins.
 $template = Get-Content (Join-Path $PSScriptRoot "com.pdfeditor.host.json.template") -Raw
 $manifestJson = Join-Path $stage "com.pdfeditor.host.json"
-$template.Replace("__HOST_PATH__", "PdfEditor.NativeHost.exe").Replace("__EXTENSION_ID__", $extensionId) |
+$template.Replace("__HOST_PATH__", "PdfEditor.NativeHost.exe").Replace("__EXTENSION_ID__", $extensionId).Replace("__EDGE_EXTENSION_ID__", $edgeExtensionId) |
     Set-Content -Path $manifestJson -Encoding UTF8
 
-# Shipped alongside the host so register-host.ps1 defaults to the same ID this MSI pinned.
+# Shipped alongside the host so register-host.ps1 defaults to the same IDs this MSI pinned.
 $extensionIdFile = Join-Path $stage "extension-id.txt"
 Set-Content -Path $extensionIdFile -Value $extensionId -Encoding ascii -NoNewline
+$edgeExtensionIdFile = Join-Path $stage "edge-extension-id.txt"
+Set-Content -Path $edgeExtensionIdFile -Value $edgeExtensionId -Encoding ascii -NoNewline
 
 $outDirFull = Join-Path $repoRoot $OutputDir
 New-Item -ItemType Directory -Force -Path $outDirFull | Out-Null
@@ -63,8 +73,10 @@ wix build (Join-Path $repoRoot "installer\windows\PdfEditorHost.wxs") -arch x64 
     -d "Version=$version" -d "HostDir=$hostDir" -d "ManifestJson=$manifestJson" `
     -d "RegisterScript=$(Join-Path $PSScriptRoot 'register-host.ps1')" `
     -d "ExtensionIdFile=$extensionIdFile" `
+    -d "EdgeExtensionIdFile=$edgeExtensionIdFile" `
     -o $msiPath
 if ($LASTEXITCODE -ne 0) { throw "wix build failed with exit code $LASTEXITCODE." }
 
 Write-Host "Built: $msiPath"
-Write-Host "Extension ID pinned: $extensionId"
+Write-Host "Extension ID pinned:      $extensionId"
+Write-Host "Edge extension ID pinned: $edgeExtensionId"

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -7,7 +7,8 @@
 # the native-messaging manifest as a package-owned file (marked %config so `dnf remove` cleans it
 # up). The manifest points at the /usr/bin launcher rather than at /opt, because a sandboxed
 # browser is far more likely to be permitted to execute it there. allowed_origins is pinned to the
-# extension ID (from $CHROME_EXTENSION_ID, else scripts/extension-id.txt).
+# Chrome and Edge extension IDs (from $CHROME_EXTENSION_ID/$EDGE_EXTENSION_ID, else
+# scripts/extension-id.txt/edge-extension-id.txt).
 #
 # It also ships /usr/bin/pdf-editor-host-register, the per-user helper for the two cases no
 # system-wide manifest can reach: snap/flatpak browsers, and a developer-mode extension whose ID
@@ -34,6 +35,15 @@ if [[ -z "$EXTENSION_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
 fi
 if [[ -z "$EXTENSION_ID" ]]; then
   echo "error: no extension ID (set CHROME_EXTENSION_ID or scripts/extension-id.txt)" >&2
+  exit 1
+fi
+
+EDGE_ID="${EDGE_EXTENSION_ID:-}"
+if [[ -z "$EDGE_ID" && -f "$REPO_ROOT/scripts/edge-extension-id.txt" ]]; then
+  EDGE_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/edge-extension-id.txt")"
+fi
+if [[ -z "$EDGE_ID" ]]; then
+  echo "error: no Edge extension ID (set EDGE_EXTENSION_ID or scripts/edge-extension-id.txt)" >&2
   exit 1
 fi
 
@@ -71,16 +81,19 @@ find "$BUILDROOT$INSTALL_DIR" -type f \( -name '*.so' -o -name 'createdump' \) -
 mkdir -p "$BUILDROOT/usr/bin"
 ln -sf "$INSTALL_DIR/$EXE" "$BUILDROOT$LAUNCH_PATH"
 
-# Per-user registration helper, plus the extension ID this package was built with so the helper
-# defaults to the same one.
+# Per-user registration helper, plus the extension IDs this package was built with so the helper
+# defaults to the same ones.
 install -Dm0755 "$REPO_ROOT/scripts/register-host.sh" "$BUILDROOT$REGISTER_PATH"
 install -d -m0755 "$BUILDROOT$SHARE_DIR"
 printf '%s\n' "$EXTENSION_ID" > "$BUILDROOT$SHARE_DIR/extension-id"
 chmod 0644 "$BUILDROOT$SHARE_DIR/extension-id"
+printf '%s\n' "$EDGE_ID" > "$BUILDROOT$SHARE_DIR/edge-extension-id"
+chmod 0644 "$BUILDROOT$SHARE_DIR/edge-extension-id"
 
-# Native-messaging manifest, pinned to the extension ID and pointing at the launcher symlink.
+# Native-messaging manifest, pinned to both extension IDs and pointing at the launcher symlink.
 render_manifest() {
   sed -e "s|__HOST_PATH__|$LAUNCH_PATH|" -e "s|__EXTENSION_ID__|$EXTENSION_ID|" \
+    -e "s|__EDGE_EXTENSION_ID__|$EDGE_ID|" \
     "$REPO_ROOT/scripts/com.pdfeditor.host.json.template"
 }
 # Register for every common Chromium-based browser (see linux-manifest-dirs.sh). Each %config
@@ -119,6 +132,7 @@ cp -a %{_sourcedir}/buildroot/. %{buildroot}/
 echo "PDF Editor native messaging host installed."
 echo "  host:     $LAUNCH_PATH -> $INSTALL_DIR/$EXE"
 echo "  allowed:  chrome-extension://$EXTENSION_ID/"
+echo "            chrome-extension://$EDGE_ID/"
 if "$LAUNCH_PATH" --version >/dev/null 2>&1; then
   echo "  self-test: OK"
 else
@@ -163,7 +177,8 @@ mv "$BUILT" "$RPM_PATH"
 
 echo
 echo "Built: $RPM_PATH ($(du -h "$RPM_PATH" | cut -f1))"
-echo "Extension ID pinned: $EXTENSION_ID"
+echo "Extension ID pinned:      $EXTENSION_ID"
+echo "Edge extension ID pinned: $EDGE_ID"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "rpm_path=$RPM_PATH" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/register-host.ps1
+++ b/scripts/register-host.ps1
@@ -1,10 +1,10 @@
 # Registers an already-installed PDF Editor native messaging host with the *current user's*
 # Chromium-based browsers on Windows. The counterpart of scripts/register-host.sh on Linux/macOS.
 #
-# The MSI registers the host machine-wide under HKLM and pins allowed_origins to the published Web
-# Store extension ID. That is right for the common case and wrong for one: a developer-mode /
-# unpacked extension has a different, machine-specific ID, so the pinned origin never matches and
-# the browser refuses the connection. Chromium looks in HKEY_CURRENT_USER before
+# The MSI registers the host machine-wide under HKLM and pins allowed_origins to the published
+# Chrome and Edge Web Store extension IDs. That is right for the common case and wrong for one: a
+# developer-mode / unpacked extension has a different, machine-specific ID, so the pinned origins
+# never match and the browser refuses the connection. Chromium looks in HKEY_CURRENT_USER before
 # HKEY_LOCAL_MACHINE, so writing a per-user manifest here overrides the MSI's without touching it.
 #
 # The MSI installs this script next to the host (Program Files\PDF Editor Host\register-host.ps1)
@@ -13,9 +13,10 @@
 # is safe to re-run.
 #
 # Usage:
-#   .\register-host.ps1 [-ExtensionId <id>] [-HostPath <path>] [-List] [-Uninstall]
+#   .\register-host.ps1 [-ExtensionId <id>] [-EdgeExtensionId <id>] [-HostPath <path>] [-List] [-Uninstall]
 param(
     [string]$ExtensionId = "",
+    [string]$EdgeExtensionId = "",
     [string]$HostPath = "",
     [switch]$List,
     [switch]$Uninstall
@@ -24,9 +25,11 @@ param(
 $ErrorActionPreference = "Stop"
 
 $hostName = "com.pdfeditor.host"
-# Pinned Chrome Web Store extension ID, used when nothing else supplies one. The MSI drops the ID
-# it was built with next to the host so a rebuild for a different ID stays self-consistent.
-$defaultExtensionId = "ikbkielkpaloojhibinmcfbeekhkdblc"
+# Pinned Chrome and Edge Web Store extension IDs, used when nothing else supplies one. The MSI
+# drops the IDs it was built with next to the host so a rebuild for different IDs stays
+# self-consistent.
+$defaultExtensionId = "cbmfodojjlfppljbdebmpbcppngkkibi"
+$defaultEdgeExtensionId = "kcppllhgnfmdbmglohgmabipeikopfhb"
 
 # Per-user manifests live under LOCALAPPDATA: HKCU keys are per-user, so pointing them at a
 # machine-wide file the user cannot rewrite would defeat the purpose.
@@ -62,10 +65,21 @@ if (-not $ExtensionId) {
 }
 if (-not $ExtensionId) { $ExtensionId = $defaultExtensionId }
 
-# A Chrome extension ID is exactly 32 characters from a-p (a base-16 digest re-encoded into
-# letters). Catching a typo here beats a browser silently refusing the connection later.
+if (-not $EdgeExtensionId) { $EdgeExtensionId = $env:EDGE_EXTENSION_ID }
+if (-not $EdgeExtensionId) {
+    $edgeIdFile = Join-Path $PSScriptRoot "edge-extension-id.txt"
+    if (Test-Path $edgeIdFile) { $EdgeExtensionId = (Get-Content $edgeIdFile -Raw).Trim() }
+}
+if (-not $EdgeExtensionId) { $EdgeExtensionId = $defaultEdgeExtensionId }
+
+# A Chromium extension ID is exactly 32 characters from a-p (a base-16 digest re-encoded into
+# letters), for Chrome and Edge alike. Catching a typo here beats a browser silently refusing the
+# connection later.
 if ($ExtensionId -cnotmatch '^[a-p]{32}$') {
     throw "'$ExtensionId' is not a valid extension ID (expected 32 characters, a-p). Find yours at chrome://extensions with Developer mode on."
+}
+if ($EdgeExtensionId -cnotmatch '^[a-p]{32}$') {
+    throw "'$EdgeExtensionId' is not a valid Edge extension ID (expected 32 characters, a-p)."
 }
 
 # ------------------------------------------------------------------- host path
@@ -104,7 +118,8 @@ if ($HostPath) { $HostPath = [System.IO.Path]::GetFullPath($HostPath) }
 # ---------------------------------------------------------------------- actions
 
 if ($List) {
-    Write-Host "Extension ID: $ExtensionId"
+    Write-Host "Extension ID:      $ExtensionId"
+    Write-Host "Edge extension ID: $EdgeExtensionId"
     if ($HostPath) { Write-Host "Host path:    $HostPath" } else { Write-Host "Host path:    <not found>" }
     Write-Host "Manifest:     $manifestPath"
     Write-Host "Registry keys:"
@@ -145,7 +160,8 @@ $manifest = @"
   "path": "$escapedHostPath",
   "type": "stdio",
   "allowed_origins": [
-    "chrome-extension://$ExtensionId/"
+    "chrome-extension://$ExtensionId/",
+    "chrome-extension://$EdgeExtensionId/"
   ]
 }
 "@
@@ -160,9 +176,10 @@ foreach ($root in $registryRoots) {
 
 Write-Host ""
 Write-Host "Registered the host for this user in $($registryRoots.Count) location(s)."
-Write-Host "  host path:    $HostPath"
-Write-Host "  extension ID: $ExtensionId"
-Write-Host "  manifest:     $manifestPath"
+Write-Host "  host path:         $HostPath"
+Write-Host "  extension ID:      $ExtensionId"
+Write-Host "  Edge extension ID: $EdgeExtensionId"
+Write-Host "  manifest:          $manifestPath"
 
 # The host is only useful if it actually starts. A host that exits immediately is reported by the
 # browser as one that "has exited", which looks much like a host that was never installed -- say so

--- a/scripts/register-host.sh
+++ b/scripts/register-host.sh
@@ -7,23 +7,28 @@
 #
 #   * snap and flatpak browsers  -- they run sandboxed and read their manifests from inside the
 #     sandbox's own config tree (~/snap/... or ~/.var/app/...), never from /etc.
-#   * a developer-mode extension -- the packages pin allowed_origins to the published Web Store
-#     extension ID; an unpacked extension has a different, machine-specific ID, so it needs its own
-#     manifest. A per-user manifest takes precedence over the system-wide one.
+#   * a developer-mode extension whose ID is neither published one -- the packages pin
+#     allowed_origins to the published Chrome and Edge Web Store IDs; a custom-built/re-keyed
+#     extension has a different ID, so it needs its own manifest. A per-user manifest takes
+#     precedence over the system-wide one.
 #
 # This script fixes both. It only writes manifests -- it never downloads or builds anything, so it
 # is safe to re-run. The Linux packages install it as /usr/bin/pdf-editor-host-register; it also
 # runs on macOS, where scripts/install-host.sh delegates its registration step to it.
 #
 # Usage:
-#   pdf-editor-host-register [--extension-id ID] [--host-path PATH] [--uninstall] [--list]
+#   pdf-editor-host-register [--extension-id ID] [--edge-extension-id ID] [--host-path PATH]
+#                             [--uninstall] [--list]
 set -euo pipefail
 
 HOST_NAME="com.pdfeditor.host"
-# Pinned Chrome Web Store extension ID, used when nothing else supplies one. The packages drop the
-# ID they were built with next to the host so a rebuild for a different ID stays self-consistent.
-DEFAULT_EXTENSION_ID="ikbkielkpaloojhibinmcfbeekhkdblc"
+# Pinned Chrome and Edge Web Store extension IDs, used when nothing else supplies one. The
+# packages drop the IDs they were built with next to the host so a rebuild for different IDs
+# stays self-consistent.
+DEFAULT_EXTENSION_ID="cbmfodojjlfppljbdebmpbcppngkkibi"
+DEFAULT_EDGE_EXTENSION_ID="kcppllhgnfmdbmglohgmabipeikopfhb"
 EXTENSION_ID_FILE="/usr/share/pdf-editor-host/extension-id"
+EDGE_EXTENSION_ID_FILE="/usr/share/pdf-editor-host/edge-extension-id"
 # Where the OS packages put the host. The /usr/bin entry is a symlink onto the second path; it is
 # preferred because sandboxed browsers are far more likely to be allowed to execute /usr/bin.
 HOST_PATH_CANDIDATES=(
@@ -33,6 +38,7 @@ HOST_PATH_CANDIDATES=(
 )
 
 EXTENSION_ID=""
+EDGE_ID=""
 HOST_PATH=""
 MODE="install"
 
@@ -40,19 +46,22 @@ usage() {
   cat >&2 <<'USAGE'
 Usage: pdf-editor-host-register [options]
 
-  --extension-id ID   Extension ID to allow (default: the pinned Web Store ID, or the ID the
-                      installed package was built with). Use your unpacked extension's ID --
-                      find it at chrome://extensions with Developer mode on.
-  --host-path PATH    Path to the host executable (default: autodetected).
-  --uninstall         Remove the per-user manifests this script wrote.
-  --list              Show what would be written (or removed) and exit.
-  -h, --help          This message.
+  --extension-id ID        Chrome/Chromium extension ID to allow (default: the pinned Web Store
+                           ID, or the ID the installed package was built with). Use your unpacked
+                           extension's ID -- find it at chrome://extensions with Developer mode on.
+  --edge-extension-id ID   Same, for Microsoft Edge (default: the pinned Edge Add-ons ID, or the
+                           ID the installed package was built with).
+  --host-path PATH         Path to the host executable (default: autodetected).
+  --uninstall              Remove the per-user manifests this script wrote.
+  --list                   Show what would be written (or removed) and exit.
+  -h, --help               This message.
 USAGE
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --extension-id) EXTENSION_ID="${2:?--extension-id needs a value}"; shift 2 ;;
+    --extension-id)      EXTENSION_ID="${2:?--extension-id needs a value}"; shift 2 ;;
+    --edge-extension-id) EDGE_ID="${2:?--edge-extension-id needs a value}"; shift 2 ;;
     --host-path)    HOST_PATH="${2:?--host-path needs a value}"; shift 2 ;;
     --uninstall)    MODE="uninstall"; shift ;;
     --list)         MODE="list"; shift ;;
@@ -69,10 +78,23 @@ if [[ -z "$EXTENSION_ID" && -r "$EXTENSION_ID_FILE" ]]; then
 fi
 : "${EXTENSION_ID:=$DEFAULT_EXTENSION_ID}"
 
-# A Chrome extension ID is exactly 32 characters from a-p (a base-16 digest re-encoded into
-# letters). Catching a typo here beats a browser silently refusing the connection later.
+if [[ -z "$EDGE_ID" ]]; then
+  EDGE_ID="${EDGE_EXTENSION_ID:-}"
+fi
+if [[ -z "$EDGE_ID" && -r "$EDGE_EXTENSION_ID_FILE" ]]; then
+  EDGE_ID="$(tr -d '[:space:]' < "$EDGE_EXTENSION_ID_FILE")"
+fi
+: "${EDGE_ID:=$DEFAULT_EDGE_EXTENSION_ID}"
+
+# A Chromium extension ID is exactly 32 characters from a-p (a base-16 digest re-encoded into
+# letters), for Chrome and Edge alike. Catching a typo here beats a browser silently refusing the
+# connection later.
 if [[ ! "$EXTENSION_ID" =~ ^[a-p]{32}$ ]]; then
   echo "error: '$EXTENSION_ID' is not a valid extension ID (expected 32 characters, a-p)" >&2
+  exit 1
+fi
+if [[ ! "$EDGE_ID" =~ ^[a-p]{32}$ ]]; then
+  echo "error: '$EDGE_ID' is not a valid Edge extension ID (expected 32 characters, a-p)" >&2
   exit 1
 fi
 
@@ -216,7 +238,8 @@ add_flatpak com.opera.Opera opera
 # -------------------------------------------------------------------- actions
 
 if [[ "$MODE" == "list" ]]; then
-  echo "Extension ID: $EXTENSION_ID"
+  echo "Extension ID:      $EXTENSION_ID"
+  echo "Edge extension ID: $EDGE_ID"
   echo "Host path:    ${HOST_PATH:-<not found>}"
   if [[ -n "$HOST_PATH" && "$FLATPAK_HOST_PATH" != "$HOST_PATH" ]]; then
     echo "  (flatpak:   $FLATPAK_HOST_PATH -- flatpak will not share $HOST_PATH into a sandbox)"
@@ -256,7 +279,8 @@ manifest_for() {
   "path": "$1",
   "type": "stdio",
   "allowed_origins": [
-    "chrome-extension://$EXTENSION_ID/"
+    "chrome-extension://$EXTENSION_ID/",
+    "chrome-extension://$EDGE_ID/"
   ]
 }
 MANIFEST_JSON
@@ -278,8 +302,9 @@ done
 
 echo
 echo "Registered the host for this user in $written location(s)."
-echo "  host path:    $HOST_PATH"
-echo "  extension ID: $EXTENSION_ID"
+echo "  host path:         $HOST_PATH"
+echo "  extension ID:      $EXTENSION_ID"
+echo "  Edge extension ID: $EDGE_ID"
 
 # The host is only useful if it actually starts; a self-contained .NET build that is missing a
 # system library exits immediately and the browser reports it as a host that "has exited", which

--- a/scripts/verify-linux-package.sh
+++ b/scripts/verify-linux-package.sh
@@ -23,6 +23,11 @@ if [[ -z "$EXPECTED_ID" && -f "$REPO_ROOT/scripts/extension-id.txt" ]]; then
   EXPECTED_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/extension-id.txt")"
 fi
 
+EXPECTED_EDGE_ID="${EDGE_EXTENSION_ID:-}"
+if [[ -z "$EXPECTED_EDGE_ID" && -f "$REPO_ROOT/scripts/edge-extension-id.txt" ]]; then
+  EXPECTED_EDGE_ID="$(tr -d '[:space:]' < "$REPO_ROOT/scripts/edge-extension-id.txt")"
+fi
+
 if [[ $# -eq 0 ]]; then
   echo "Usage: $0 <package> [<package>...]" >&2
   exit 1
@@ -132,12 +137,14 @@ verify_one() {
     fail "manifest points at '$host_path', expected '$LAUNCH_PATH'"
   fi
 
-  # 4. allowed_origins must be the pinned extension ID, with the trailing slash Chrome requires.
-  if [[ -n "$EXPECTED_ID" ]]; then
-    if [[ "$origins" == "chrome-extension://$EXPECTED_ID/" ]]; then
-      pass "allowed_origins pinned to $EXPECTED_ID"
+  # 4. allowed_origins must be the pinned Chrome and Edge extension IDs, with the trailing slash
+  #    Chrome requires, Chrome first then Edge (the order every renderer here uses).
+  if [[ -n "$EXPECTED_ID" && -n "$EXPECTED_EDGE_ID" ]]; then
+    expected="chrome-extension://$EXPECTED_ID/,chrome-extension://$EXPECTED_EDGE_ID/"
+    if [[ "$origins" == "$expected" ]]; then
+      pass "allowed_origins pinned to $EXPECTED_ID and $EXPECTED_EDGE_ID"
     else
-      fail "allowed_origins is '$origins', expected 'chrome-extension://$EXPECTED_ID/'"
+      fail "allowed_origins is '$origins', expected '$expected'"
     fi
   fi
 

--- a/scripts/verify-msi.ps1
+++ b/scripts/verify-msi.ps1
@@ -9,10 +9,11 @@
 # It reads the MSI's own tables through the Windows Installer API (no install required) and, when
 # it can, also extracts the payload with an administrative install to check the shipped manifest.
 #
-# Usage: .\scripts\verify-msi.ps1 <path-to-msi> [-ExpectedExtensionId <id>]
+# Usage: .\scripts\verify-msi.ps1 <path-to-msi> [-ExpectedExtensionId <id>] [-ExpectedEdgeExtensionId <id>]
 param(
     [Parameter(Mandatory = $true)][string]$MsiPath,
-    [string]$ExpectedExtensionId = ""
+    [string]$ExpectedExtensionId = "",
+    [string]$ExpectedEdgeExtensionId = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -31,7 +32,7 @@ $expectedKeys = @(
     "SOFTWARE\Vivaldi\NativeMessagingHosts\$hostName",
     "SOFTWARE\Opera Software\NativeMessagingHosts\$hostName"
 )
-$expectedFiles = @("PdfEditor.NativeHost.exe", $manifestName, "register-host.ps1", "extension-id.txt")
+$expectedFiles = @("PdfEditor.NativeHost.exe", $manifestName, "register-host.ps1", "extension-id.txt", "edge-extension-id.txt")
 
 $script:failures = 0
 # Named with the Show- verb rather than Add-/Write-: both write to the host for a human reading the
@@ -206,12 +207,15 @@ if ($extracted) {
         }
 
         $origins = @($manifest.allowed_origins)
-        if ($origins.Count -ne 1 -or $origins[0] -notmatch '^chrome-extension://[a-p]{32}/$') {
-            Show-Failure "$manifestName allowed_origins is '$($origins -join ', ')', expected a single chrome-extension://<id>/ origin"
+        if ($origins.Count -ne 2 -or ($origins | Where-Object { $_ -notmatch '^chrome-extension://[a-p]{32}/$' })) {
+            Show-Failure "$manifestName allowed_origins is '$($origins -join ', ')', expected exactly two chrome-extension://<id>/ origins (Chrome, then Edge)"
         } else {
-            Show-Pass "$manifestName allows $($origins[0])"
+            Show-Pass "$manifestName allows $($origins -join ', ')"
             if ($ExpectedExtensionId -and $origins[0] -ne "chrome-extension://$ExpectedExtensionId/") {
-                Show-Failure "$manifestName pins a different extension ID than the expected $ExpectedExtensionId"
+                Show-Failure "$manifestName pins a different Chrome extension ID than the expected $ExpectedExtensionId"
+            }
+            if ($ExpectedEdgeExtensionId -and $origins[1] -ne "chrome-extension://$ExpectedEdgeExtensionId/") {
+                Show-Failure "$manifestName pins a different Edge extension ID than the expected $ExpectedEdgeExtensionId"
             }
         }
     }

--- a/tests/PdfEditor.NativeHost.Tests/HostDiagnosticsTests.cs
+++ b/tests/PdfEditor.NativeHost.Tests/HostDiagnosticsTests.cs
@@ -56,7 +56,7 @@ public class HostDiagnosticsTests
         // Chrome launches the host with the calling extension's origin as argv[0].
         var writer = new StringWriter();
         Assert.Null(HostDiagnostics.TryRunCli(
-            new[] { "chrome-extension://ikbkielkpaloojhibinmcfbeekhkdblc/" }, writer));
+            new[] { "chrome-extension://cbmfodojjlfppljbdebmpbcppngkkibi/" }, writer));
         Assert.Equal("", writer.ToString());
     }
 }


### PR DESCRIPTION
Two commits, in dependency order.

## 1. Fix the pinned Chrome extension ID, and extend native messaging to Edge

While wiring up Edge, cryptographic verification of the public key you provided turned up a real, already-shipping bug: `extension/manifest.json`'s `"key"` and the committed `scripts/extension-id.txt` both pinned `ikbkielkpaloojhibinmcfbeekhkdblc` — but the actual, published Chrome Web Store item's ID is `cbmfodojjlfppljbdebmpbcppngkkibi` (confirmed by hashing the real Chrome Web Store public key you gave me, which matches this ID and not the old one).

Every native-host package (`.deb`/`.rpm`/Arch/MSI) has been pinning `allowed_origins` to an ID nobody's real install has — native messaging would silently fail for actual Chrome Web Store users, with only "Specified native messaging host not found" and no hint why.

**Fixed at the source:** `manifest.json`'s `"key"` is now the real Chrome Web Store keypair's public key, so `extension-id.txt` and every unpacked/dev-mode load (what the `package-install-e2e` suite drives, and what `host-install.js`'s FORBIDDEN-state diagnosis assumes) all agree with the real, live ID.

**Extending to Edge, additively:** Edge is Chromium-based and reads the exact same native-messaging manifest format, so `allowed_origins` gains a second entry everywhere it's built — the shared `scripts/com.pdfeditor.host.json.template` the four OS packagers and the MSI render from, and `register-host.sh`/`.ps1`'s own inline manifest — sourced the same way the Chrome ID already was (`--edge-extension-id` / an `EDGE_EXTENSION_ID` env var / the committed `scripts/edge-extension-id.txt`), mirroring the Chrome resolution chain exactly. Both verify scripts and the CI/release-candidate jobs that call them now expect and check both origins.

**Regression test added:** `host-install.test.mjs` now cross-checks `PINNED_EXTENSION_ID`/`EDGE_PINNED_EXTENSION_ID` against their committed `.txt` files and against what `manifest.json`'s `"key"` actually computes to — the three independent copies that let the Chrome ID drift silently in the first place. I verified it actually catches drift (deliberately desynced `extension-id.txt`, confirmed the test fails, restored it, confirmed it passes).

## 2. Deploy releases to the Microsoft Edge Add-ons store automatically

Mirrors the Chrome Web Store deploy. `release-extension.yml`'s `package` job now also builds an Edge-specific zip and, on a published (non-prerelease) GitHub Release, uploads and publishes it via Microsoft's Edge Add-ons REST API (v1.1).

**Why a separate zip:** `manifest.json` keeps `"key"` (see commit 1 — it's load-bearing for the e2e suite and for Chrome ID pinning), but Edge's own submission validator rejects any package whose manifest has a `"key"` at all. `scripts/package-edge-extension.sh` takes the already-built Chrome zip and re-packages it with `"key"` stripped from the copy, so the two can never drift apart in anything but that one line. Verified by hand: unzipped both, diffed the manifests (differ only in the `"key"` line) and the file listings (identical).

**Why curl instead of a package:** three HTTP calls (upload, poll, publish, poll), authenticated with two headers (`ApiKey` + `X-ClientID` — the current v1.1 scheme, no OAuth exchange needed) — matching how the existing Chrome step avoids a GitHub Marketplace Action, one fewer opaque dependency in a release pipeline.

**Verified end-to-end against a local mock server** standing in for the Edge API: the success path (upload → poll to Succeeded → publish → poll to Completed) and the failure path (a poll that returns `"Failed"` fails the job with the API's own error body surfaced, exit 1).

Caught two real bugs by extracting the step's script and running it standalone rather than trusting it unread:
- A multi-line Python heredoc embedded in the YAML block scalar broke YAML's own indentation rules.
- Once that was fixed, the same snippet broke Python's indentation rules instead (top-level statements can't have leading whitespace, even uniform whitespace).

Replaced both with a `jq` one-liner (pre-installed on GitHub-hosted runners), verified safe under `set -e` against both a well-formed and a malformed API response.

### Needed to actually run

Three new repo secrets — `docs/EDGE_ADD_ONS_STORE.md` is the checklist for getting them, mirroring `CHROME_WEB_STORE.md`:
- `EDGE_PRODUCT_ID` (Partner Center's Product ID — `2219de73-2b3f-4327-b8d0-1e38d4160f2b`, not the Store ID or CRXID)
- `EDGE_CLIENT_ID`, `EDGE_API_KEY` (from Partner Center's Publish API access page — not yet generated, per our conversation)

Like the Chrome job, a missing secret skips the deploy gracefully and leaves the packaged zip as a build artifact for manual upload.

**Not secrets, and not needed anywhere in the pipeline:** the Store ID (`0RDCKF3D4DH2`, only used for the public listing URL) and the Edge public key you gave me (no operational role — Edge's validator forbids `"key"` in the manifest, so nothing ever embeds it; it was useful only to verify the CRXID, which I did — see `docs/EDGE_ADD_ONS_STORE.md` §2).

## Verification

- `node --test "extension/test/**/*.test.mjs"` — 116 pass (114 existing + 2 new), 0 fail
- `node scripts/check-innerhtml.mjs` — clean
- All three touched workflow YAML files parse
- `bash -n` clean on every touched shell script
- A synthetic `.deb` built locally and run through the real `verify-linux-package.sh` — passes, both origins present in the rendered manifest
- The shared template's `sed` substitution verified to render both origins correctly
- The Edge deploy step extracted from the YAML and run standalone against a local mock server (success and failure paths both confirmed)

`dotnet`, `bsdtar`, `rpmbuild`, and `zstd` are not installed in this environment, so the `.rpm`/Arch packagers and the C# test project could not be built or run directly here — the C# change (`HostDiagnosticsTests.cs`) is a one-line string-literal swap, low risk, but worth a CI confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHQnn9v3uzCgW5ppxLhnBu)_