### PR TITLE
Fix doc-shots.js screenshot size, and add a workflow to regenerate them

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -1,0 +1,80 @@
+name: Generate Screenshots
+
+# Regenerates docs/screenshots/ by driving the real extension and native host against the sample
+# document (e2e/scripts/doc-shots.js) -- the same images the README embeds and the store listings
+# use. Manual only: these are visual assets for a public listing, worth a human look before they
+# land, not something that should regenerate (and diff) on every push.
+#
+# Opens a PR with whatever changed rather than pushing straight to the default branch, so the
+# images get reviewed like any other change. If nothing changed, the job stops after uploading the
+# artifact -- no empty PR.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "8.0.x"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+      - name: Install e2e dependencies
+        working-directory: e2e
+        run: npm ci --ignore-scripts
+      - name: Install Playwright Chromium
+        working-directory: e2e
+        run: npx --no-install playwright@1.61.1 install --with-deps chromium
+
+      - name: Generate screenshots
+        working-directory: e2e
+        # doc-shots.js catches each screenshot's own errors so one bad shot doesn't abort the
+        # rest -- it prints "✗ name — reason" for that one and keeps going, and still exits 0.
+        # Left alone that ships a stale image with a green run, so this step fails the build
+        # itself on any ✗ in the script's own summary.
+        run: |
+          set -o pipefail
+          node scripts/doc-shots.js 2>&1 | tee /tmp/doc-shots.log
+          if grep -q '✗' /tmp/doc-shots.log; then
+            echo "::error::One or more screenshots failed to capture:"
+            grep '✗' /tmp/doc-shots.log
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: doc-screenshots
+          path: docs/screenshots/
+          if-no-files-found: error
+
+      - name: Open a PR with the regenerated screenshots
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/screenshots; then
+            echo "No screenshot changes; nothing to open a PR for."
+            exit 0
+          fi
+
+          branch="docs/screenshots-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add docs/screenshots
+          git commit -m "Regenerate documentation/store screenshots"
+          git push origin "$branch"
+
+          gh pr create \
+            --title "Regenerate documentation/store screenshots" \
+            --base "$DEFAULT_BRANCH" \
+            --head "$branch" \
+            --body "Automated run of \`e2e/scripts/doc-shots.js\` via the Generate Screenshots workflow (run ${{ github.run_id }}). Every shot in the run's own summary reported ✓ (a ✗ would have failed the job before this step), but review the images themselves before merging -- nothing here checks that a screenshot shows the right *thing*, only that it was captured."

--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -72,9 +72,9 @@ installed and link to the install instructions.
 **Graphics required by the store:**
 - [x] Store icon 128×128 — `extension/icons/icon128.png` (also mirrored at
       `docs/store/store-icon-128.png`, with a 512×512 master at `docs/store/store-icon-512.png`).
-- [ ] At least one **screenshot 1280×800** (or 640×400). The generated shots in
-      `docs/screenshots/` are a starting point but are captured at a different size — recapture at
-      1280×800 (adjust the viewport in `e2e/scripts/doc-shots.js`) or crop/pad to the required size.
+- [ ] At least one **screenshot 1280×800**. `e2e/scripts/doc-shots.js` now captures at exactly that
+      size (`node e2e/scripts/doc-shots.js`, needs the .NET SDK and Playwright's Chromium — see
+      CONTRIBUTING.md) — the shots in `docs/screenshots/` just haven't been regenerated with it yet.
 - [x] Optional: small promo tile 440×280 — `docs/store/small-promo-440x280.png`.
 - [x] Optional: marquee promo tile 1400×560 — `docs/store/marquee-1400x560.png`.
 

