### PR TITLE
Fix the real screenshot-size bug, and stop the PR step failing the job

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -58,6 +58,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           if git diff --quiet -- docs/screenshots; then
@@ -73,8 +75,24 @@ jobs:
           git commit -m "Regenerate documentation/store screenshots"
           git push origin "$branch"
 
-          gh pr create \
+          # Best-effort, like release-extension.yml's GitHub Release attach step: the images are
+          # already generated and pushed by this point, which is the actual point of the job, so a
+          # repo with "Allow GitHub Actions to create pull requests" left off (the default) should
+          # not turn a successful screenshot run red over the one step that needs it.
+          if gh pr create \
             --title "Regenerate documentation/store screenshots" \
             --base "$DEFAULT_BRANCH" \
             --head "$branch" \
-            --body "Automated run of \`e2e/scripts/doc-shots.js\` via the Generate Screenshots workflow (run ${{ github.run_id }}). Every shot in the run's own summary reported ✓ (a ✗ would have failed the job before this step), but review the images themselves before merging -- nothing here checks that a screenshot shows the right *thing*, only that it was captured."
+            --body "Automated run of \`e2e/scripts/doc-shots.js\` via the Generate Screenshots workflow ($RUN_URL). Every shot in the run's own summary reported ✓ (a ✗ would have failed the job before this step), but review the images themselves before merging -- nothing here checks that a screenshot shows the right *thing*, only that it was captured."
+          then
+            exit 0
+          fi
+
+          compare_url="${{ github.server_url }}/$REPO/compare/$DEFAULT_BRANCH...$branch?expand=1"
+          echo "::warning::Could not open a PR automatically (likely \"Allow GitHub Actions to create and approve pull requests\" is off under Settings > Actions > General). The screenshots are pushed to $branch -- open one by hand: $compare_url"
+          {
+            echo "## Screenshots pushed, PR needs opening by hand"
+            echo "Branch \`$branch\` has the regenerated images, but this token isn't allowed to open a"
+            echo "pull request. Either open one at $compare_url, or enable \"Allow GitHub Actions to"
+            echo "create and approve pull requests\" under Settings > Actions > General and re-run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/e2e/helpers/harness.js
+++ b/e2e/helpers/harness.js
@@ -185,8 +185,9 @@ async function launchExtension({ host: hostSource = 'profile', viewport } = {}) 
       `--load-extension=${EXTENSION_DIR}`,
     ],
   };
-  // Undefined leaves Playwright's own default (1280x720) for every caller except doc-shots.js,
-  // which needs the store's exact 1280x800 screenshot size.
+  // Undefined leaves Playwright's own context-level default for every caller except
+  // doc-shots.js. Note this is only the *context* default: a page that later calls
+  // page.setViewportSize() (as doc-shots.js's openViewer() does) overrides it per-page.
   if (viewport) {
     launchOptions.viewport = viewport;
   }

--- a/e2e/scripts/doc-shots.js
+++ b/e2e/scripts/doc-shots.js
@@ -41,7 +41,8 @@ async function ui(page, sel) {
 
 async function openViewer(ext) {
   const page = await ext.context.newPage();
-  await page.setViewportSize({ width: 1440, height: 960 });
+  // The Chrome/Edge store listings want a 1280x800 screenshot exactly.
+  await page.setViewportSize({ width: 1280, height: 800 });
   await page.goto(ext.viewerUrl);
   const chooser = page.waitForEvent('filechooser');
   await page.click('#btn-open-empty');
@@ -83,8 +84,9 @@ async function shot(page, name, fn) {
     execFileSync('node', [path.join(REPO_ROOT, 'scripts', 'generate-sample-pdf.mjs')], { stdio: 'inherit' });
   }
   buildPrerequisites();
-  // The Chrome/Edge store listings want a 1280x800 screenshot; Playwright's own default
-  // (1280x720) is 80px short.
+  // The context-level default; every page this script actually screenshots is opened by
+  // openViewer() below, which sets its own per-page size that wins over this -- keep both in
+  // sync. This one only matters for a page opened some other way (there is currently none).
   const ext = await launchExtension({ viewport: { width: 1280, height: 800 } });
   try {
     // 1) Overview — the document open, both charts visible on page 1.


### PR DESCRIPTION
Follow-up to #161 (merged) — the actual [run of that workflow](https://github.com/ZanattaMichael/reDACT-PDF-Editor/actions/runs/33554187705) surfaced two real bugs my earlier fix and testing missed.

## 1. The real screenshot-size bug

That run captured all 16 screenshots successfully (every shot reported `✓`), but at **1440×960**, not the 1280×800 the store wants. My fix in #161 set the *context-level* default viewport on `launchExtension()` — but `openViewer()` (called before every single screenshot `doc-shots.js` takes) unconditionally calls `page.setViewportSize({ width: 1440, height: 960 })` on each page right after creating it, which wins over the context default every time. That line — not Playwright's own default, which is what I'd assumed in #161 — is what actually controlled the shipped size.

Confirmed by reading the PNG `IHDR` chunk directly off the branch that run pushed (1440×960) and off `main`'s existing committed screenshots (also 1440×960, predating any of this work) — both matched the hardcoded value in `openViewer()`, not my context-level change, which is what pointed at the real culprit. Fixed the line itself and corrected the now-inaccurate comments in both files that described the wrong mechanism.

## 2. The PR-creation step was failing the whole job

Separately, that run's "Open a PR" step failed outright: `GitHub Actions is not permitted to create or approve pull requests` — a repo setting (Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"), off by default. The screenshots were already correctly generated and the branch already pushed by that point, which is the actual point of the job, so failing the whole run over the one step that needs a permission this repo doesn't grant was misleading.

Made PR creation best-effort, matching the existing `continue-on-error` precedent on `release-extension.yml`'s GitHub Release attach step: on failure it now prints a compare URL to open one by hand (to both the log and the job summary) and still exits 0.

## Verification

- `node --test "extension/test/**/*.test.mjs"` — 116 pass, 0 fail
- `node scripts/check-innerhtml.mjs` — clean
- Workflow YAML parses, `bash -n` clean on every extracted `run:` block
- `node --check` on both changed JS files
- Confirmed `if failing_command; then exit 0; fi` correctly survives `set -e` before relying on it (a command in an `if` condition is exempt from `errexit` — verified rather than assumed)

## Left for you

- The stray branch `docs/screenshots-20260901-201637` from the failed run has the wrong-size (1440×960) images and isn't referenced by any PR — worth deleting, but I didn't do it unprompted.
- Once this merges, re-running the workflow should produce correctly-sized images and either open a PR automatically or, if that repo setting is still off, leave a compare link in the job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHQnn9v3uzCgW5ppxLhnBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHQnn9v3uzCgW5ppxLhnBu)_