--- a/e2e/helpers/harness.js
+++ b/e2e/helpers/harness.js
@@ -142,7 +142,7 @@ function systemHostManifests() {
  *   a leftover installed package turns "no host" into a connected one, and a missing package
  *   turns the package suite into a test of nothing.
  */
-async function launchExtension({ host: hostSource = 'profile' } = {}) {
+async function launchExtension({ host: hostSource = 'profile', viewport } = {}) {
   // Only the two host sources that depend on what is installed system-wide look; the default
   // registers its own host into the profile and would just be paying for the scan.
   const systemManifests = hostSource === 'profile' ? [] : systemHostManifests();
@@ -185,6 +185,11 @@ async function launchExtension({ host: hostSource = 'profile' } = {}) {
       `--load-extension=${EXTENSION_DIR}`,
     ],
   };
+  // Undefined leaves Playwright's own default (1280x720) for every caller except doc-shots.js,
+  // which needs the store's exact 1280x800 screenshot size.
+  if (viewport) {
+    launchOptions.viewport = viewport;
+  }
   if (executablePath) {
     launchOptions.executablePath = executablePath;
   } else {

--- a/e2e/scripts/doc-shots.js
+++ b/e2e/scripts/doc-shots.js
@@ -83,7 +83,9 @@ async function shot(page, name, fn) {
     execFileSync('node', [path.join(REPO_ROOT, 'scripts', 'generate-sample-pdf.mjs')], { stdio: 'inherit' });
   }
   buildPrerequisites();
-  const ext = await launchExtension();
+  // The Chrome/Edge store listings want a 1280x800 screenshot; Playwright's own default
+  // (1280x720) is 80px short.
+  const ext = await launchExtension({ viewport: { width: 1280, height: 800 } });
   try {
     // 1) Overview — the document open, both charts visible on page 1.
     let page = await openViewer(ext);


### PR DESCRIPTION
Follow-up to #160 (merged) — two commits, closing out the "screenshot size" item from that PR's store checklist and giving it a way to actually run.

## 1. Capture doc-shots.js screenshots at the store's exact 1280x800 size

Both store checklists want a 1280×800 screenshot; `docs/screenshots/` has been 80px short in height, because `launchExtension()` left Playwright's own default viewport (1280×720) in place.

`launchExtension()` gains an optional `viewport` override — every other caller (the real test suites, `shots.js`) passes none and keeps exactly today's behavior, since the option is only applied when given. Only `doc-shots.js` now requests 1280×800. `shot()`'s `page.screenshot()` has no `fullPage`, so it already captures exactly the viewport — no change needed there.

Not run here: this environment has no .NET SDK, and `buildPrerequisites()` (which `doc-shots.js` calls before launching) shells out to `dotnet build` to produce the native host the screenshots need to talk to. Verified with `node --check` on both files and by confirming every other `launchExtension` call site is unaffected (grepped every caller — none pass a `viewport` key).

## 2. Add a workflow to regenerate the documentation/store screenshots

Gives the fix above somewhere to actually run, since this environment can't. `workflow_dispatch` only — these are visual assets for a public listing, worth a human look before they land, not something that should regenerate (and diff) on every push.

Builds the native host, installs Playwright's Chromium, runs `e2e/scripts/doc-shots.js`, then opens a PR with whatever changed in `docs/screenshots/` rather than pushing straight to the default branch.

**A correctness gap worth flagging explicitly:** `doc-shots.js` catches each screenshot's own errors internally so one bad shot doesn't abort the rest — it logs `✗ name — reason` for that one and keeps going, and **still exits 0**. Left alone, that ships a stale/missing image with a green run. The workflow step also fails the build itself on any `✗` in the script's own summary output. I verified both branches of that check (a log with a `✗`, and a clean log) directly in bash before trusting it inside the workflow, and separately verified the no-diff-skips-the-PR check against the actual repo state.

Uses `gh pr create` with the built-in `GITHUB_TOKEN` rather than a third-party Action, matching how the Chrome and Edge store-deploy jobs in #160 already avoid GitHub Marketplace Actions.

## Verification

- `node --test "extension/test/**/*.test.mjs"` — 116 pass, 0 fail (unchanged from #160)
- `node scripts/check-innerhtml.mjs` — clean
- All four workflow YAML files parse, including the new one
- `bash -n` clean on every extracted `run:` block in the new workflow
- The `✗`-detection and no-diff-skip logic each tested standalone with mocked/real inputs before being trusted inside the workflow

## What this doesn't do

Doesn't run the workflow itself, and doesn't regenerate `docs/screenshots/` — that needs a real run with `.NET`/Playwright available, which is exactly what this PR gives you a button for (Actions → Generate Screenshots → Run workflow). GitHub Pages for the privacy policy is still a manual repo-settings toggle — no tool I have can flip that; see the earlier conversation for the exact steps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHQnn9v3uzCgW5ppxLhnBu)_