### PR TITLE
Investigate iText → OfficeIMO decoupling: source-level capability mapping

### DIFF
--- a/docs/backend-portability.md
+++ b/docs/backend-portability.md
@@ -1,0 +1,254 @@
+# PDF backend portability: iText → OfficeIMO
+
+Tracks **#115** (should the engine change) and **#116** (the abstraction seam). This
+document supersedes the README-only investigation recorded in the [#115 comment
+thread](https://github.com/ZanattaMichael/reDACT-PDF-Editor/issues/115#issuecomment-5233486742):
+that pass could not reach OfficeIMO's source (`api.github.com` was blocked from that
+session) and had to guess at the 🔴 items from documentation alone. This pass cloned
+[`EvotecIT/OfficeIMO`](https://github.com/EvotecIT/OfficeIMO) at `master`
+(commit `aba60b7b`, 2026‑09‑03) and read the actual implementation behind every
+capability this project depends on.
+
+## Headline finding
+
+**The migration is very likely viable**, including the content-stream-level
+guarantees that were the previous investigation's open question. `OfficeIMO.Pdf`
+3.3.0 (published to NuGet the same day as the cloned commit) ships a first-party,
+dependency-free PDF engine with a purpose-built redaction subsystem
+(`OfficeIMO.Pdf/Manipulation/PdfRedaction*.cs`, ~5,200 lines) that plans, applies, and
+*independently verifies* rectangle-based redaction — removing intersecting text runs,
+paths, annotations, form fields, and image pixels, then re-opening the output to prove
+the removed content is gone. That is not a coincidence: OfficeIMO's own current-state
+docs describe redaction, forms, signatures, and content-level text/image editing as
+core, tested workflows, not aspirational ones.
+
+This does **not** mean the migration is risk-free — see [Caveats and what
+remains unverified](#caveats-and-what-remains-unverified) — but it means the
+project should proceed past Phase 0 rather than conclude "stay on iText."
+
+## Method
+
+- Read `src/PdfEditor.Core/*.cs` in this repo and catalogued every `using iText.*`
+  (28 files use iText directly; `CertificateFactory.cs`, `OcrTool.cs`,
+  `DocumentImport.cs`'s Word path via LibreOffice, `Models.cs`, `ValidationModels.cs`,
+  `UrlClassifier.cs`, `PageRenderer.cs`, and `VisualDiff.cs` do not).
+- Cloned `EvotecIT/OfficeIMO` read-only and read the actual source under
+  `OfficeIMO.Pdf/` (not just its README) for every capability area this project
+  touches, including the internal `PdfRedactionApplier*`, `PdfRedactionPlanner*`,
+  and `PdfRedactionVerification*` implementation files.
+- Confirmed NuGet publication: `OfficeIMO.Pdf` and `OfficeIMO.Core` are both published
+  through `3.3.0`, MIT-licensed, targeting `netstandard2.0;net8.0;net10.0` (plus
+  `net472` on Windows) — compatible with this project's `net8.0` target.
+- **Did not** run a compiled prototype against this project's own golden/fuzz PDF
+  corpus. This session's egress proxy allows `nuget.org` and `github.com` but blocks
+  `builds.dotnet.microsoft.com` (the .NET SDK installer), and there is no `dotnet` CLI
+  in this container. The runtime spike issue #115 asks for is therefore still
+  outstanding — see [Recommended next step](#recommended-next-step).
+
+## Licensing
+
+`OfficeIMO.Pdf`'s dependency footprint (from its own README, confirmed by its
+`.csproj`): only `OfficeIMO.Core`, both MIT. No third-party PDF parser, writer,
+renderer, or cryptography package ships in the base package. Certificate-based CMS,
+RFC 3161, and X.509 signing move to the **optional** `OfficeIMO.Security` package —
+also referenced only when the host application explicitly needs certificate signing
+or validation, so a build that doesn't sign never pulls in cryptography beyond
+`System.Security.Cryptography`. This resolves the motivation in #115: no AGPL
+network/distribution clause anywhere in the dependency graph.
+
+## Capability mapping
+
+Organized by the capability seams #116 proposes, so this table doubles as the
+per-interface migration plan. Status: 🟢 direct equivalent found in OfficeIMO source ·
+🟡 equivalent exists but needs a fidelity check against this project's test corpus ·
+🔴 no equivalent found — needs bespoke code or an upstream OfficeIMO feature.
+
+### `IPdfDocumentStore` — open/save/merge/split/rotate/arrange/import
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `PdfIo.Open`/`OpenReadOnly` (`PdfReader`/`PdfWriter`) | `PdfDocument.Load(...)` — one entry point for bytes/file/stream, `Save`/`SaveAsync` | 🟢 |
+| `Merger.Merge` (`PdfMerger`) | `PdfDocument.MergeWith`/`MergeWithReport`, independent per-source passwords/permissions | 🟢 |
+| `PageTools.Arrange` (reorder/delete via `PdfMerger`) | `Pages.Extract`/`Split`/`Delete`/`Duplicate`/`Move` with range selectors (`1-3`, `last`, `odd`, exclusions) | 🟢 |
+| `PageTools.Rotate` | `Pages.Rotate(degrees, pageRanges)` | 🟢 |
+| `DocumentImport.ImageToPdf` | `PdfDocument.Create` + `.InlineImage`/image content block sized to page | 🟢 (straightforward rewrite) |
+| `DocumentImport.DocxToPdf` (external LibreOffice process) | `OfficeIMO.Word` + `OfficeIMO.Word.Pdf`: `WordDocument.Load(...).SaveAsPdf(...)`, in-process, no external binary | 🟢 — **and an improvement**: removes the `soffice` external-process dependency and its `CanConvertWord` runtime probe entirely |
+
+### `IInspector` — pages/fonts/images/attachments/outlines/security/DoS guards
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `PdfInspector.GetInfo` (page geometry, effective crop×media box, rotation, encryption) | `PdfDocument.Inspect()` → page count/geometry; `Security` info via preflight | 🟢 |
+| `Encryptor.IsEncrypted`/`CanOpen` | `PdfDocument.Load` + `PdfLoadOptions.Password`, `PdfDocumentSecurityInfo` | 🟢 |
+| `ExportValidator.Validate` (re-read output: xref/trailer, stream round-trip, page tree, AcroForm appearance invariants) | `PdfDocument.Analyze(...)` (health/rewrite-safety/diagnostics/repair/signature/compliance in one report) + `PdfRepairReport` | 🟡 — the *shape* of findings differs; needs a small adapter reproducing this project's specific checks (see [Gaps](#verified-gaps--upstream-issue-candidates)) |
+| `PdfStructureGuard.EnsureFormXObjectsTerminate` (cyclic form-XObject guard before content processing) | Built into the parser itself: `PdfRedactionPlan`'s form-resource traversal enforces `MaxFormResourceTraversals`/depth limits (`PdfRedactionPlan.cs`, `AppendFormRenderingResourceIdentity`, `maximumDepth = 64`), and the general reader is fuzzed against a pinned GovDocs corpus + Open Preservation Foundation/veraPDF fixtures | 🟢 — likely **deletable** rather than portable: the guard becomes the library's job |
+| `PdfContentGuard.InDefaultUserSpace` (draw without inheriting a page's leftover CTM) | `Stamp.Content((canvas, page) => ...)` canvas stamping operates in a fixed, page-relative coordinate system by contract | 🟢 |
+| `Sanitizer.Inspect` (counts: metadata fields, attachments, scripts/actions, markup annotations, bookmarks, OC layers) | No single matching "hidden data" counter; the underlying facts are all independently readable (`Inspect()`, `JavaScript.List()`, `Attachments.Extract()`, `Annotations` list, `Bookmarks`, catalog optional-content) | 🟡 — portable, but as a small aggregation written against this repo, not a single OfficeIMO call (see Gaps) |
+
+### `ITextEditor` / `IContentStreamEditor` — the highest-risk seam
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `TextTools.GetTextInRegion`/`GetTextSpans` (via `LocationTextExtractionStrategy`-style `IEventListener`) | `Text.Inspect(region)`, `PdfDocument.Read()` → `PdfLogicalPage.TextBlocks`/`PdfTextSpan` (font, size, color, transform per span) | 🟢 |
+| `TextTools.ReplaceTextInRegion` (drop matched glyphs, re-stamp) | `document.Text.Replace(region, newText, options)` — README states it "preserves unmatched source-span text" and fails closed for invisible/clipped text rather than guessing | 🟢, pending the fidelity check below |
+| `TextTools.MoveText` | `Text.Add` + prior region removal, or the dedicated move path implied by `Images.Move`'s sibling text API | 🟡 — confirm a first-class move exists vs. compose remove+add |
+| `TextTools.AddText` (canvas + `PdfFont`) | `document.Text.Add(region, text, PdfTextEditOptions)` | 🟢 |
+| `TextTools.FindText` (`TextMatchMode`, whole/partial) | `Text.Find(...)` — "case and whole-word filters over visible, unclipped text" | 🟢 |
+| **`ContentStreamEditor`** — subclasses `PdfCanvasProcessor`, intercepts `Tj/TJ/'/"` and `Do`, does **per-glyph** replacement (drops only the glyphs inside a region, re-emits the rest as an equivalent-width `TJ` displacement so surrounding text doesn't reflow), recurses into form XObjects up to depth 6, handles inline images | `PdfRedactionApplier.TextScrubbing.cs` (945 lines) + `PdfRedactionApplier.TextFormScrubbing.cs` (157 lines, form-XObject-aware) implement the same class of operation: matched text objects are physically removed from the content stream, not merely covered | 🟡→🟢 by evidence of scale and dedicated form-XObject handling, but **this is the one operation in the whole migration worth an actual before/after content-stream diff** before trusting it — see [Gaps](#verified-gaps--upstream-issue-candidates) item 1 |
+| `ImageTools.MoveImage` (remove draw call, redraw at shifted rect) | `Images.Move(placement, deltaX, deltaY)` | 🟢 |
+| `ImageScrubber.TryScrubPixels` (re-encode image XObject with pixels inside a region blacked out or paper-colored, for OCR'd scanned pages) | `PdfRedactionApplier.Images.PixelRewrite.cs` (1,007 lines) — dedicated pixel-level image rewrite path, distinct from the 988-line whole-placement `Images.cs` | 🟢 by evidence of scale/dedication |
+
+### `IRedactionEngine` — the project's core differentiator
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `Redactor.Redact`/`RemoveContent` (drives `ContentStreamEditor`, then removes intersecting annotations, then paints the box) | `document.Redactions.Apply(areas, options)` — "removes matched text objects and annotations, then paints redaction marks" (`PdfRedactionApplier.cs:9`); `PdfRedactionApplyOptions` exposes `RemoveIntersectingPaths`, `PaintUnmatchedAreas`, `UnsupportedImagePolicy`, `CleanupScope` | 🟢 |
+| `RedactionBox.Prepare`/`MergeAdjacent`/`Expand` (pre-processing regions before applying) | `document.Redactions.Plan(areas)` — a **non-mutating** preview returning every `PdfRedactionMatch` (text/annotation/image) intersecting each area, plus preflight/diagnostics | 🟢 — and arguably better: this project has no equivalent dry-run today |
+| `RedactionReporter.Analyze` (per-region: text removed, image thumbnails, annotation/text-run counts, computed from the *original* doc) | `PdfRedactionMatch` already carries `Text`, `Kind` (TextBlock/Annotation/ImagePlacement), `ImagePlacement`, page/rect — everything except a rendered thumbnail, which is one `Images.Extract()` call away | 🟢 — direct rebuild on `Plan(...).Matches`, likely simpler than today's hand-rolled version that separately re-derives spans/images/annotations |
+| *(nothing today)* | `document.Redactions.Verify`/`AssertVerified`/`VerifyAppliedPlan` — re-opens the rewritten PDF and proves configured content no longer intersects the reviewed areas (`PdfRedactionVerification.Residue.cs`, 375 lines) | 🟢 **capability upgrade** — an independent, automatable proof this project does not currently have for its own compliance claims |
+
+### `IAnnotationEngine` — highlight/ink/watermark/Bates/stamps
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `HighlightTool.AddHighlight` (`Multiply` blend rectangle in default user space) | `Stamp.Content` canvas supports fills and blend-mode effects (`SetBlendMode` appears in `PdfStamper.Pages.cs`); confirm the fluent canvas exposes blend mode directly | 🟡 — see Gaps item 2 |
+| `InkTools.AddInk` (freehand polylines, round caps/joins) | `Stamp.Content` canvas: README lists "shapes, drawings, clipping, and effects are supported" for canvas stamping | 🟢, pending a round-cap/join fidelity check |
+| `WatermarkTool.AddTextWatermark` | `PdfOptions.TextWatermark` at creation time, or `Stamp.TextWatermark(text, PdfTextStampOptions { RotationDegrees, Opacity, ... })` on an existing document | 🟢 |
+| `BatesTool.AddBatesNumbers` | `PdfBatesNumberer.Apply(documents, PdfBatesNumberingOptions { StartNumber, Prefix, MinimumDigits, Position })` — a **named, first-class feature**, not something to reimplement on the canvas | 🟢 |
+| `Signer.AddImageSignature` (stamp an uploaded/drawn signature image) | `Stamp` image placement, or `Images.Add` fit-to-region | 🟢 |
+
+### `IFormEngine`
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `FormTools.AddTextField`/`AddDropdown`/`AddRadioGroup`/`AddCheckbox`/`AddButton` | `Forms.Edit(form => form.Create(new PdfFormFieldCreateOptions { Kind, Name, PageNumber, X, Y, Width, Height, Style, ... }))` — text/checkbox/combo/list/radio-group/push-button/signature fields in one transaction | 🟢 |
+| `FormTools.ListFields` (name, type, value, options, readonly, geometry, attached script) | `PdfDocument.Inspect().FormFields` / `PdfDocumentReadResult.FormFields` | 🟡 — confirm per-field JS/activation script surfaces (README shows `JavaScript` as a *create*-time option on push buttons; reading it back per-field, and setting it on non-button fields' `/AA /U`, needs confirming) — see Gaps item 3 |
+| `FormTools.FillFields` (+ optional flatten) | `Forms.FillAndFlatten(values)`; `Forms.Edit` for fill-without-flatten | 🟢 |
+| `FlattenTool.Flatten` (Mode: forms-only / annotations-only / all) | `Forms.FillAndFlatten` (forms) + `Annotations.Flatten` (non-form annotations), per the annotation workflow row ("...flatten... authored or diagnosed synthesized appearances") | 🟢 — composes to the same three modes |
+
+### `ISecurityEngine` — encrypt/sanitize/JS/URLs
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `Encryptor.Encrypt`/`Decrypt` (AES-256, `WriterProperties`) | `PdfStandardEncryptionOptions` (AES-256 default, AES-128, legacy RC4, Unicode passwords, typed permission bits) via `PdfOptions().SetEncryption(...)`; platform AES by default, managed AES from `OfficeIMO.Core` for restricted hosts | 🟢 |
+| `JavaScriptTool.AddDocumentScript`/`ListScripts`/`RemoveScript` (`/Names /JavaScript` tree) | `document.JavaScript.List()` / `.Edit(scripts => scripts.AddOrReplace(name, code).Remove(name))` — named, exact-match, name-tree-preserving | 🟢 (closer to a 1:1 API match than most items in this table) |
+| `PdfSafety.Scan`/`StripActive` (document JS, open/page/annotation actions, outward URI/Launch/SubmitForm/GoToR/ImportData) | The sanitizer workflow ("policy-driven full rewrites remove or quarantine embedded payloads, unsafe actions and URI targets") plus `JavaScript.List()` for the JS half | 🟡 — confirm the *action-kind* granularity (URI vs. Launch vs. SubmitForm vs. GoToR vs. ImportData) is individually selectable, since `PdfSafety.Scan` reports and this project's UI surfaces those separately | see Gaps item 4 |
+| `UrlTools.ExtractLinks`/`ExtractLinkAnnotations` (URI links + every link kind with geometry and chained `/Next` actions) | `PdfDocumentReadResult.Links` (`PdfLogicalLinkAnnotation`) | 🟡 — confirm action-kind classification (goto/remote-goto/launch/named/submit vs. plain uri) and chained-action traversal match today's `UrlTools.ClassifyLink`/`CollectUri` |
+| `Sanitizer.Sanitize` (metadata incl. XMP, attachments, comment annotations, bookmarks, OC layers, scripts/actions) | Composable from `UpdateMetadata(...)` (clear standard fields) + catalog `/Metadata` removal + `Attachments` remove-all + `Annotations` remove-by-kind + `Bookmarks` remove-all + optional-content removal + the JS/action sanitizer above | 🟡 — every piece exists; there's no single call. See Gaps item 5 for whether OfficeIMO should offer one |
+
+### `ISigningEngine`
+
+| Today | OfficeIMO.Pdf | Status |
+|---|---|---|
+| `Signer.SignDigitally` (PKCS#12, `PdfSigner` + BouncyCastle, detached CMS) | `Security.SignExternal(signer, PdfExternalSignatureOptions)` — PDF package owns byte ranges/incremental updates/signature dictionary; `PdfCmsExternalSigner` (from optional `OfficeIMO.Security`) supplies the CMS/PKCS#12 side | 🟢, with a package split (core PDF signature mechanics vs. optional crypto provider) that is actually cleaner than today's single `Signer.cs` |
+| `Signer.GetSignatures` (list + `coversWholeDocument` / integrity) | `Security.ValidateSignatures(cryptography)` → `PdfSignatureValidationReport`; byte-range/incremental-update inspection is native to the PDF package (not the optional crypto package) | 🟢 — this is exactly the item the earlier README-only investigation flagged 🔴→🟡 as unresolved; source inspection resolves it to 🟢 |
+| `CertificateFactory.CreateSelfSignedPkcs12` (`System.Security.Cryptography` + BouncyCastle, **not iText today**) | No change needed — this file has no `iText` dependency now and none after migration | 🟢 (no migration work) |
+
+### Unaffected / independent of iText already
+
+`PageRenderer` (PDFium via `PDFtoImage` + SkiaSharp), `VisualDiff` (renders both versions via `PageRenderer`, diffs pixels), `DocComparer` (word-level LCS diff over `TextTools.GetTextSpans` output — portable once `TextTools` is), `OcrTool` (Tesseract over rendered pages; writes its invisible text layer through `TextTools.AddText`, so it inherits that seam's status), `UrlClassifier` (pure string classification, no PDF library at all).
+
+*Aside, out of scope for #115 but worth flagging separately*: `OfficeIMO.Pdf` also ships its own page-to-image renderer (`ToImages()`/`ToImage()`) and its own PDF/A, signature-appearance, and font-embedding stack. Once the engine migration lands, `PDFtoImage`/PDFium could in principle be retired too — but that's a second, independent decision with its own risk (PDFium is a mature, widely-deployed renderer; OfficeIMO's is comparatively new) and should be a separate issue, not bundled into #115.
+
+## Verified gaps / upstream issue candidates
+
+These are the concrete items this pass could not resolve to 🟢 from source alone —
+each needs either a code spike against this project's test corpus, or is a real,
+filable gap in OfficeIMO. Draft issue text for the OfficeIMO-side items is in
+[`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md).
+
+1. **Per-glyph redaction fidelity vs. run-level.** `ContentStreamEditor` specifically
+   preserves layout by splitting a partially-overlapping text-show operator at the
+   *glyph* boundary — glyphs outside a region survive with their original spacing,
+   only the glyphs inside are replaced by an equivalent-width displacement. Whether
+   `PdfRedactionApplier.TextScrubbing.cs` does the same (vs. dropping/keeping whole
+   runs, which would over- or under-redact at a run's edges) cannot be confirmed by
+   reading around a 945-line file at reasonable depth — it needs a real round-trip:
+   redact half of a multi-word run and diff the resulting content stream. **This is
+   the one spike issue #115 explicitly calls for, and it's still open** — this
+   session's egress proxy blocks the .NET SDK installer, so it needs to run in the
+   project's own devcontainer (which already carries a .NET SDK per
+   `.devcontainer/Dockerfile`) or on a developer machine, not in this remote session.
+2. **Blend-mode control on canvas stamping isn't documented at the fluent level.**
+   `HighlightTool` relies on `Multiply` specifically so glyphs stay legible under the
+   highlight color. `SetBlendMode` exists in OfficeIMO's internal stamping code but
+   the public `Stamp.Content` canvas API surface in the README doesn't show a
+   blend-mode setter. If it's missing, this is an upstream issue (draft #1).
+3. **Per-field JavaScript activation, read and write, on non-button fields.** Today's
+   `FormTools` attaches script to a push button's `/A` and to every other field
+   type's widget `/AA /U`, and reads it back the same way for the forms panel. The
+   README only demonstrates `JavaScript` as a create-time option on a push button.
+   If `Forms.Edit`/`ListFields`-equivalent doesn't expose `/AA /U` for text/choice/
+   checkbox/radio fields, that's an upstream issue (draft #2).
+4. **Individually selectable outward-action kinds when stripping active content.**
+   `PdfSafety` distinguishes `URI`, `Launch`, `SubmitForm`, `GoToR`, `ImportData` and
+   lets the caller strip JavaScript and URL-reaching actions independently. Confirm
+   OfficeIMO's sanitizer exposes the same granularity rather than an all-or-nothing
+   "unsafe actions" toggle (draft #3 covers the case it doesn't).
+5. **No single "strip everything a user didn't mean to share" call.** Every
+   ingredient of `Sanitizer.Sanitize` exists somewhere in OfficeIMO, but as separate
+   calls across metadata, attachments, annotations, bookmarks, optional content, and
+   the JS/action sanitizer — with no combined report shaped like
+   `HiddenDataReport` (one count per category, before removal). This is a
+   product-shape gap worth filing upstream since `PdfEditor.Core`'s `Sanitizer` is a
+   plausible template for it (draft #4).
+6. **`ExportValidator`'s specific checks vs. `Analyze()`'s shape.** `ExportValidator`
+   checks are narrow and read-only-forever (never throws, reports findings): xref/
+   trailer integrity, stream length/filter round-trip, page-tree consistency, cheap
+   AcroForm appearance invariants. `PdfDocument.Analyze()` looks like a superset, but
+   confirm it never throws on a malformed *output* it just produced (a self-check
+   must not itself be fragile) and that its diagnostics are granular enough to
+   reproduce this project's specific post-export assertions.
+7. **`TextTools.MoveText` as a first-class operation.** Confirm whether moving
+   selected text is a direct OfficeIMO API or has to be composed from
+   `Text.Inspect` + region removal + `Text.Add` (likely fine either way, just needs
+   confirming before committing to the seam's method shape).
+
+## Recommended plan
+
+Recommendation stands as the original investigation framed it, updated for what
+source access changed:
+
+1. **Phase 0 — build the engine seam (#116), regardless of outcome.** This pass's
+   findings make Phase 0 unconditionally worth doing sooner: nearly every capability
+   table above landed 🟢 or 🟡, which means the seam is very likely to be *used*
+   (not built and then abandoned back onto iText). Introduce the interfaces #116
+   lists, move the 28 files behind them with **iText as the sole implementation**,
+   zero behavior change, existing tests + 90% coverage gate stay green.
+2. **Phase 1 — the one required spike, not a broad one.** Where the prior
+   investigation asked "can OfficeIMO do content-stream redaction and text editing
+   at all", this pass's source reading answers "yes, with dedicated, sizeable
+   implementation code for exactly that." The remaining spike is narrower and
+   mechanical: build a small console harness against `OfficeIMO.Pdf` 3.3.0,
+   round-trip a handful of this repo's existing golden/fuzz fixtures
+   (`tests/PdfEditor.Core.Tests/Golden`, `.../Fuzz`) through `Redactions.Plan` →
+   `Redactions.Apply` → `Redactions.Verify`, and diff against today's `Redactor`
+   output on the same inputs. Needs a real .NET SDK (the project's own devcontainer
+   has one; this session's sandboxed egress does not).
+3. **Phase 2 — migrate capability-by-capability behind the seam**, in the order the
+   mapping table suggests confidence: `ISigningEngine`/`IPdfDocumentStore` first
+   (cleanest 🟢s, including deleting the LibreOffice dependency), then
+   `IAnnotationEngine`/`IFormEngine`/`ISecurityEngine`, then `IRedactionEngine`/
+   `ITextEditor` once Phase 1's spike confirms fidelity.
+4. **File the upstream issues** in [`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md)
+   against `EvotecIT/OfficeIMO` for the items in [Verified gaps](#verified-gaps--upstream-issue-candidates)
+   that are genuine product gaps (drafts #1–#4) rather than this project's own
+   spike work (items 1, 6, 7 above stay this project's problem).
+
+## Caveats and what remains unverified
+
+- This is a static-source-reading pass, not a compiled, executed one. OfficeIMO's own
+  documentation is unusually precise about boundaries (it explicitly lists what each
+  workflow does *not* claim), which is a good sign for trustworthiness, but "the code
+  exists and looks purpose-built" is not the same evidence as "it passed on our
+  fixtures."
+- `OfficeIMO.Pdf`'s current-state doc describes itself as "useful and broad, but
+  still evolving," with open items in font/color/pattern rendering fidelity — none
+  of which this project depends on for its core redaction/editing guarantees, but
+  worth knowing the engine is young relative to iText's ~20 years of edge-case
+  hardening.
+- No attempt was made in this pass to build or run anything against OfficeIMO —
+  the egress proxy in this session allows `github.com`/`nuget.org` (used to clone
+  the repo and confirm package publication) but rejected
+  `builds.dotnet.microsoft.com` (the .NET SDK installer), and no `dotnet` CLI is
+  present in this container.

--- a/docs/backend-portability.md
+++ b/docs/backend-portability.md
@@ -1,254 +1,267 @@
 # PDF backend portability: iText → OfficeIMO
 
-Tracks **#115** (should the engine change) and **#116** (the abstraction seam). This
-document supersedes the README-only investigation recorded in the [#115 comment
-thread](https://github.com/ZanattaMichael/reDACT-PDF-Editor/issues/115#issuecomment-5233486742):
-that pass could not reach OfficeIMO's source (`api.github.com` was blocked from that
-session) and had to guess at the 🔴 items from documentation alone. This pass cloned
-[`EvotecIT/OfficeIMO`](https://github.com/EvotecIT/OfficeIMO) at `master`
-(commit `aba60b7b`, 2026‑09‑03) and read the actual implementation behind every
-capability this project depends on.
+Tracks **#115** (should the engine change) and **#116** (the abstraction seam).
+
+This document has been through two investigation passes:
+
+1. A README/NuGet-only pass (recorded in the [#115 comment
+   thread](https://github.com/ZanattaMichael/reDACT-PDF-Editor/issues/115#issuecomment-5233486742)),
+   which could not reach OfficeIMO's source and flagged content-stream redaction as an
+   unresolved 🔴 risk.
+2. A source-level pass (this document), which cloned
+   [`EvotecIT/OfficeIMO`](https://github.com/EvotecIT/OfficeIMO) at `master`
+   (commit `aba60b7b`, 2026‑09‑03) and read the redaction and text-editing
+   implementations line by line, verified the published NuGet dependency graph, and
+   measured PDF text-object granularity empirically against real Microsoft Word output.
+
+**The second pass reversed the first pass's own initial optimism.** An earlier draft of
+this file rated the content-stream work "🟡→🟢 by evidence of scale" — inferring
+capability from the size and naming of OfficeIMO's redaction files rather than from
+reading the algorithm. Reading the algorithm gives a different answer, recorded below.
 
 ## Headline finding
 
-**The migration is very likely viable**, including the content-stream-level
-guarantees that were the previous investigation's open question. `OfficeIMO.Pdf`
-3.3.0 (published to NuGet the same day as the cloned commit) ships a first-party,
-dependency-free PDF engine with a purpose-built redaction subsystem
-(`OfficeIMO.Pdf/Manipulation/PdfRedaction*.cs`, ~5,200 lines) that plans, applies, and
-*independently verifies* rectangle-based redaction — removing intersecting text runs,
-paths, annotations, form fields, and image pixels, then re-opening the output to prove
-the removed content is gone. That is not a coincidence: OfficeIMO's own current-state
-docs describe redaction, forms, signatures, and content-level text/image editing as
-core, tested workflows, not aspirational ones.
+**The migration is clean for roughly 80% of the surface and blocked at the core.**
 
-This does **not** mean the migration is risk-free — see [Caveats and what
-remains unverified](#caveats-and-what-remains-unverified) — but it means the
-project should proceed past Phase 0 rather than conclude "stay on iText."
+The licensing motivation is real and OfficeIMO delivers on it: verified from the
+published `.nuspec` files, `OfficeIMO.Pdf` 3.3.0 depends on exactly one package
+(`OfficeIMO.Core` 3.3.0), which itself declares **zero** dependencies on every target
+framework. No transitive AGPL, no ImageSharp-style split license, nothing. Page
+operations, merge/split, forms, encryption, signatures, JavaScript/action handling,
+Bates numbering, watermarks, and Word→PDF import all map cleanly and in several cases
+are an upgrade on what this project does today.
+
+But `OfficeIMO.Pdf` redacts and edits text at **whole-text-object (`BT`…`ET`)
+granularity**, where this project's `ContentStreamEditor` operates at **glyph**
+granularity. That is an architectural difference, not a maturity gap, and it lands
+squarely on this application's two differentiating features. Because a hybrid that
+keeps iText for redaction still ships iText, a partial migration does **not** achieve
+the AGPL goal — which is exactly the trap the original #115 comment warned about.
 
 ## Method
 
-- Read `src/PdfEditor.Core/*.cs` in this repo and catalogued every `using iText.*`
-  (28 files use iText directly; `CertificateFactory.cs`, `OcrTool.cs`,
-  `DocumentImport.cs`'s Word path via LibreOffice, `Models.cs`, `ValidationModels.cs`,
-  `UrlClassifier.cs`, `PageRenderer.cs`, and `VisualDiff.cs` do not).
-- Cloned `EvotecIT/OfficeIMO` read-only and read the actual source under
-  `OfficeIMO.Pdf/` (not just its README) for every capability area this project
-  touches, including the internal `PdfRedactionApplier*`, `PdfRedactionPlanner*`,
-  and `PdfRedactionVerification*` implementation files.
-- Confirmed NuGet publication: `OfficeIMO.Pdf` and `OfficeIMO.Core` are both published
-  through `3.3.0`, MIT-licensed, targeting `netstandard2.0;net8.0;net10.0` (plus
-  `net472` on Windows) — compatible with this project's `net8.0` target.
-- **Did not** run a compiled prototype against this project's own golden/fuzz PDF
-  corpus. This session's egress proxy allows `nuget.org` and `github.com` but blocks
-  `builds.dotnet.microsoft.com` (the .NET SDK installer), and there is no `dotnet` CLI
-  in this container. The runtime spike issue #115 asks for is therefore still
-  outstanding — see [Recommended next step](#recommended-next-step).
+- Catalogued every `using iText.*` in `src/PdfEditor.Core` (28 of 40 files).
+- Read OfficeIMO's actual redaction/editing implementation, not its documentation:
+  `PdfRedactionApplier.TextScrubbing.cs`, `PdfRedactionApplier.cs`,
+  `PdfRedactionPlan.cs`, `PdfRedactionVerification.Residue.cs`, `PdfTextEditor.cs`,
+  `PdfDocumentRedactions.cs`, `PdfRedactionApplyOptions.cs`.
+- **Verified licensing from the published artifacts**, not the README: downloaded
+  `OfficeIMO.Pdf.3.3.0.nupkg` and `OfficeIMO.Core.3.3.0.nupkg` from nuget.org and read
+  their `.nuspec` dependency groups directly.
+- **Measured text-object granularity empirically.** Wrote a content-stream analyzer
+  (decompress streams → enumerate `BT`…`ET` blocks → count characters, show-operators,
+  and distinct baselines per block) and ran it against this repo's
+  `docs/sample/PDF-Editor-Sample.pdf` and against real Microsoft Word–produced PDFs
+  shipped as reference baselines in OfficeIMO's own test corpus.
+- **Did not** compile or execute anything against OfficeIMO. There is no `dotnet` CLI
+  in this container and the egress proxy rejects `builds.dotnet.microsoft.com`, so the
+  SDK could not be installed. Findings below are from source reading plus static
+  analysis of PDF bytes — strong evidence, but not a passing test.
 
-## Licensing
+## Licensing — verified clean ✅
 
-`OfficeIMO.Pdf`'s dependency footprint (from its own README, confirmed by its
-`.csproj`): only `OfficeIMO.Core`, both MIT. No third-party PDF parser, writer,
-renderer, or cryptography package ships in the base package. Certificate-based CMS,
-RFC 3161, and X.509 signing move to the **optional** `OfficeIMO.Security` package —
-also referenced only when the host application explicitly needs certificate signing
-or validation, so a build that doesn't sign never pulls in cryptography beyond
-`System.Security.Cryptography`. This resolves the motivation in #115: no AGPL
-network/distribution clause anywhere in the dependency graph.
+```
+OfficeIMO.Pdf 3.3.0  ──depends on──>  OfficeIMO.Core 3.3.0  ──depends on──>  (nothing)
+```
+
+Read from the packages' own `.nuspec` files. MIT license expression on both. The
+optional `OfficeIMO.Security` package (CMS/RFC 3161/X.509 for certificate signing) is
+**not** a transitive dependency — a build that doesn't sign never pulls it in. This is
+a genuine, verified escape from iText's AGPL terms, and it is the strongest argument
+in favour of the migration.
+
+## The blocking finding: redaction granularity
+
+### What this project does today
+
+`ContentStreamEditor` subclasses iText's `PdfCanvasProcessor` and intercepts the
+show-text operators (`Tj`/`TJ`/`'`/`"`). For a text run that only *partially* overlaps
+a redaction rectangle, it splits at the **glyph** boundary: glyphs outside the region
+are re-emitted unchanged, glyphs inside are replaced by an equivalent-width `TJ`
+displacement so the surviving text keeps its original spacing and does not reflow
+(`ContentStreamEditor.cs`, `HandleShowText`/`DisplacementFor`).
+
+### What OfficeIMO does
+
+`PdfRedactionApplier.TextScrubbing.cs` works one level up, on whole text objects:
+
+- `BuildRedactionTextObject` computes **a single union bounding box for the entire
+  `BT`…`ET` block** (`AddSpanBounds` takes `Math.Min`/`Math.Max` across every span in
+  the object).
+- `MarkMatchingTextObjects` → `IntersectsTarget` tests the redaction rectangle against
+  that union box.
+- On any intersection, `RemoveTextObjectSpans` **excises the entire `BT`→`ET` byte
+  range** from the content stream. There is no re-emission of surviving glyphs and no
+  spacing compensation.
+- Nothing in `PdfRedactionApplyOptions` controls this granularity (its knobs are fill
+  color, unmatched-area painting, image policy, path removal, and document-level
+  cleanup scope).
+
+### How much text that actually destroys
+
+Measured, not assumed. One `BT`…`ET` block per line is the dominant pattern in real
+output:
+
+| Document | Text objects | Largest object |
+|---|---|---|
+| `docs/sample/PDF-Editor-Sample.pdf` (this repo's own sample) | 93 | 98 chars, ~1 baseline |
+| `microsoft-word-16.109-native-word-report.pdf` | 73 | 89 chars, ~1 baseline |
+| `microsoft-word-windows-word-business-delivery-summary.pdf` | ~136 per stream | 105 chars, ~1 baseline |
+
+So the practical blast radius is **one whole line of text per redaction box**. A user
+who draws a box over `John Smith` in the line
+
+> Prepared by John Smith on 14 March for internal review
+
+loses the entire line from the content stream, while the painted black box still covers
+only the rectangle they drew.
+
+### The mitigation, and why it doesn't fully rescue it
+
+The text-editing path is smarter about this. `PdfTextEditor.RemoveTextPreservingUnmatchedSpans`
+snapshots spans before, removes the whole text objects, re-reads the result, diffs which
+*non-targeted* spans disappeared as collateral, and **re-stamps them back onto the
+page**. That is how the README's "preserves unmatched source-span text" claim is
+honoured — by delete-and-redraw, not by surgical retention.
+
+Three consequences for this project:
+
+1. **Font fidelity regresses.** The re-stamp resolves style through
+   `ResolveStandardFont(...)` — the closest **standard PDF font** — and emits
+   `BuildSubstitutionWarnings`. Text originally set in an embedded Calibri comes back
+   as Helvetica. This is precisely the defect issue #29 was filed for and that
+   `tests/PdfEditor.Core.Tests/TextFontFidelityTests.cs` now guards against.
+2. **OCR'd scans fail closed.** `IsSafelyEditableSpan` requires
+   `span.IsVisible && !span.ClipPath.HasValue && span.TextRenderingMode == 0 && ...`,
+   and the editor throws `NotSupportedException` otherwise. A searchable scan's OCR
+   layer is invisible text (`Tr 3`) by definition — so the text-edit path rejects the
+   exact documents `OcrTool.MakeSearchable` produces and that
+   `ContentKinds.TextAndPixelsBeneath` was built to handle. (The pure-redaction path
+   does not throw; it removes the objects.)
+3. **`Plan()` and `Apply()` use different geometry engines.** The planner
+   (`PdfRedactionPlanner.cs:79`) walks `document.TextBlocks` from the logical read
+   model, which uses real font metrics. The applier parses the raw content stream and
+   approximates every glyph advance as a flat half-em —
+   `SumWidth1000 = bytes.Length * 500D` (`PdfRedactionApplier.TextScrubbing.cs:525`).
+   Preview and effect are therefore computed two different ways, which matters a great
+   deal for a tool whose compliance story is "here is exactly what was removed" (#48).
+   Under-estimated widths are also the one path by which this design could *under*-redact
+   rather than over-redact; worth explicit testing if the migration proceeds.
+
+### On the verification API
+
+`Redactions.Verify`/`AssertVerified` is real and useful, but it is **marker-based**:
+`ContainsEncodedPdfMarker`/`ContainsDecodedStreamMarker` search the output bytes for
+strings the caller names. It proves "the string I told you about is gone." It is not a
+geometric proof that a rectangle is free of extractable content, so it complements
+rather than replaces this project's own assertions.
 
 ## Capability mapping
 
-Organized by the capability seams #116 proposes, so this table doubles as the
-per-interface migration plan. Status: 🟢 direct equivalent found in OfficeIMO source ·
-🟡 equivalent exists but needs a fidelity check against this project's test corpus ·
-🔴 no equivalent found — needs bespoke code or an upstream OfficeIMO feature.
+Organized by the seams #116 proposes. 🟢 direct equivalent verified in source ·
+🟡 exists, needs a fidelity check · 🔴 architectural gap.
 
-### `IPdfDocumentStore` — open/save/merge/split/rotate/arrange/import
+### `IPdfDocumentStore` — 🟢 clean port
 
-| Today | OfficeIMO.Pdf | Status |
-|---|---|---|
-| `PdfIo.Open`/`OpenReadOnly` (`PdfReader`/`PdfWriter`) | `PdfDocument.Load(...)` — one entry point for bytes/file/stream, `Save`/`SaveAsync` | 🟢 |
-| `Merger.Merge` (`PdfMerger`) | `PdfDocument.MergeWith`/`MergeWithReport`, independent per-source passwords/permissions | 🟢 |
-| `PageTools.Arrange` (reorder/delete via `PdfMerger`) | `Pages.Extract`/`Split`/`Delete`/`Duplicate`/`Move` with range selectors (`1-3`, `last`, `odd`, exclusions) | 🟢 |
-| `PageTools.Rotate` | `Pages.Rotate(degrees, pageRanges)` | 🟢 |
-| `DocumentImport.ImageToPdf` | `PdfDocument.Create` + `.InlineImage`/image content block sized to page | 🟢 (straightforward rewrite) |
-| `DocumentImport.DocxToPdf` (external LibreOffice process) | `OfficeIMO.Word` + `OfficeIMO.Word.Pdf`: `WordDocument.Load(...).SaveAsPdf(...)`, in-process, no external binary | 🟢 — **and an improvement**: removes the `soffice` external-process dependency and its `CanConvertWord` runtime probe entirely |
+| Today | OfficeIMO.Pdf |
+|---|---|
+| `PdfIo.Open`/`OpenReadOnly` | `PdfDocument.Load(...)`, `Save`/`SaveAsync` |
+| `Merger.Merge` | `MergeWith`/`MergeWithReport`, per-source passwords and permission policy |
+| `PageTools.Arrange` | `Pages.Extract`/`Split`/`Delete`/`Duplicate`/`Move` with range selectors |
+| `PageTools.Rotate` | `Pages.Rotate(degrees, ranges)` |
+| `DocumentImport.ImageToPdf` | `PdfDocument.Create` + image content block |
+| `DocumentImport.DocxToPdf` (spawns LibreOffice) | `WordDocument.Load(...).SaveAsPdf(...)` in-process — **removes the external `soffice` dependency entirely** |
 
-### `IInspector` — pages/fonts/images/attachments/outlines/security/DoS guards
+### `IInspector` — 🟢/🟡
 
 | Today | OfficeIMO.Pdf | Status |
 |---|---|---|
-| `PdfInspector.GetInfo` (page geometry, effective crop×media box, rotation, encryption) | `PdfDocument.Inspect()` → page count/geometry; `Security` info via preflight | 🟢 |
-| `Encryptor.IsEncrypted`/`CanOpen` | `PdfDocument.Load` + `PdfLoadOptions.Password`, `PdfDocumentSecurityInfo` | 🟢 |
-| `ExportValidator.Validate` (re-read output: xref/trailer, stream round-trip, page tree, AcroForm appearance invariants) | `PdfDocument.Analyze(...)` (health/rewrite-safety/diagnostics/repair/signature/compliance in one report) + `PdfRepairReport` | 🟡 — the *shape* of findings differs; needs a small adapter reproducing this project's specific checks (see [Gaps](#verified-gaps--upstream-issue-candidates)) |
-| `PdfStructureGuard.EnsureFormXObjectsTerminate` (cyclic form-XObject guard before content processing) | Built into the parser itself: `PdfRedactionPlan`'s form-resource traversal enforces `MaxFormResourceTraversals`/depth limits (`PdfRedactionPlan.cs`, `AppendFormRenderingResourceIdentity`, `maximumDepth = 64`), and the general reader is fuzzed against a pinned GovDocs corpus + Open Preservation Foundation/veraPDF fixtures | 🟢 — likely **deletable** rather than portable: the guard becomes the library's job |
-| `PdfContentGuard.InDefaultUserSpace` (draw without inheriting a page's leftover CTM) | `Stamp.Content((canvas, page) => ...)` canvas stamping operates in a fixed, page-relative coordinate system by contract | 🟢 |
-| `Sanitizer.Inspect` (counts: metadata fields, attachments, scripts/actions, markup annotations, bookmarks, OC layers) | No single matching "hidden data" counter; the underlying facts are all independently readable (`Inspect()`, `JavaScript.List()`, `Attachments.Extract()`, `Annotations` list, `Bookmarks`, catalog optional-content) | 🟡 — portable, but as a small aggregation written against this repo, not a single OfficeIMO call (see Gaps) |
+| `PdfInspector.GetInfo` | `Inspect()` page geometry/count | 🟢 |
+| `Encryptor.IsEncrypted`/`CanOpen` | `PdfLoadOptions.Password`, `PdfDocumentSecurityInfo` | 🟢 |
+| `ExportValidator.Validate` | `Analyze(...)` + `PdfRepairReport` | 🟡 different finding shape; needs an adapter |
+| `PdfStructureGuard`/`PdfContentGuard` | Parser-level bounded limits (`PdfReadLimits`: max operations, nesting depth, operands, decoded bytes) | 🟢 likely **deletable** — becomes the library's job |
+| `Sanitizer.Inspect` | No single equivalent; composable from `Inspect()`/`JavaScript.List()`/`Attachments`/`Annotations`/`Bookmarks` | 🟡 |
 
-### `ITextEditor` / `IContentStreamEditor` — the highest-risk seam
-
-| Today | OfficeIMO.Pdf | Status |
-|---|---|---|
-| `TextTools.GetTextInRegion`/`GetTextSpans` (via `LocationTextExtractionStrategy`-style `IEventListener`) | `Text.Inspect(region)`, `PdfDocument.Read()` → `PdfLogicalPage.TextBlocks`/`PdfTextSpan` (font, size, color, transform per span) | 🟢 |
-| `TextTools.ReplaceTextInRegion` (drop matched glyphs, re-stamp) | `document.Text.Replace(region, newText, options)` — README states it "preserves unmatched source-span text" and fails closed for invisible/clipped text rather than guessing | 🟢, pending the fidelity check below |
-| `TextTools.MoveText` | `Text.Add` + prior region removal, or the dedicated move path implied by `Images.Move`'s sibling text API | 🟡 — confirm a first-class move exists vs. compose remove+add |
-| `TextTools.AddText` (canvas + `PdfFont`) | `document.Text.Add(region, text, PdfTextEditOptions)` | 🟢 |
-| `TextTools.FindText` (`TextMatchMode`, whole/partial) | `Text.Find(...)` — "case and whole-word filters over visible, unclipped text" | 🟢 |
-| **`ContentStreamEditor`** — subclasses `PdfCanvasProcessor`, intercepts `Tj/TJ/'/"` and `Do`, does **per-glyph** replacement (drops only the glyphs inside a region, re-emits the rest as an equivalent-width `TJ` displacement so surrounding text doesn't reflow), recurses into form XObjects up to depth 6, handles inline images | `PdfRedactionApplier.TextScrubbing.cs` (945 lines) + `PdfRedactionApplier.TextFormScrubbing.cs` (157 lines, form-XObject-aware) implement the same class of operation: matched text objects are physically removed from the content stream, not merely covered | 🟡→🟢 by evidence of scale and dedicated form-XObject handling, but **this is the one operation in the whole migration worth an actual before/after content-stream diff** before trusting it — see [Gaps](#verified-gaps--upstream-issue-candidates) item 1 |
-| `ImageTools.MoveImage` (remove draw call, redraw at shifted rect) | `Images.Move(placement, deltaX, deltaY)` | 🟢 |
-| `ImageScrubber.TryScrubPixels` (re-encode image XObject with pixels inside a region blacked out or paper-colored, for OCR'd scanned pages) | `PdfRedactionApplier.Images.PixelRewrite.cs` (1,007 lines) — dedicated pixel-level image rewrite path, distinct from the 988-line whole-placement `Images.cs` | 🟢 by evidence of scale/dedication |
-
-### `IRedactionEngine` — the project's core differentiator
+### `ITextEditor` / `IContentStreamEditor` — 🔴 the blocker
 
 | Today | OfficeIMO.Pdf | Status |
 |---|---|---|
-| `Redactor.Redact`/`RemoveContent` (drives `ContentStreamEditor`, then removes intersecting annotations, then paints the box) | `document.Redactions.Apply(areas, options)` — "removes matched text objects and annotations, then paints redaction marks" (`PdfRedactionApplier.cs:9`); `PdfRedactionApplyOptions` exposes `RemoveIntersectingPaths`, `PaintUnmatchedAreas`, `UnsupportedImagePolicy`, `CleanupScope` | 🟢 |
-| `RedactionBox.Prepare`/`MergeAdjacent`/`Expand` (pre-processing regions before applying) | `document.Redactions.Plan(areas)` — a **non-mutating** preview returning every `PdfRedactionMatch` (text/annotation/image) intersecting each area, plus preflight/diagnostics | 🟢 — and arguably better: this project has no equivalent dry-run today |
-| `RedactionReporter.Analyze` (per-region: text removed, image thumbnails, annotation/text-run counts, computed from the *original* doc) | `PdfRedactionMatch` already carries `Text`, `Kind` (TextBlock/Annotation/ImagePlacement), `ImagePlacement`, page/rect — everything except a rendered thumbnail, which is one `Images.Extract()` call away | 🟢 — direct rebuild on `Plan(...).Matches`, likely simpler than today's hand-rolled version that separately re-derives spans/images/annotations |
-| *(nothing today)* | `document.Redactions.Verify`/`AssertVerified`/`VerifyAppliedPlan` — re-opens the rewritten PDF and proves configured content no longer intersects the reviewed areas (`PdfRedactionVerification.Residue.cs`, 375 lines) | 🟢 **capability upgrade** — an independent, automatable proof this project does not currently have for its own compliance claims |
+| `TextTools.GetTextInRegion`/`GetTextSpans` | `Text.Inspect(region)`, public `PdfReadPage.GetTextSpans()` → `PdfTextSpan` with position/font/size/transform | 🟢 |
+| `TextTools.FindText` | `Text.Find(...)` with case/whole-word filters | 🟢 |
+| `TextTools.AddText` | `Text.Add(region, text, PdfTextEditOptions)` | 🟢 |
+| `TextTools.ReplaceTextInRegion`, `MoveText` | `Text.Replace`/`Add` — but via whole-text-object removal + re-stamp in a **substituted standard font**; throws on invisible/clipped text | 🔴 regresses #29 font fidelity; rejects OCR'd scans |
+| **`ContentStreamEditor`** (per-glyph split, width-compensated `TJ`, form-XObject recursion, inline images) | Whole-`BT`…`ET` excision against a union bbox with flat half-em width estimates | 🔴 **architectural gap** |
+| `ImageTools.MoveImage` | `Images.Move(placement, dx, dy)` | 🟢 |
+| `ImageScrubber.TryScrubPixels` | `PdfRedactionApplier.Images.PixelRewrite.cs`; JPEG/masked/indexed cases need a caller-supplied `IPdfRedactionImageDecoder` or fail closed | 🟡 |
 
-### `IAnnotationEngine` — highlight/ink/watermark/Bates/stamps
-
-| Today | OfficeIMO.Pdf | Status |
-|---|---|---|
-| `HighlightTool.AddHighlight` (`Multiply` blend rectangle in default user space) | `Stamp.Content` canvas supports fills and blend-mode effects (`SetBlendMode` appears in `PdfStamper.Pages.cs`); confirm the fluent canvas exposes blend mode directly | 🟡 — see Gaps item 2 |
-| `InkTools.AddInk` (freehand polylines, round caps/joins) | `Stamp.Content` canvas: README lists "shapes, drawings, clipping, and effects are supported" for canvas stamping | 🟢, pending a round-cap/join fidelity check |
-| `WatermarkTool.AddTextWatermark` | `PdfOptions.TextWatermark` at creation time, or `Stamp.TextWatermark(text, PdfTextStampOptions { RotationDegrees, Opacity, ... })` on an existing document | 🟢 |
-| `BatesTool.AddBatesNumbers` | `PdfBatesNumberer.Apply(documents, PdfBatesNumberingOptions { StartNumber, Prefix, MinimumDigits, Position })` — a **named, first-class feature**, not something to reimplement on the canvas | 🟢 |
-| `Signer.AddImageSignature` (stamp an uploaded/drawn signature image) | `Stamp` image placement, or `Images.Add` fit-to-region | 🟢 |
-
-### `IFormEngine`
+### `IRedactionEngine` — 🔴 core, 🟢 periphery
 
 | Today | OfficeIMO.Pdf | Status |
 |---|---|---|
-| `FormTools.AddTextField`/`AddDropdown`/`AddRadioGroup`/`AddCheckbox`/`AddButton` | `Forms.Edit(form => form.Create(new PdfFormFieldCreateOptions { Kind, Name, PageNumber, X, Y, Width, Height, Style, ... }))` — text/checkbox/combo/list/radio-group/push-button/signature fields in one transaction | 🟢 |
-| `FormTools.ListFields` (name, type, value, options, readonly, geometry, attached script) | `PdfDocument.Inspect().FormFields` / `PdfDocumentReadResult.FormFields` | 🟡 — confirm per-field JS/activation script surfaces (README shows `JavaScript` as a *create*-time option on push buttons; reading it back per-field, and setting it on non-button fields' `/AA /U`, needs confirming) — see Gaps item 3 |
-| `FormTools.FillFields` (+ optional flatten) | `Forms.FillAndFlatten(values)`; `Forms.Edit` for fill-without-flatten | 🟢 |
-| `FlattenTool.Flatten` (Mode: forms-only / annotations-only / all) | `Forms.FillAndFlatten` (forms) + `Annotations.Flatten` (non-form annotations), per the annotation workflow row ("...flatten... authored or diagnosed synthesized appearances") | 🟢 — composes to the same three modes |
+| `Redactor.Redact` content removal | `Redactions.Apply(areas, options)` — correct security posture (errs toward removing more), wrong granularity for an interactive editor | 🔴 |
+| `RedactionBox.Prepare`/`Expand` | `Redactions.Plan(areas)` non-mutating preview | 🟢 — better than today; no dry-run exists now |
+| `RedactionReporter.Analyze` | `PdfRedactionMatch` carries `Text`, `Kind`, `ImagePlacement`, page/rect | 🟡 — rebuildable, but plan/apply geometry mismatch (above) undermines "exactly what was removed" |
+| *(nothing today)* | `Redactions.Verify`/`AssertVerified` marker-based residue proof | 🟢 net-new, worth adopting regardless |
 
-### `ISecurityEngine` — encrypt/sanitize/JS/URLs
-
-| Today | OfficeIMO.Pdf | Status |
-|---|---|---|
-| `Encryptor.Encrypt`/`Decrypt` (AES-256, `WriterProperties`) | `PdfStandardEncryptionOptions` (AES-256 default, AES-128, legacy RC4, Unicode passwords, typed permission bits) via `PdfOptions().SetEncryption(...)`; platform AES by default, managed AES from `OfficeIMO.Core` for restricted hosts | 🟢 |
-| `JavaScriptTool.AddDocumentScript`/`ListScripts`/`RemoveScript` (`/Names /JavaScript` tree) | `document.JavaScript.List()` / `.Edit(scripts => scripts.AddOrReplace(name, code).Remove(name))` — named, exact-match, name-tree-preserving | 🟢 (closer to a 1:1 API match than most items in this table) |
-| `PdfSafety.Scan`/`StripActive` (document JS, open/page/annotation actions, outward URI/Launch/SubmitForm/GoToR/ImportData) | The sanitizer workflow ("policy-driven full rewrites remove or quarantine embedded payloads, unsafe actions and URI targets") plus `JavaScript.List()` for the JS half | 🟡 — confirm the *action-kind* granularity (URI vs. Launch vs. SubmitForm vs. GoToR vs. ImportData) is individually selectable, since `PdfSafety.Scan` reports and this project's UI surfaces those separately | see Gaps item 4 |
-| `UrlTools.ExtractLinks`/`ExtractLinkAnnotations` (URI links + every link kind with geometry and chained `/Next` actions) | `PdfDocumentReadResult.Links` (`PdfLogicalLinkAnnotation`) | 🟡 — confirm action-kind classification (goto/remote-goto/launch/named/submit vs. plain uri) and chained-action traversal match today's `UrlTools.ClassifyLink`/`CollectUri` |
-| `Sanitizer.Sanitize` (metadata incl. XMP, attachments, comment annotations, bookmarks, OC layers, scripts/actions) | Composable from `UpdateMetadata(...)` (clear standard fields) + catalog `/Metadata` removal + `Attachments` remove-all + `Annotations` remove-by-kind + `Bookmarks` remove-all + optional-content removal + the JS/action sanitizer above | 🟡 — every piece exists; there's no single call. See Gaps item 5 for whether OfficeIMO should offer one |
-
-### `ISigningEngine`
+### `IAnnotationEngine` / `IFormEngine` / `ISecurityEngine` / `ISigningEngine` — 🟢/🟡 clean
 
 | Today | OfficeIMO.Pdf | Status |
 |---|---|---|
-| `Signer.SignDigitally` (PKCS#12, `PdfSigner` + BouncyCastle, detached CMS) | `Security.SignExternal(signer, PdfExternalSignatureOptions)` — PDF package owns byte ranges/incremental updates/signature dictionary; `PdfCmsExternalSigner` (from optional `OfficeIMO.Security`) supplies the CMS/PKCS#12 side | 🟢, with a package split (core PDF signature mechanics vs. optional crypto provider) that is actually cleaner than today's single `Signer.cs` |
-| `Signer.GetSignatures` (list + `coversWholeDocument` / integrity) | `Security.ValidateSignatures(cryptography)` → `PdfSignatureValidationReport`; byte-range/incremental-update inspection is native to the PDF package (not the optional crypto package) | 🟢 — this is exactly the item the earlier README-only investigation flagged 🔴→🟡 as unresolved; source inspection resolves it to 🟢 |
-| `CertificateFactory.CreateSelfSignedPkcs12` (`System.Security.Cryptography` + BouncyCastle, **not iText today**) | No change needed — this file has no `iText` dependency now and none after migration | 🟢 (no migration work) |
+| `HighlightTool` (`Multiply` blend) | `Stamp.Content` canvas; blend mode used internally, not clearly public | 🟡 upstream draft #1 |
+| `InkTools`, `WatermarkTool` | `Stamp.Content` shapes/drawings; `Stamp.TextWatermark`, `PdfOptions.TextWatermark` | 🟢 |
+| `BatesTool` | `PdfBatesNumberer` with prefix/digits/position — a first-class feature | 🟢 |
+| `FormTools` add/list/fill | `Forms.Edit(...)`/`Forms.FillAndFlatten(...)`; per-field JS on non-button fields unconfirmed | 🟢/🟡 upstream draft #2 |
+| `FlattenTool` 3 modes | `Forms.FillAndFlatten` + `Annotations.Flatten` | 🟢 |
+| `Encryptor` | `PdfStandardEncryptionOptions` (AES-256/128, RC4, permissions) | 🟢 |
+| `JavaScriptTool` | `JavaScript.List()`/`.Edit(...)` — near 1:1 | 🟢 |
+| `PdfSafety`, `UrlTools` | Sanitizer + `Links`; action-subtype granularity unconfirmed | 🟡 upstream drafts #3/#4 |
+| `Signer.SignDigitally`/`GetSignatures` | `Security.SignExternal(...)`, `ValidateSignatures(...)` → `PdfSignatureValidationReport` | 🟢 — resolves the earlier 🔴 |
+| `CertificateFactory` | No iText dependency today; unaffected | 🟢 no work |
 
-### Unaffected / independent of iText already
+### Unaffected
 
-`PageRenderer` (PDFium via `PDFtoImage` + SkiaSharp), `VisualDiff` (renders both versions via `PageRenderer`, diffs pixels), `DocComparer` (word-level LCS diff over `TextTools.GetTextSpans` output — portable once `TextTools` is), `OcrTool` (Tesseract over rendered pages; writes its invisible text layer through `TextTools.AddText`, so it inherits that seam's status), `UrlClassifier` (pure string classification, no PDF library at all).
+`PageRenderer`/`VisualDiff` (PDFium + SkiaSharp), `DocComparer` (LCS over extracted
+text), `OcrTool` (Tesseract; but see the invisible-text finding), `UrlClassifier`.
 
-*Aside, out of scope for #115 but worth flagging separately*: `OfficeIMO.Pdf` also ships its own page-to-image renderer (`ToImages()`/`ToImage()`) and its own PDF/A, signature-appearance, and font-embedding stack. Once the engine migration lands, `PDFtoImage`/PDFium could in principle be retired too — but that's a second, independent decision with its own risk (PDFium is a mature, widely-deployed renderer; OfficeIMO's is comparatively new) and should be a separate issue, not bundled into #115.
+## Revised recommendation
 
-## Verified gaps / upstream issue candidates
+1. **Phase 0 — build the seam (#116). Unchanged, and still worth doing on its own.**
+   It isolates the iText surface, makes the tools testable against fakes, and is the
+   only way to migrate the 🟢 majority without a big-bang rewrite.
+2. **Do not plan a full engine swap on today's OfficeIMO.** The 🟢 items are genuinely
+   ready, but migrating them alone leaves iText in the tree for redaction and text
+   editing, so the AGPL goal — the entire point of #115 — is not met. Migrating the
+   core as-is would trade an AGPL problem for a product-quality regression: losing a
+   line of text per redaction box, standard-font substitution on every edit, and
+   `NotSupportedException` on OCR'd scans.
+3. **Open the upstream conversation now** (drafts in
+   [`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md)). Draft #5 is the
+   one that decides this project's outcome: sub-text-object redaction granularity,
+   and/or public content-stream tokenizer + writer primitives so a per-glyph editor can
+   be built on an MIT base. OfficeIMO already has the machinery internally
+   (`PdfContentStreamInterpreter`, `TextContentParser`, font decoders, real metrics in
+   the read model) — it is `internal`, not absent. This is a plausible ask, not a
+   rewrite request.
+4. **Re-evaluate when that lands.** If OfficeIMO exposes sub-object granularity or the
+   primitives, the migration becomes attractive across the board and Phase 0 will have
+   made it incremental. If it does not, the honest answer to #115 is **stay on iText**
+   and keep the seam as the net win.
+5. **Adopt one idea regardless of the outcome:** a post-redaction residue assertion in
+   the spirit of `Redactions.Verify`. This project makes a removal guarantee (#48) and
+   currently has no independent post-hoc check that the bytes are actually gone.
 
-These are the concrete items this pass could not resolve to 🟢 from source alone —
-each needs either a code spike against this project's test corpus, or is a real,
-filable gap in OfficeIMO. Draft issue text for the OfficeIMO-side items is in
-[`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md).
+## Caveats
 
-1. **Per-glyph redaction fidelity vs. run-level.** `ContentStreamEditor` specifically
-   preserves layout by splitting a partially-overlapping text-show operator at the
-   *glyph* boundary — glyphs outside a region survive with their original spacing,
-   only the glyphs inside are replaced by an equivalent-width displacement. Whether
-   `PdfRedactionApplier.TextScrubbing.cs` does the same (vs. dropping/keeping whole
-   runs, which would over- or under-redact at a run's edges) cannot be confirmed by
-   reading around a 945-line file at reasonable depth — it needs a real round-trip:
-   redact half of a multi-word run and diff the resulting content stream. **This is
-   the one spike issue #115 explicitly calls for, and it's still open** — this
-   session's egress proxy blocks the .NET SDK installer, so it needs to run in the
-   project's own devcontainer (which already carries a .NET SDK per
-   `.devcontainer/Dockerfile`) or on a developer machine, not in this remote session.
-2. **Blend-mode control on canvas stamping isn't documented at the fluent level.**
-   `HighlightTool` relies on `Multiply` specifically so glyphs stay legible under the
-   highlight color. `SetBlendMode` exists in OfficeIMO's internal stamping code but
-   the public `Stamp.Content` canvas API surface in the README doesn't show a
-   blend-mode setter. If it's missing, this is an upstream issue (draft #1).
-3. **Per-field JavaScript activation, read and write, on non-button fields.** Today's
-   `FormTools` attaches script to a push button's `/A` and to every other field
-   type's widget `/AA /U`, and reads it back the same way for the forms panel. The
-   README only demonstrates `JavaScript` as a create-time option on a push button.
-   If `Forms.Edit`/`ListFields`-equivalent doesn't expose `/AA /U` for text/choice/
-   checkbox/radio fields, that's an upstream issue (draft #2).
-4. **Individually selectable outward-action kinds when stripping active content.**
-   `PdfSafety` distinguishes `URI`, `Launch`, `SubmitForm`, `GoToR`, `ImportData` and
-   lets the caller strip JavaScript and URL-reaching actions independently. Confirm
-   OfficeIMO's sanitizer exposes the same granularity rather than an all-or-nothing
-   "unsafe actions" toggle (draft #3 covers the case it doesn't).
-5. **No single "strip everything a user didn't mean to share" call.** Every
-   ingredient of `Sanitizer.Sanitize` exists somewhere in OfficeIMO, but as separate
-   calls across metadata, attachments, annotations, bookmarks, optional content, and
-   the JS/action sanitizer — with no combined report shaped like
-   `HiddenDataReport` (one count per category, before removal). This is a
-   product-shape gap worth filing upstream since `PdfEditor.Core`'s `Sanitizer` is a
-   plausible template for it (draft #4).
-6. **`ExportValidator`'s specific checks vs. `Analyze()`'s shape.** `ExportValidator`
-   checks are narrow and read-only-forever (never throws, reports findings): xref/
-   trailer integrity, stream length/filter round-trip, page-tree consistency, cheap
-   AcroForm appearance invariants. `PdfDocument.Analyze()` looks like a superset, but
-   confirm it never throws on a malformed *output* it just produced (a self-check
-   must not itself be fragile) and that its diagnostics are granular enough to
-   reproduce this project's specific post-export assertions.
-7. **`TextTools.MoveText` as a first-class operation.** Confirm whether moving
-   selected text is a direct OfficeIMO API or has to be composed from
-   `Text.Inspect` + region removal + `Text.Add` (likely fine either way, just needs
-   confirming before committing to the seam's method shape).
-
-## Recommended plan
-
-Recommendation stands as the original investigation framed it, updated for what
-source access changed:
-
-1. **Phase 0 — build the engine seam (#116), regardless of outcome.** This pass's
-   findings make Phase 0 unconditionally worth doing sooner: nearly every capability
-   table above landed 🟢 or 🟡, which means the seam is very likely to be *used*
-   (not built and then abandoned back onto iText). Introduce the interfaces #116
-   lists, move the 28 files behind them with **iText as the sole implementation**,
-   zero behavior change, existing tests + 90% coverage gate stay green.
-2. **Phase 1 — the one required spike, not a broad one.** Where the prior
-   investigation asked "can OfficeIMO do content-stream redaction and text editing
-   at all", this pass's source reading answers "yes, with dedicated, sizeable
-   implementation code for exactly that." The remaining spike is narrower and
-   mechanical: build a small console harness against `OfficeIMO.Pdf` 3.3.0,
-   round-trip a handful of this repo's existing golden/fuzz fixtures
-   (`tests/PdfEditor.Core.Tests/Golden`, `.../Fuzz`) through `Redactions.Plan` →
-   `Redactions.Apply` → `Redactions.Verify`, and diff against today's `Redactor`
-   output on the same inputs. Needs a real .NET SDK (the project's own devcontainer
-   has one; this session's sandboxed egress does not).
-3. **Phase 2 — migrate capability-by-capability behind the seam**, in the order the
-   mapping table suggests confidence: `ISigningEngine`/`IPdfDocumentStore` first
-   (cleanest 🟢s, including deleting the LibreOffice dependency), then
-   `IAnnotationEngine`/`IFormEngine`/`ISecurityEngine`, then `IRedactionEngine`/
-   `ITextEditor` once Phase 1's spike confirms fidelity.
-4. **File the upstream issues** in [`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md)
-   against `EvotecIT/OfficeIMO` for the items in [Verified gaps](#verified-gaps--upstream-issue-candidates)
-   that are genuine product gaps (drafts #1–#4) rather than this project's own
-   spike work (items 1, 6, 7 above stay this project's problem).
-
-## Caveats and what remains unverified
-
-- This is a static-source-reading pass, not a compiled, executed one. OfficeIMO's own
-  documentation is unusually precise about boundaries (it explicitly lists what each
-  workflow does *not* claim), which is a good sign for trustworthiness, but "the code
-  exists and looks purpose-built" is not the same evidence as "it passed on our
-  fixtures."
-- `OfficeIMO.Pdf`'s current-state doc describes itself as "useful and broad, but
-  still evolving," with open items in font/color/pattern rendering fidelity — none
-  of which this project depends on for its core redaction/editing guarantees, but
-  worth knowing the engine is young relative to iText's ~20 years of edge-case
-  hardening.
-- No attempt was made in this pass to build or run anything against OfficeIMO —
-  the egress proxy in this session allows `github.com`/`nuget.org` (used to clone
-  the repo and confirm package publication) but rejected
-  `builds.dotnet.microsoft.com` (the .NET SDK installer), and no `dotnet` CLI is
-  present in this container.
+- Source reading and PDF byte analysis, not execution. The granularity finding is
+  structural and I consider it solid (it follows from the shape of the algorithm, not
+  from a judgement call about quality), but the *severity* estimates — how often a
+  producer emits multi-line text objects, whether the half-em width approximation ever
+  causes under-redaction — deserve a compiled test before anyone acts on them.
+- Everything here describes `OfficeIMO.Pdf` 3.3.0 / `master` at `aba60b7b`. This is a
+  fast-moving library (3.2.x → 3.3.0 moved several public engine classes to `internal`
+  per its `MIGRATION.md`); re-check before relying on any specific API shape.
+- The flip side of that churn is a maintenance consideration this project should weigh
+  independently of features: a security-critical removal guarantee resting on a young,
+  rapidly-changing library with a small maintainer team is a different risk profile
+  from iText's two decades of hardening — even though iText's licence is the reason
+  this exercise exists at all.

--- a/docs/backend-portability.md
+++ b/docs/backend-portability.md
@@ -19,7 +19,39 @@ this file rated the content-stream work "🟡→🟢 by evidence of scale" — i
 capability from the size and naming of OfficeIMO's redaction files rather than from
 reading the algorithm. Reading the algorithm gives a different answer, recorded below.
 
-## Headline finding
+## Update — the blocking finding is fixed in unreleased `master`
+
+Everything below analyses `OfficeIMO.Pdf` **3.3.0**, which is what NuGet ships today
+(release `OfficeIMO-v20260902190744`, commit `bd9e881f`). That analysis stands for the
+shipped package.
+
+Since it was written, `master` has picked up ~33 commits that fix the core blocker:
+
+- **Glyph-level redaction** — new `PdfContentStreamTextRewriter.cs` (commit `6a384161`,
+  "Preserve unaffected PDF glyphs during redaction"). `TrySplitGlyphs` splits encoded
+  strings per glyph, tests each against the rectangle, keeps survivors **in their
+  original encoding** (`kept.AddRange(glyph.Bytes)` — so no standard-font substitution)
+  and flushes removed glyphs as numeric `TJ` displacements. That is the same technique
+  as our `ContentStreamEditor`, and it removes both the whole-line blast radius and the
+  font-fidelity regression described below. Backed by ~1,050 lines of new tests.
+- **Font width providers** — the P0 bug is fixed: `SumWidth1000` now resolves real
+  per-font providers via `ResourceResolver.GetFontWidthProviders(...)`, threaded through
+  the whole call chain, so applier geometry matches the read model.
+- **Invisible-text opt-in** (`allowTextRenderingMode3`), **scoped canvas blend modes**,
+  **typed action sanitization**, and **combined before-sharing sanitization** also
+  landed — see [`officeimo-issues-to-file.md`](officeimo-issues-to-file.md).
+
+**None of this is published.** Latest NuGet remains 3.3.0. So the verdict changes from
+*"blocked at the core"* to *"blocked pending a release"* — a capability question has
+become a timing question. Re-validate against the first published version that contains
+it, using our own fixtures, rather than trusting commit messages or this summary.
+
+One caveat cuts the other way: redaction internals were substantially rewritten inside
+24 hours. That responsiveness is a real asset, but it reinforces the churn note at the
+bottom of this document — pin an exact version and re-run our own assertions on every
+bump.
+
+## Headline finding (as shipped in 3.3.0)
 
 **The migration is clean for roughly 80% of the surface and blocked at the core.**
 
@@ -228,24 +260,18 @@ text), `OcrTool` (Tesseract; but see the invisible-text finding), `UrlClassifier
 1. **Phase 0 — build the seam (#116). Unchanged, and still worth doing on its own.**
    It isolates the iText surface, makes the tools testable against fakes, and is the
    only way to migrate the 🟢 majority without a big-bang rewrite.
-2. **Do not plan a full engine swap on today's OfficeIMO.** The 🟢 items are genuinely
-   ready, but migrating them alone leaves iText in the tree for redaction and text
-   editing, so the AGPL goal — the entire point of #115 — is not met. Migrating the
-   core as-is would trade an AGPL problem for a product-quality regression: losing a
-   line of text per redaction box, standard-font substitution on every edit, and
-   `NotSupportedException` on OCR'd scans.
-3. **Open the upstream conversation now** (drafts in
-   [`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md)). Draft #5 is the
-   one that decides this project's outcome: sub-text-object redaction granularity,
-   and/or public content-stream tokenizer + writer primitives so a per-glyph editor can
-   be built on an MIT base. OfficeIMO already has the machinery internally
-   (`PdfContentStreamInterpreter`, `TextContentParser`, font decoders, real metrics in
-   the read model) — it is `internal`, not absent. This is a plausible ask, not a
-   rewrite request.
-4. **Re-evaluate when that lands.** If OfficeIMO exposes sub-object granularity or the
-   primitives, the migration becomes attractive across the board and Phase 0 will have
-   made it incremental. If it does not, the honest answer to #115 is **stay on iText**
-   and keep the seam as the net win.
+2. **Don't migrate against 3.3.0 — and don't build against `master` either.** The
+   shipped package still has the whole-line blast radius, the width-provider bug and
+   the OCR rejection. Tracking an unreleased branch for a security-critical guarantee
+   is the wrong trade, however good the fixes look.
+3. **Watch for the next published release above 3.3.0**, then validate it against our
+   own fixtures before trusting it: redact a word mid-line and assert the rest of the
+   line survives *in its original font*; redact a partially-overlapping run and assert
+   no reflow; redact on an OCR'd searchable scan; confirm `Plan()` and `Apply()` agree
+   on geometry. That is the spike #115 always asked for, now with a much better prior.
+4. **File only what's left.** Six of the seven drafted upstream issues are already
+   fixed on `master`; only the per-field form JavaScript question remains
+   ([`docs/officeimo-issues-to-file.md`](officeimo-issues-to-file.md)).
 5. **Adopt one idea regardless of the outcome:** a post-redaction residue assertion in
    the spirit of `Redactions.Verify`. This project makes a removal guarantee (#48) and
    currently has no independent post-hoc check that the bytes are actually gone.

--- a/docs/officeimo-issues-to-file.md
+++ b/docs/officeimo-issues-to-file.md
@@ -1,256 +1,44 @@
 # Issues to submit to EvotecIT/OfficeIMO
 
-Found while evaluating `OfficeIMO.Pdf` 3.3.0 as an iText replacement (see
-[`docs/backend-portability.md`](backend-portability.md)). Drafted, not filed — this
-session has read-only access to that repository.
+> **Status: 6 of 7 drafts are obsolete — do not file them.**
+>
+> Between the review that produced this list and now, OfficeIMO's `master` picked up
+> ~33 commits that independently fix or address six of the seven items. Filing them
+> would be reporting work that's already done. Only **Issue 5** below is still worth
+> submitting.
+>
+> Nothing here was ever filed, and there's no evidence these fixes relate to this
+> analysis — they're the maintainer's own work landing on a repo with very high commit
+> velocity. Verified at `origin/master` (`819a0516`); the release these were written
+> against, `OfficeIMO-v20260902190744` (= commit `bd9e881f` = NuGet **3.3.0**),
+> contains none of them.
 
-File at [github.com/EvotecIT/OfficeIMO/issues/new](https://github.com/EvotecIT/OfficeIMO/issues).
-Submit **in this order**: #1 is a correctness bug worth reporting on its own merits,
-#2 decides whether our migration is possible at all, #3–#7 are papercuts that can go in
-any order (or be skipped if you'd rather not open seven at once).
+## Current state of each draft
 
-All findings are from reading source at commit `aba60b7b` and from static analysis of
-PDF bytes. **Nothing here was compiled or executed** — there's no .NET SDK in the
-environment this was written in. Each draft says so; please keep that caveat in when
-filing, it's the honest framing and it costs nothing.
-
-| # | Title | Type | Priority |
+| # | Original title | Status on `master` | Evidence |
 |---|---|---|---|
-| 1 | Redaction applier computes text bounds without font width providers | Bug | **P0** — possible under-redaction |
-| 2 | Sub-text-object redaction granularity, or public content-stream primitives | Enhancement | **P1** — blocks our migration |
-| 3 | Text editing rejects invisible text, so OCR'd scans can't be edited | Enhancement | P2 |
-| 4 | Blend mode on `Stamp.Content` canvas fills | Question | P3 |
-| 5 | Per-field JavaScript activation on non-button AcroForm fields | Question | P3 |
-| 6 | Independently selectable outward-action kinds when stripping active content | Question | P3 |
-| 7 | Combined "hidden data" inspect + one-call sanitize | Enhancement | P3 |
+| 1 | Redaction bounds computed without font width providers | ✅ **Fixed** | `SumWidth1000` now resolves `fontWidthProviders` from `ResourceResolver.GetFontWidthProviders(...)`, threaded through `CollectTextObjects` → `BuildRedactionTextObject` → `ParseTextSpans` |
+| 2 | Sub-text-object redaction granularity | ✅ **Fixed** | New `PdfContentStreamTextRewriter.cs` (610 lines), commit `6a384161` "Preserve unaffected PDF glyphs during redaction" |
+| 3 | Text editing rejects invisible text (OCR'd scans) | ✅ **Addressed** | `IsSafelyEditableSpan(span, allowTextRenderingMode3)` opt-in; commit `e5eee161` "Support opt-in PDF OCR text operations" |
+| 4 | Blend mode on `Stamp.Content` canvas | ✅ **Addressed** | Commit `d88ae3b3` "Add scoped PDF canvas blend modes" — `PdfPageCanvas.cs` + `PdfDocumentCanvasTests.cs` |
+| 5 | Per-field JavaScript on non-button form fields | ❌ **Not addressed** | No matching commit — **still worth filing** |
+| 6 | Selectable outward-action kinds when sanitizing | ✅ **Addressed** | Commit `522dc06a` "Add typed PDF action sanitization" — new `PdfSanitizationActionCounts.cs` |
+| 7 | Combined "hidden data" inspect + sanitize | ✅ **Addressed** | Commit `00e109ff` "Add combined PDF before-sharing sanitization" — new `PdfSanitizationCategoryCounts.cs` |
 
----
+**Important caveat:** all of the above is on `master` and **unreleased**. The latest
+published `OfficeIMO.Pdf` on NuGet is still **3.3.0**, which has none of it. Don't plan
+around these fixes until they ship — and validate them against our own fixtures when
+they do, rather than trusting the commit messages (or this table).
 
-## Issue 1 — Redaction applier computes text bounds without font width providers
-
-**Labels:** bug
-
-**Title:** `Redaction: text object bounds computed with a flat 0.5em width estimate, ignoring font metrics`
-
-**Body:**
-
-While evaluating `OfficeIMO.Pdf` for a redaction tool I think I've found a correctness
-issue in how `PdfRedactionApplier` computes the bounds it uses to decide what a
-redaction rectangle intersects. Flagging it because the failure direction appears to be
-*retaining* text inside a painted redaction area, which runs against the intent
-documented in that same file.
-
-**What I'm seeing**
-
-`TextContentParser.Parse` takes a `sumWidth1000ForFont` callback and uses it to
-accumulate glyph advances into each span's width
-(`TextContentParser.cs:877-878`: `double w1000 = sumWidth1000ForFont(font, g);` →
-`advGlyph = ((w1000 / 1000.0) * size + charSpacing + ...) * hScale`).
-
-There are two callers, and they supply very different width functions.
-
-`PdfReadPage.cs:666` resolves real per-font metrics, falling back to a flat estimate
-only when a font resource can't be found:
-
-```csharp
-double SumWidth1000(string fontRes, byte[] bytes) =>
-    widthProviders.TryGetValue(fontRes, out var wp) ? wp(bytes) : (bytes?.Length ?? 0) * 500.0;
-```
-
-`PdfRedactionApplier.TextScrubbing.cs:524` uses the flat estimate unconditionally — no
-width providers are passed in at all:
-
-```csharp
-double SumWidth1000(string fontResource, byte[] bytes) =>
-    bytes is null ? 0D : bytes.Length * 500D;
-```
-
-So every glyph is assumed to be exactly half an em wide during redaction, regardless of
-the actual font.
-
-**Why I think it matters**
-
-Those bounds feed `AddSpanBounds` → `BuildRedactionTextObject`'s union box →
-`IntersectsTarget`, which decides whether a text object is removed. When real text is
-wider than the estimate — capitals (`W` is 944/1000 in Helvetica, `M` 833), bold and
-many display faces, monospace at 0.6em — the computed box is narrower than the text
-actually painted on the page. A redaction rectangle placed over the right-hand end of
-such a line can then fail to intersect the *estimated* box even though it visually
-covers the text, leaving the text object in place. The mark is painted, the text stays
-extractable underneath.
-
-That's the opposite of the guarantee the code seems to intend a few lines further down
-in the same file:
-
-```csharp
-// An area redaction is a confidentiality boundary. If a text object cannot be
-// located, retaining it could leave extractable text inside the painted area.
-```
-
-There's a secondary effect too: `PdfRedactionPlanner` derives its matches from
-`document.TextBlocks` (the logical read model, i.e. real metrics), while the applier
-uses the estimate. So `Redactions.Plan(...)` and `Redactions.Apply(...)` can disagree
-about which content a given rectangle covers, which is awkward for anyone using `Plan`
-as a reviewable preview or as an audit record of what was removed.
-
-**Expected**
-
-The applier resolves the same per-font width providers the read model uses, so
-redaction geometry matches both the rendered page and the plan preview.
-
-**Repro sketch**
-
-I have not been able to compile a repro — there's no .NET SDK available in the
-environment I'm working in, so this is from reading the source. What I'd expect to
-demonstrate it:
-
-1. Generate a PDF with a line of capitals in Helvetica (e.g. `WWWWW MMMMM WWWWW`) at a
-   known position and font size.
-2. Compute where that line actually ends (real advance widths) versus where a
-   0.5-em-per-byte estimate puts it — the estimate should fall well short.
-3. `Redactions.Apply` a rectangle covering the last word, in the gap between the two.
-4. Extract text from the output and check whether the covered word survives.
-
-Happy to contribute that as a test fixture if it's a useful shape, and equally happy to
-be told I've misread the call graph.
-
----
-
-## Issue 2 — Sub-text-object redaction granularity, or public content-stream primitives
-
-**Labels:** enhancement
-
-**Title:** `Redaction removes whole BT..ET text objects; allow sub-object granularity or expose content-stream primitives`
-
-**Body:**
-
-First: thank you for `OfficeIMO.Pdf` — the redaction subsystem is clearly built with
-care, the fail-toward-removal posture in `IntersectsTarget` is the right call for a
-confidentiality boundary, and `Redactions.Verify` is a feature most PDF libraries don't
-offer at all.
-
-I'm evaluating it as a replacement for iText in an interactive PDF redaction editor,
-where a user drags a rectangle over a few words and expects exactly that content to
-disappear. Reading `PdfRedactionApplier.TextScrubbing.cs`, redaction resolves to whole
-text objects:
-
-- `BuildRedactionTextObject` unions the bounds of every span in a `BT`…`ET` block into
-  one bounding box (`AddSpanBounds`).
-- `MarkMatchingTextObjects` → `IntersectsTarget` tests the requested rectangle against
-  that union box.
-- `RemoveTextObjectSpans` then excises the whole `BT`→`ET` byte range.
-
-Because most producers emit one text object per line, a rectangle over one word removes
-the whole line. Measured on real files — including Word-produced PDFs in your own
-`OfficeIMO.Pdf.Tests/Pdf/ReferenceBaselines/` — that's ~73–145 text objects per content
-stream, with the largest holding 89–105 characters across a single baseline.
-
-`PdfTextEditor.RemoveTextPreservingUnmatchedSpans` compensates by diffing which
-non-targeted spans disappeared and re-stamping them, which is a clever recovery. But the
-re-stamp resolves style through `ResolveStandardFont(...)`, so text originally set in an
-embedded font returns as its closest standard-14 approximation (correctly reported via
-`BuildSubstitutionWarnings`). For a redaction tool the visible result is that redacting
-one word changes the typeface of the rest of the line.
-
-**Ask — either of these would unblock this use case, whichever fits your design:**
-
-1. **Sub-text-object redaction granularity.** When a rectangle partially intersects a
-   text object, rewrite the show-text operators so glyphs outside the rectangle survive
-   in place, replacing removed glyphs with equivalent-width `TJ` displacements so the
-   surviving text keeps its spacing and doesn't reflow. Could be opt-in through
-   `PdfRedactionApplyOptions` (e.g. `TextGranularity = TextObject | Span | Glyph`) so the
-   current conservative default is preserved for callers who prefer it.
-2. **Or make the content-stream primitives public**, so callers can implement that
-   themselves on top of your parser: `PdfContentStreamInterpreter`, `TextContentParser`,
-   and a supported way to write a rewritten content stream back. These already exist and
-   are used internally by exactly this code path — they're `internal`, not absent.
-   `PdfReadPage.GetTextSpans()` being public already gets us halfway; the missing half is
-   writing.
-
-Option 2 would suit us fine and is presumably much less work for you — we'd carry the
-glyph-splitting logic ourselves rather than asking you to own it.
-
-Caveat: this is from reading source, not from running it — no .NET SDK in my current
-environment. Happy to be corrected if there's an option I've missed.
-
----
-
-## Issue 3 — Text editing rejects invisible text, so OCR'd scans can't be edited
-
-**Labels:** enhancement
-
-**Title:** `Text editing fails closed on invisible text (Tr 3), blocking OCR'd searchable scans`
-
-**Body:**
-
-`PdfTextEditor.IsSafelyEditableSpan` requires, among other things,
-`span.TextRenderingMode == 0`:
-
-```csharp
-private static bool IsSafelyEditableSpan(PdfTextSpan span) =>
-    span.IsVisible &&
-    !span.ClipPath.HasValue &&
-    span.TextRenderingMode == 0 &&
-    (!span.Color.HasValue || span.Color.Value.A == byte.MaxValue) &&
-    span.CanRestamp &&
-    !string.IsNullOrEmpty(span.Text);
-```
-
-…and the editor throws `NotSupportedException("The selected region contains invisible or
-clipped text whose rendering state cannot be recreated safely.")` otherwise.
-
-As a conservative default that's very reasonable — recreating arbitrary invisible or
-clipped rendering state is genuinely unsafe. But it also rules out a common and
-well-understood case: an OCR'd "searchable scan", which is a page image with an
-invisible text layer painted in rendering mode 3. That layer is invisible *by
-construction*, and a caller who produced it (or who has detected it) knows exactly what
-it is. Today those documents can't go through text editing at all.
-
-**Ask:** an explicit opt-in for this case — something like
-`PdfTextEditOptions.AllowInvisibleTextEditing`, or a narrower
-`AllowTextRenderingMode3`, letting a caller who understands the document take
-responsibility. I notice `RemoveTextPreservingUnmatchedSpans` already carries an
-`allowInvisibleTargetRemoval` parameter internally, so the concept seems to exist
-already — the ask is essentially to surface it.
-
-For context on why this matters for redaction specifically: with a searchable scan, the
-words a user sees are pixels in the page image and the only real text is the invisible
-OCR layer. Removing just that layer leaves the words visibly in place, so a correct
-redaction has to take both — which means the text side has to be reachable in the first
-place.
-
-From source reading rather than execution (no .NET SDK to hand), so apologies if
-there's already a supported route here.
-
----
-
-## Issue 4 — Blend mode on `Stamp.Content` canvas fills
-
-**Labels:** question, enhancement
-
-**Title:** `Is blend mode (e.g. Multiply) settable on Stamp.Content canvas fills?`
-
-**Body:**
-
-Evaluating `OfficeIMO.Pdf` as a replacement for an engine that paints text highlights as
-a rectangle with a `Multiply` blend mode, so the highlight colour tints the paper while
-the (usually dark) glyphs underneath stay legible — a plain alpha-blended fill washes the
-text out instead.
-
-`Stamp.Content((canvas, page) => ...)` looks like the right primitive (README: "Text,
-rich tables, images, shapes, drawings, clipping, and effects are supported"). I can see
-`SetBlendMode` used internally (e.g. `PdfStamper.Pages.cs`), but I couldn't find a
-blend-mode setter on the public canvas surface in the README or package docs.
-
-Is there a supported way to set the blend mode for a fill made through the
-`Stamp.Content` canvas, or another route to a markup-highlight effect (painted under
-existing text, blended, without using an annotation)? If not, would a canvas method for
-it be in scope — something like
-`canvas.WithBlendMode(PdfBlendMode.Multiply, draw => draw.Rectangle(...).Fill())`?
+Draft #2's *alternative* ask — making `TextContentParser` / `PdfContentStreamInterpreter`
+public — was **not** done; they remain `internal`. That's moot for us, since they
+implemented the glyph-granularity option directly, which is the better outcome.
 
 ---
 
 ## Issue 5 — Per-field JavaScript activation on non-button AcroForm fields
+
+**The only draft still worth submitting.**
 
 **Labels:** question, enhancement
 
@@ -290,69 +78,14 @@ Two questions:
 If neither exists today, would they be in scope? Happy to describe the exact
 widget-type → action-slot mapping we're trying to match.
 
----
-
-## Issue 6 — Independently selectable outward-action kinds when stripping active content
-
-**Labels:** question, enhancement
-
-**Title:** `Can active-content sanitization select individual outward-action kinds?`
-
-**Body:**
-
-Evaluating `OfficeIMO.Pdf`'s active-content sanitizer as a replacement for a tool that
-strips **JavaScript** and **outward-reaching actions** independently, where
-"outward-reaching" is itself broken into distinct subtypes: `URI` (open a URL), `Launch`
-(open a file), `SubmitForm`, `GoToR` (jump to a remote file), and `ImportData`. Our scan
-reports counts per bucket and the strip call takes independent flags, so a user can keep
-their hyperlinks while removing embedded scripts, or vice versa.
-
-The README's "Sanitize active content" section describes "policy-driven full rewrites
-remove or quarantine embedded payloads, unsafe actions and URI targets, and rich-media
-content", which reads like a single "unsafe actions" bucket rather than the five-subtype
-breakdown above.
-
-Is that granularity available — can a caller strip JavaScript without touching
-`Launch`/`SubmitForm`, or strip only `URI` actions while leaving `GoToR`/`ImportData`
-alone, and get a scan result broken out the same way? If the policy is currently
-coarser, would finer-grained action-kind selection (and a matching per-kind diagnostic
-count) be a reasonable addition?
+*(From reading source rather than running it — no .NET SDK in the environment this was
+written in — so apologies if there's already a supported route.)*
 
 ---
 
-## Issue 7 — Combined "hidden data" inspect + one-call sanitize
+## Appendix: the superseded drafts
 
-**Labels:** enhancement
-
-**Title:** `A single "what would sanitizing remove" report and one-call sanitize`
-
-**Body:**
-
-Evaluating `OfficeIMO.Pdf` as a replacement for a "sanitize before sharing" feature
-that, in one pass, both **previews** and **removes** everything a user typically doesn't
-intend to share in a PDF but which never shows on the rendered page:
-
-- document metadata (Author/Title/Subject/Keywords/Creator plus the XMP packet — but
-  *not* Producer/CreationDate/ModDate/Trapped, which are tool-authored rather than
-  user-authored)
-- embedded file attachments (name-tree `EmbeddedFiles`, catalog `/AF`, and per-page
-  `FileAttachment` annotations)
-- JavaScript and outward-reaching actions (see the previous issue)
-- comment/markup annotations, keeping `Link`/`Widget` (structural, not hidden info)
-- the bookmark/outline tree
-- optional-content (layer) definitions
-
-The preview is a single typed report — one count per category — so a UI can say "this
-will remove: 3 metadata fields, 1 attachment, 2 scripts, 5 comments, 8 bookmarks, 1
-hidden layer" before the user commits, and the removal call takes the same category
-flags so they can opt out per category.
-
-Every ingredient exists in `OfficeIMO.Pdf` individually (metadata update, `Attachments`,
-`Annotations`, `Bookmarks`, catalog optional content, the active-content sanitizer).
-This is asking whether a **combined** inspect+strip entry point — or a documented recipe
-composing the pieces with one combined report — is in scope, since folding six
-subsystems into one user-facing "sanitize" action seems like something worth having a
-single supported route for.
-
-Happy to share our current shape (a report with one count per category, and an options
-type with one bool per category) as a concrete reference if useful for scoping.
+The full text of drafts 1, 2, 3, 4, 6 and 7 is preserved in this file's git history
+(see the commit that added them, prior to this revision) should any of them need
+reviving — for example if a shipped release turns out not to cover the case, or if
+validation against our fixtures shows a fix is incomplete.

--- a/docs/officeimo-issues-to-file.md
+++ b/docs/officeimo-issues-to-file.md
@@ -1,0 +1,144 @@
+# Draft issues for EvotecIT/OfficeIMO
+
+Written while evaluating `OfficeIMO.Pdf` as an iText replacement for
+[`reDACT-PDF-Editor`](https://github.com/ZanattaMichael/reDACT-PDF-Editor) (see
+[`docs/backend-portability.md`](backend-portability.md) for the full investigation).
+These are drafted, not filed: this session has read-only access to
+`EvotecIT/OfficeIMO` and no authorization to open issues on someone else's
+repository on the project owner's behalf. Each entry is ready to paste into
+[github.com/EvotecIT/OfficeIMO/issues/new](https://github.com/EvotecIT/OfficeIMO/issues).
+
+Every item below is a genuine capability question found by reading OfficeIMO's own
+source (not a misunderstanding correctable by reading further docs) — but they are
+phrased as questions/requests, since it's possible the capability already exists
+under a name this pass didn't find.
+
+---
+
+## Draft #1 — Is blend mode (e.g. `Multiply`) settable on `Stamp.Content` canvas fills?
+
+**Labels:** question, enhancement
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf` as a replacement for a PDF engine that currently paints
+text highlights as a semi-transparent rectangle using a `Multiply` blend mode, so the
+highlight color tints the paper while the (usually dark) glyphs underneath stay
+legible — a plain alpha-blended fill would wash the text out instead.
+
+`Stamp.Content((canvas, page) => ...)` looks like the right primitive (README:
+"Text, rich tables, images, shapes, drawings, clipping, and effects are supported").
+I can see `SetBlendMode` used internally (e.g. `PdfStamper.Pages.cs`), but I couldn't
+find a blend-mode setter on the public canvas API surface shown in the README or
+package docs.
+
+Is there a supported way to set the blend mode (specifically `Multiply`) for a fill
+made through the `Stamp.Content` canvas, or another route to a markup-highlight
+effect (paint under existing text, blended, without an annotation)? If not, would a
+canvas method for this be in scope — something like
+`canvas.WithBlendMode(PdfBlendMode.Multiply, draw => draw.Rectangle(...).Fill())`?
+
+---
+
+## Draft #2 — Reading/writing per-field JavaScript activation on non-button AcroForm fields
+
+**Labels:** question, enhancement
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf`'s form APIs as a replacement for a tool that lets a user
+attach a JavaScript snippet to any inserted form field (text, checkbox, combo,
+radio group, push button) so it runs when the field is activated in Acrobat/Chrome —
+and later list that script back for display/editing.
+
+The convention: a push button's script goes on its widget's `/A` (activation) entry;
+every other field type's goes on the widget's `/AA` dictionary's `/U` (mouse-up)
+entry. Radio groups get it per-option-widget.
+
+The README shows `JavaScript` as a `PdfFormFieldCreateOptions` property, demonstrated
+only on a `PushButton` kind:
+
+```csharp
+.Create(new PdfFormFieldCreateOptions {
+    Name = "calculate",
+    Kind = PdfFormFieldCreationKind.PushButton,
+    ...
+    JavaScript = "this.getField('total').value = 42;"
+})
+```
+
+Two questions:
+1. Does `JavaScript` on `PdfFormFieldCreateOptions` write to `/AA /U` when `Kind` is
+   `Text`/`CheckBox`/`Combo`/`List`/`RadioGroup` (not just the button's `/A`)?
+2. Is there a way to **read back** the activation script for an existing field —
+   something on the form-field-listing result equivalent to "the JS attached to this
+   field's widget," checking both `/A` and `/AA /U` depending on field type?
+
+If neither exists today, would you consider it in scope? Happy to describe the exact
+current behavior we're trying to match if useful (widget-type → action-slot mapping).
+
+---
+
+## Draft #3 — Independently selectable outward-action kinds when stripping active content
+
+**Labels:** question, enhancement
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf`'s active-content sanitizer as a replacement for a tool
+that lets a user strip **JavaScript** and **outward-reaching actions** independently,
+where "outward-reaching" is itself broken into distinct action subtypes: `URI`
+(open a URL), `Launch` (open a file), `SubmitForm`, `GoToR` (jump to a remote file),
+and `ImportData`. A scan reports counts per bucket (JS count vs. URL-action count),
+and the strip call takes independent `javaScript`/`urls` flags.
+
+The `README.md` "Sanitize active content" section describes "policy-driven full
+rewrites remove or quarantine embedded payloads, unsafe actions and URI targets, and
+rich-media content," which reads as an all-or-nothing "unsafe actions" bucket rather
+than the five-subtype breakdown above.
+
+Is that granularity available — i.e. can a caller strip JavaScript without touching
+`Launch`/`SubmitForm` actions, or strip only `URI` actions while leaving
+`GoToR`/`ImportData` alone, and get a scan result broken out the same way? If the
+policy is currently coarser than this, would finer-grained action-kind selection (and
+a matching diagnostic count per kind) be a reasonable addition?
+
+---
+
+## Draft #4 — A single "what would sanitizing this document remove" report + one-call sanitize
+
+**Labels:** enhancement
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf` as a replacement for a "sanitize before sharing" feature
+that, in one pass, both **previews** and **removes** everything a user typically
+doesn't intend to share in a PDF that never shows on the rendered page:
+
+- document metadata (Author/Title/Subject/Keywords/Creator + the XMP packet — but
+  *not* Producer/CreationDate/ModDate/Trapped, which are tool-authored, not
+  user-authored)
+- embedded file attachments (name-tree `EmbeddedFiles`, catalog `/AF`, and
+  per-page `FileAttachment` annotations)
+- JavaScript and outward-reaching actions (see draft #3)
+- comment/markup annotations (keeping `Link`/`Widget`, which are structural, not
+  "hidden info")
+- the bookmark/outline tree
+- optional-content (layer) definitions
+
+The preview is a single typed report — one count per category — so a UI can show
+"this will remove: 3 metadata fields, 1 attachment, 2 scripts, 5 comments, 8
+bookmarks, 1 hidden layer" before the user commits, and the removal call takes the
+same category flags to let the user opt out of specific categories.
+
+Every ingredient exists somewhere in `OfficeIMO.Pdf` individually (metadata update,
+`Attachments`, `Annotations`, `Bookmarks`, catalog optional-content, the active-content
+sanitizer) — this issue is asking whether a **combined** "hidden data" inspect+strip
+call (or a documented recipe composing the pieces into one call with one combined
+report) is in scope, since composing six separate subsystems into one user-facing
+"sanitize" action is exactly the kind of thing worth having a single supported entry
+point for.
+
+Happy to share our current shape (`HiddenDataReport` with one int per category, and a
+`SanitizeOptions` with one bool per category) as a concrete reference if that's useful
+for scoping.

--- a/docs/officeimo-issues-to-file.md
+++ b/docs/officeimo-issues-to-file.md
@@ -13,6 +13,9 @@ source (not a misunderstanding correctable by reading further docs) — but they
 phrased as questions/requests, since it's possible the capability already exists
 under a name this pass didn't find.
 
+**Draft #5 is the one that matters.** Drafts #1–#4 are papercuts; #5 decides whether
+a full migration off iText is possible at all.
+
 ---
 
 ## Draft #1 — Is blend mode (e.g. `Multiply`) settable on `Stamp.Content` canvas fills?
@@ -142,3 +145,72 @@ point for.
 Happy to share our current shape (`HiddenDataReport` with one int per category, and a
 `SanitizeOptions` with one bool per category) as a concrete reference if that's useful
 for scoping.
+
+---
+
+## Draft #5 — Sub-text-object redaction granularity (or public content-stream primitives)
+
+**Labels:** enhancement
+
+**Body:**
+
+First: thank you for `OfficeIMO.Pdf` — the redaction subsystem is clearly built with
+care, the fail-toward-removal posture in `IntersectsTarget` is the right call for a
+confidentiality boundary, and `Redactions.Verify` is a feature most PDF libraries
+don't offer at all.
+
+I'm evaluating it as a replacement for iText in an interactive PDF redaction editor,
+where a user drags a rectangle over a few words and expects exactly that content to
+disappear. Reading `PdfRedactionApplier.TextScrubbing.cs`, redaction resolves to whole
+text objects:
+
+- `BuildRedactionTextObject` unions the bounds of every span in a `BT`…`ET` block into
+  one bounding box (`AddSpanBounds`).
+- `MarkMatchingTextObjects` → `IntersectsTarget` tests the requested rectangle against
+  that union box.
+- `RemoveTextObjectSpans` then excises the whole `BT`→`ET` byte range.
+
+Because most producers emit one text object per line, a rectangle over one word removes
+the whole line. Measured on real files: Word-produced PDFs in your own
+`OfficeIMO.Pdf.Tests/Pdf/ReferenceBaselines/` run ~73–145 text objects per stream with
+the largest holding 89–105 characters across a single baseline.
+
+`PdfTextEditor.RemoveTextPreservingUnmatchedSpans` compensates by re-stamping the
+collateral spans, which is a clever recovery — but the re-stamp resolves through
+`ResolveStandardFont(...)`, so text originally in an embedded font returns as its
+closest standard-14 approximation (correctly reported via
+`BuildSubstitutionWarnings`). For a redaction tool the visible result is that
+redacting one word changes the typeface of the rest of the line.
+
+**Ask — either of these would unblock this use case, whichever fits your design:**
+
+1. **Sub-text-object redaction granularity**: when a rectangle partially intersects a
+   text object, rewrite the show-text operators so glyphs outside the rectangle survive
+   in place — replacing removed glyphs with equivalent-width `TJ` displacements so the
+   surviving text keeps its original spacing and doesn't reflow. Possibly opt-in via
+   `PdfRedactionApplyOptions` (e.g. `TextGranularity = TextObject | Span | Glyph`) so
+   the current conservative default is preserved.
+2. **Or make the content-stream primitives public** so callers can implement that
+   themselves on top of your parser: `PdfContentStreamInterpreter`, `TextContentParser`
+   (and a supported way to write a rewritten content stream back). These already exist
+   and are used internally by exactly this code path; today they're `internal`, so the
+   only route to glyph-level editing is a different library. `PdfReadPage.GetTextSpans()`
+   being public is already halfway there — the missing half is writing.
+
+Two smaller observations from the same file, offered as data rather than requests:
+
+- The applier estimates every glyph advance as a flat half-em
+  (`SumWidth1000 => bytes.Length * 500D`, line ~525), while `PdfRedactionPlanner` derives
+  its matches from `document.TextBlocks` in the logical read model, which uses real
+  font metrics. So `Plan()` and `Apply()` compute geometry two different ways; a
+  proportional-font line whose true width the estimate undershoots could in principle
+  leave text inside a painted area, which seems contrary to the intent documented in
+  `IntersectsTarget`'s comment.
+- `IsSafelyEditableSpan` requires `TextRenderingMode == 0`, so the text-edit path
+  rejects invisible text. That's the correct conservative default in general, but it
+  also means OCR'd "searchable scans" (an invisible `Tr 3` layer over a page image) —
+  a very common redaction input — can't go through text editing at all. An explicit
+  opt-in for that case (the caller knowing the layer is an OCR layer) might be worth
+  considering.
+
+Happy to contribute failing test fixtures for any of the above if that's useful.

--- a/docs/officeimo-issues-to-file.md
+++ b/docs/officeimo-issues-to-file.md
@@ -1,163 +1,133 @@
-# Draft issues for EvotecIT/OfficeIMO
+# Issues to submit to EvotecIT/OfficeIMO
 
-Written while evaluating `OfficeIMO.Pdf` as an iText replacement for
-[`reDACT-PDF-Editor`](https://github.com/ZanattaMichael/reDACT-PDF-Editor) (see
-[`docs/backend-portability.md`](backend-portability.md) for the full investigation).
-These are drafted, not filed: this session has read-only access to
-`EvotecIT/OfficeIMO` and no authorization to open issues on someone else's
-repository on the project owner's behalf. Each entry is ready to paste into
-[github.com/EvotecIT/OfficeIMO/issues/new](https://github.com/EvotecIT/OfficeIMO/issues).
+Found while evaluating `OfficeIMO.Pdf` 3.3.0 as an iText replacement (see
+[`docs/backend-portability.md`](backend-portability.md)). Drafted, not filed — this
+session has read-only access to that repository.
 
-Every item below is a genuine capability question found by reading OfficeIMO's own
-source (not a misunderstanding correctable by reading further docs) — but they are
-phrased as questions/requests, since it's possible the capability already exists
-under a name this pass didn't find.
+File at [github.com/EvotecIT/OfficeIMO/issues/new](https://github.com/EvotecIT/OfficeIMO/issues).
+Submit **in this order**: #1 is a correctness bug worth reporting on its own merits,
+#2 decides whether our migration is possible at all, #3–#7 are papercuts that can go in
+any order (or be skipped if you'd rather not open seven at once).
 
-**Draft #5 is the one that matters.** Drafts #1–#4 are papercuts; #5 decides whether
-a full migration off iText is possible at all.
+All findings are from reading source at commit `aba60b7b` and from static analysis of
+PDF bytes. **Nothing here was compiled or executed** — there's no .NET SDK in the
+environment this was written in. Each draft says so; please keep that caveat in when
+filing, it's the honest framing and it costs nothing.
 
----
-
-## Draft #1 — Is blend mode (e.g. `Multiply`) settable on `Stamp.Content` canvas fills?
-
-**Labels:** question, enhancement
-
-**Body:**
-
-Evaluating `OfficeIMO.Pdf` as a replacement for a PDF engine that currently paints
-text highlights as a semi-transparent rectangle using a `Multiply` blend mode, so the
-highlight color tints the paper while the (usually dark) glyphs underneath stay
-legible — a plain alpha-blended fill would wash the text out instead.
-
-`Stamp.Content((canvas, page) => ...)` looks like the right primitive (README:
-"Text, rich tables, images, shapes, drawings, clipping, and effects are supported").
-I can see `SetBlendMode` used internally (e.g. `PdfStamper.Pages.cs`), but I couldn't
-find a blend-mode setter on the public canvas API surface shown in the README or
-package docs.
-
-Is there a supported way to set the blend mode (specifically `Multiply`) for a fill
-made through the `Stamp.Content` canvas, or another route to a markup-highlight
-effect (paint under existing text, blended, without an annotation)? If not, would a
-canvas method for this be in scope — something like
-`canvas.WithBlendMode(PdfBlendMode.Multiply, draw => draw.Rectangle(...).Fill())`?
+| # | Title | Type | Priority |
+|---|---|---|---|
+| 1 | Redaction applier computes text bounds without font width providers | Bug | **P0** — possible under-redaction |
+| 2 | Sub-text-object redaction granularity, or public content-stream primitives | Enhancement | **P1** — blocks our migration |
+| 3 | Text editing rejects invisible text, so OCR'd scans can't be edited | Enhancement | P2 |
+| 4 | Blend mode on `Stamp.Content` canvas fills | Question | P3 |
+| 5 | Per-field JavaScript activation on non-button AcroForm fields | Question | P3 |
+| 6 | Independently selectable outward-action kinds when stripping active content | Question | P3 |
+| 7 | Combined "hidden data" inspect + one-call sanitize | Enhancement | P3 |
 
 ---
 
-## Draft #2 — Reading/writing per-field JavaScript activation on non-button AcroForm fields
+## Issue 1 — Redaction applier computes text bounds without font width providers
 
-**Labels:** question, enhancement
+**Labels:** bug
+
+**Title:** `Redaction: text object bounds computed with a flat 0.5em width estimate, ignoring font metrics`
 
 **Body:**
 
-Evaluating `OfficeIMO.Pdf`'s form APIs as a replacement for a tool that lets a user
-attach a JavaScript snippet to any inserted form field (text, checkbox, combo,
-radio group, push button) so it runs when the field is activated in Acrobat/Chrome —
-and later list that script back for display/editing.
+While evaluating `OfficeIMO.Pdf` for a redaction tool I think I've found a correctness
+issue in how `PdfRedactionApplier` computes the bounds it uses to decide what a
+redaction rectangle intersects. Flagging it because the failure direction appears to be
+*retaining* text inside a painted redaction area, which runs against the intent
+documented in that same file.
 
-The convention: a push button's script goes on its widget's `/A` (activation) entry;
-every other field type's goes on the widget's `/AA` dictionary's `/U` (mouse-up)
-entry. Radio groups get it per-option-widget.
+**What I'm seeing**
 
-The README shows `JavaScript` as a `PdfFormFieldCreateOptions` property, demonstrated
-only on a `PushButton` kind:
+`TextContentParser.Parse` takes a `sumWidth1000ForFont` callback and uses it to
+accumulate glyph advances into each span's width
+(`TextContentParser.cs:877-878`: `double w1000 = sumWidth1000ForFont(font, g);` →
+`advGlyph = ((w1000 / 1000.0) * size + charSpacing + ...) * hScale`).
+
+There are two callers, and they supply very different width functions.
+
+`PdfReadPage.cs:666` resolves real per-font metrics, falling back to a flat estimate
+only when a font resource can't be found:
 
 ```csharp
-.Create(new PdfFormFieldCreateOptions {
-    Name = "calculate",
-    Kind = PdfFormFieldCreationKind.PushButton,
-    ...
-    JavaScript = "this.getField('total').value = 42;"
-})
+double SumWidth1000(string fontRes, byte[] bytes) =>
+    widthProviders.TryGetValue(fontRes, out var wp) ? wp(bytes) : (bytes?.Length ?? 0) * 500.0;
 ```
 
-Two questions:
-1. Does `JavaScript` on `PdfFormFieldCreateOptions` write to `/AA /U` when `Kind` is
-   `Text`/`CheckBox`/`Combo`/`List`/`RadioGroup` (not just the button's `/A`)?
-2. Is there a way to **read back** the activation script for an existing field —
-   something on the form-field-listing result equivalent to "the JS attached to this
-   field's widget," checking both `/A` and `/AA /U` depending on field type?
+`PdfRedactionApplier.TextScrubbing.cs:524` uses the flat estimate unconditionally — no
+width providers are passed in at all:
 
-If neither exists today, would you consider it in scope? Happy to describe the exact
-current behavior we're trying to match if useful (widget-type → action-slot mapping).
+```csharp
+double SumWidth1000(string fontResource, byte[] bytes) =>
+    bytes is null ? 0D : bytes.Length * 500D;
+```
+
+So every glyph is assumed to be exactly half an em wide during redaction, regardless of
+the actual font.
+
+**Why I think it matters**
+
+Those bounds feed `AddSpanBounds` → `BuildRedactionTextObject`'s union box →
+`IntersectsTarget`, which decides whether a text object is removed. When real text is
+wider than the estimate — capitals (`W` is 944/1000 in Helvetica, `M` 833), bold and
+many display faces, monospace at 0.6em — the computed box is narrower than the text
+actually painted on the page. A redaction rectangle placed over the right-hand end of
+such a line can then fail to intersect the *estimated* box even though it visually
+covers the text, leaving the text object in place. The mark is painted, the text stays
+extractable underneath.
+
+That's the opposite of the guarantee the code seems to intend a few lines further down
+in the same file:
+
+```csharp
+// An area redaction is a confidentiality boundary. If a text object cannot be
+// located, retaining it could leave extractable text inside the painted area.
+```
+
+There's a secondary effect too: `PdfRedactionPlanner` derives its matches from
+`document.TextBlocks` (the logical read model, i.e. real metrics), while the applier
+uses the estimate. So `Redactions.Plan(...)` and `Redactions.Apply(...)` can disagree
+about which content a given rectangle covers, which is awkward for anyone using `Plan`
+as a reviewable preview or as an audit record of what was removed.
+
+**Expected**
+
+The applier resolves the same per-font width providers the read model uses, so
+redaction geometry matches both the rendered page and the plan preview.
+
+**Repro sketch**
+
+I have not been able to compile a repro — there's no .NET SDK available in the
+environment I'm working in, so this is from reading the source. What I'd expect to
+demonstrate it:
+
+1. Generate a PDF with a line of capitals in Helvetica (e.g. `WWWWW MMMMM WWWWW`) at a
+   known position and font size.
+2. Compute where that line actually ends (real advance widths) versus where a
+   0.5-em-per-byte estimate puts it — the estimate should fall well short.
+3. `Redactions.Apply` a rectangle covering the last word, in the gap between the two.
+4. Extract text from the output and check whether the covered word survives.
+
+Happy to contribute that as a test fixture if it's a useful shape, and equally happy to
+be told I've misread the call graph.
 
 ---
 
-## Draft #3 — Independently selectable outward-action kinds when stripping active content
-
-**Labels:** question, enhancement
-
-**Body:**
-
-Evaluating `OfficeIMO.Pdf`'s active-content sanitizer as a replacement for a tool
-that lets a user strip **JavaScript** and **outward-reaching actions** independently,
-where "outward-reaching" is itself broken into distinct action subtypes: `URI`
-(open a URL), `Launch` (open a file), `SubmitForm`, `GoToR` (jump to a remote file),
-and `ImportData`. A scan reports counts per bucket (JS count vs. URL-action count),
-and the strip call takes independent `javaScript`/`urls` flags.
-
-The `README.md` "Sanitize active content" section describes "policy-driven full
-rewrites remove or quarantine embedded payloads, unsafe actions and URI targets, and
-rich-media content," which reads as an all-or-nothing "unsafe actions" bucket rather
-than the five-subtype breakdown above.
-
-Is that granularity available — i.e. can a caller strip JavaScript without touching
-`Launch`/`SubmitForm` actions, or strip only `URI` actions while leaving
-`GoToR`/`ImportData` alone, and get a scan result broken out the same way? If the
-policy is currently coarser than this, would finer-grained action-kind selection (and
-a matching diagnostic count per kind) be a reasonable addition?
-
----
-
-## Draft #4 — A single "what would sanitizing this document remove" report + one-call sanitize
+## Issue 2 — Sub-text-object redaction granularity, or public content-stream primitives
 
 **Labels:** enhancement
 
-**Body:**
-
-Evaluating `OfficeIMO.Pdf` as a replacement for a "sanitize before sharing" feature
-that, in one pass, both **previews** and **removes** everything a user typically
-doesn't intend to share in a PDF that never shows on the rendered page:
-
-- document metadata (Author/Title/Subject/Keywords/Creator + the XMP packet — but
-  *not* Producer/CreationDate/ModDate/Trapped, which are tool-authored, not
-  user-authored)
-- embedded file attachments (name-tree `EmbeddedFiles`, catalog `/AF`, and
-  per-page `FileAttachment` annotations)
-- JavaScript and outward-reaching actions (see draft #3)
-- comment/markup annotations (keeping `Link`/`Widget`, which are structural, not
-  "hidden info")
-- the bookmark/outline tree
-- optional-content (layer) definitions
-
-The preview is a single typed report — one count per category — so a UI can show
-"this will remove: 3 metadata fields, 1 attachment, 2 scripts, 5 comments, 8
-bookmarks, 1 hidden layer" before the user commits, and the removal call takes the
-same category flags to let the user opt out of specific categories.
-
-Every ingredient exists somewhere in `OfficeIMO.Pdf` individually (metadata update,
-`Attachments`, `Annotations`, `Bookmarks`, catalog optional-content, the active-content
-sanitizer) — this issue is asking whether a **combined** "hidden data" inspect+strip
-call (or a documented recipe composing the pieces into one call with one combined
-report) is in scope, since composing six separate subsystems into one user-facing
-"sanitize" action is exactly the kind of thing worth having a single supported entry
-point for.
-
-Happy to share our current shape (`HiddenDataReport` with one int per category, and a
-`SanitizeOptions` with one bool per category) as a concrete reference if that's useful
-for scoping.
-
----
-
-## Draft #5 — Sub-text-object redaction granularity (or public content-stream primitives)
-
-**Labels:** enhancement
+**Title:** `Redaction removes whole BT..ET text objects; allow sub-object granularity or expose content-stream primitives`
 
 **Body:**
 
 First: thank you for `OfficeIMO.Pdf` — the redaction subsystem is clearly built with
 care, the fail-toward-removal posture in `IntersectsTarget` is the right call for a
-confidentiality boundary, and `Redactions.Verify` is a feature most PDF libraries
-don't offer at all.
+confidentiality boundary, and `Redactions.Verify` is a feature most PDF libraries don't
+offer at all.
 
 I'm evaluating it as a replacement for iText in an interactive PDF redaction editor,
 where a user drags a rectangle over a few words and expects exactly that content to
@@ -171,46 +141,218 @@ text objects:
 - `RemoveTextObjectSpans` then excises the whole `BT`→`ET` byte range.
 
 Because most producers emit one text object per line, a rectangle over one word removes
-the whole line. Measured on real files: Word-produced PDFs in your own
-`OfficeIMO.Pdf.Tests/Pdf/ReferenceBaselines/` run ~73–145 text objects per stream with
-the largest holding 89–105 characters across a single baseline.
+the whole line. Measured on real files — including Word-produced PDFs in your own
+`OfficeIMO.Pdf.Tests/Pdf/ReferenceBaselines/` — that's ~73–145 text objects per content
+stream, with the largest holding 89–105 characters across a single baseline.
 
-`PdfTextEditor.RemoveTextPreservingUnmatchedSpans` compensates by re-stamping the
-collateral spans, which is a clever recovery — but the re-stamp resolves through
-`ResolveStandardFont(...)`, so text originally in an embedded font returns as its
-closest standard-14 approximation (correctly reported via
-`BuildSubstitutionWarnings`). For a redaction tool the visible result is that
-redacting one word changes the typeface of the rest of the line.
+`PdfTextEditor.RemoveTextPreservingUnmatchedSpans` compensates by diffing which
+non-targeted spans disappeared and re-stamping them, which is a clever recovery. But the
+re-stamp resolves style through `ResolveStandardFont(...)`, so text originally set in an
+embedded font returns as its closest standard-14 approximation (correctly reported via
+`BuildSubstitutionWarnings`). For a redaction tool the visible result is that redacting
+one word changes the typeface of the rest of the line.
 
 **Ask — either of these would unblock this use case, whichever fits your design:**
 
-1. **Sub-text-object redaction granularity**: when a rectangle partially intersects a
+1. **Sub-text-object redaction granularity.** When a rectangle partially intersects a
    text object, rewrite the show-text operators so glyphs outside the rectangle survive
-   in place — replacing removed glyphs with equivalent-width `TJ` displacements so the
-   surviving text keeps its original spacing and doesn't reflow. Possibly opt-in via
-   `PdfRedactionApplyOptions` (e.g. `TextGranularity = TextObject | Span | Glyph`) so
-   the current conservative default is preserved.
-2. **Or make the content-stream primitives public** so callers can implement that
-   themselves on top of your parser: `PdfContentStreamInterpreter`, `TextContentParser`
-   (and a supported way to write a rewritten content stream back). These already exist
-   and are used internally by exactly this code path; today they're `internal`, so the
-   only route to glyph-level editing is a different library. `PdfReadPage.GetTextSpans()`
-   being public is already halfway there — the missing half is writing.
+   in place, replacing removed glyphs with equivalent-width `TJ` displacements so the
+   surviving text keeps its spacing and doesn't reflow. Could be opt-in through
+   `PdfRedactionApplyOptions` (e.g. `TextGranularity = TextObject | Span | Glyph`) so the
+   current conservative default is preserved for callers who prefer it.
+2. **Or make the content-stream primitives public**, so callers can implement that
+   themselves on top of your parser: `PdfContentStreamInterpreter`, `TextContentParser`,
+   and a supported way to write a rewritten content stream back. These already exist and
+   are used internally by exactly this code path — they're `internal`, not absent.
+   `PdfReadPage.GetTextSpans()` being public already gets us halfway; the missing half is
+   writing.
 
-Two smaller observations from the same file, offered as data rather than requests:
+Option 2 would suit us fine and is presumably much less work for you — we'd carry the
+glyph-splitting logic ourselves rather than asking you to own it.
 
-- The applier estimates every glyph advance as a flat half-em
-  (`SumWidth1000 => bytes.Length * 500D`, line ~525), while `PdfRedactionPlanner` derives
-  its matches from `document.TextBlocks` in the logical read model, which uses real
-  font metrics. So `Plan()` and `Apply()` compute geometry two different ways; a
-  proportional-font line whose true width the estimate undershoots could in principle
-  leave text inside a painted area, which seems contrary to the intent documented in
-  `IntersectsTarget`'s comment.
-- `IsSafelyEditableSpan` requires `TextRenderingMode == 0`, so the text-edit path
-  rejects invisible text. That's the correct conservative default in general, but it
-  also means OCR'd "searchable scans" (an invisible `Tr 3` layer over a page image) —
-  a very common redaction input — can't go through text editing at all. An explicit
-  opt-in for that case (the caller knowing the layer is an OCR layer) might be worth
-  considering.
+Caveat: this is from reading source, not from running it — no .NET SDK in my current
+environment. Happy to be corrected if there's an option I've missed.
 
-Happy to contribute failing test fixtures for any of the above if that's useful.
+---
+
+## Issue 3 — Text editing rejects invisible text, so OCR'd scans can't be edited
+
+**Labels:** enhancement
+
+**Title:** `Text editing fails closed on invisible text (Tr 3), blocking OCR'd searchable scans`
+
+**Body:**
+
+`PdfTextEditor.IsSafelyEditableSpan` requires, among other things,
+`span.TextRenderingMode == 0`:
+
+```csharp
+private static bool IsSafelyEditableSpan(PdfTextSpan span) =>
+    span.IsVisible &&
+    !span.ClipPath.HasValue &&
+    span.TextRenderingMode == 0 &&
+    (!span.Color.HasValue || span.Color.Value.A == byte.MaxValue) &&
+    span.CanRestamp &&
+    !string.IsNullOrEmpty(span.Text);
+```
+
+…and the editor throws `NotSupportedException("The selected region contains invisible or
+clipped text whose rendering state cannot be recreated safely.")` otherwise.
+
+As a conservative default that's very reasonable — recreating arbitrary invisible or
+clipped rendering state is genuinely unsafe. But it also rules out a common and
+well-understood case: an OCR'd "searchable scan", which is a page image with an
+invisible text layer painted in rendering mode 3. That layer is invisible *by
+construction*, and a caller who produced it (or who has detected it) knows exactly what
+it is. Today those documents can't go through text editing at all.
+
+**Ask:** an explicit opt-in for this case — something like
+`PdfTextEditOptions.AllowInvisibleTextEditing`, or a narrower
+`AllowTextRenderingMode3`, letting a caller who understands the document take
+responsibility. I notice `RemoveTextPreservingUnmatchedSpans` already carries an
+`allowInvisibleTargetRemoval` parameter internally, so the concept seems to exist
+already — the ask is essentially to surface it.
+
+For context on why this matters for redaction specifically: with a searchable scan, the
+words a user sees are pixels in the page image and the only real text is the invisible
+OCR layer. Removing just that layer leaves the words visibly in place, so a correct
+redaction has to take both — which means the text side has to be reachable in the first
+place.
+
+From source reading rather than execution (no .NET SDK to hand), so apologies if
+there's already a supported route here.
+
+---
+
+## Issue 4 — Blend mode on `Stamp.Content` canvas fills
+
+**Labels:** question, enhancement
+
+**Title:** `Is blend mode (e.g. Multiply) settable on Stamp.Content canvas fills?`
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf` as a replacement for an engine that paints text highlights as
+a rectangle with a `Multiply` blend mode, so the highlight colour tints the paper while
+the (usually dark) glyphs underneath stay legible — a plain alpha-blended fill washes the
+text out instead.
+
+`Stamp.Content((canvas, page) => ...)` looks like the right primitive (README: "Text,
+rich tables, images, shapes, drawings, clipping, and effects are supported"). I can see
+`SetBlendMode` used internally (e.g. `PdfStamper.Pages.cs`), but I couldn't find a
+blend-mode setter on the public canvas surface in the README or package docs.
+
+Is there a supported way to set the blend mode for a fill made through the
+`Stamp.Content` canvas, or another route to a markup-highlight effect (painted under
+existing text, blended, without using an annotation)? If not, would a canvas method for
+it be in scope — something like
+`canvas.WithBlendMode(PdfBlendMode.Multiply, draw => draw.Rectangle(...).Fill())`?
+
+---
+
+## Issue 5 — Per-field JavaScript activation on non-button AcroForm fields
+
+**Labels:** question, enhancement
+
+**Title:** `Setting and reading per-field JavaScript activation on non-button form fields`
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf`'s form APIs as a replacement for a tool that lets a user
+attach a JavaScript snippet to any inserted form field (text, checkbox, combo, radio
+group, push button) so it runs when the field is activated in Acrobat/Chrome — and later
+lists that script back for display and editing.
+
+The convention we currently follow: a push button's script goes on its widget's `/A`
+(activation) entry; every other field type's goes on the widget's `/AA` dictionary's
+`/U` (mouse-up) entry. Radio groups get it on each option's widget.
+
+The README shows `JavaScript` as a `PdfFormFieldCreateOptions` property, demonstrated
+only on a `PushButton`:
+
+```csharp
+.Create(new PdfFormFieldCreateOptions {
+    Name = "calculate",
+    Kind = PdfFormFieldCreationKind.PushButton,
+    ...
+    JavaScript = "this.getField('total').value = 42;"
+})
+```
+
+Two questions:
+
+1. Does `JavaScript` write to `/AA /U` when `Kind` is
+   `Text`/`CheckBox`/`Combo`/`List`/`RadioGroup`, rather than only to a button's `/A`?
+2. Is there a way to **read back** an existing field's activation script — an equivalent
+   of "the JS attached to this field's widget", checking `/A` and `/AA /U` as
+   appropriate for the field type?
+
+If neither exists today, would they be in scope? Happy to describe the exact
+widget-type → action-slot mapping we're trying to match.
+
+---
+
+## Issue 6 — Independently selectable outward-action kinds when stripping active content
+
+**Labels:** question, enhancement
+
+**Title:** `Can active-content sanitization select individual outward-action kinds?`
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf`'s active-content sanitizer as a replacement for a tool that
+strips **JavaScript** and **outward-reaching actions** independently, where
+"outward-reaching" is itself broken into distinct subtypes: `URI` (open a URL), `Launch`
+(open a file), `SubmitForm`, `GoToR` (jump to a remote file), and `ImportData`. Our scan
+reports counts per bucket and the strip call takes independent flags, so a user can keep
+their hyperlinks while removing embedded scripts, or vice versa.
+
+The README's "Sanitize active content" section describes "policy-driven full rewrites
+remove or quarantine embedded payloads, unsafe actions and URI targets, and rich-media
+content", which reads like a single "unsafe actions" bucket rather than the five-subtype
+breakdown above.
+
+Is that granularity available — can a caller strip JavaScript without touching
+`Launch`/`SubmitForm`, or strip only `URI` actions while leaving `GoToR`/`ImportData`
+alone, and get a scan result broken out the same way? If the policy is currently
+coarser, would finer-grained action-kind selection (and a matching per-kind diagnostic
+count) be a reasonable addition?
+
+---
+
+## Issue 7 — Combined "hidden data" inspect + one-call sanitize
+
+**Labels:** enhancement
+
+**Title:** `A single "what would sanitizing remove" report and one-call sanitize`
+
+**Body:**
+
+Evaluating `OfficeIMO.Pdf` as a replacement for a "sanitize before sharing" feature
+that, in one pass, both **previews** and **removes** everything a user typically doesn't
+intend to share in a PDF but which never shows on the rendered page:
+
+- document metadata (Author/Title/Subject/Keywords/Creator plus the XMP packet — but
+  *not* Producer/CreationDate/ModDate/Trapped, which are tool-authored rather than
+  user-authored)
+- embedded file attachments (name-tree `EmbeddedFiles`, catalog `/AF`, and per-page
+  `FileAttachment` annotations)
+- JavaScript and outward-reaching actions (see the previous issue)
+- comment/markup annotations, keeping `Link`/`Widget` (structural, not hidden info)
+- the bookmark/outline tree
+- optional-content (layer) definitions
+
+The preview is a single typed report — one count per category — so a UI can say "this
+will remove: 3 metadata fields, 1 attachment, 2 scripts, 5 comments, 8 bookmarks, 1
+hidden layer" before the user commits, and the removal call takes the same category
+flags so they can opt out per category.
+
+Every ingredient exists in `OfficeIMO.Pdf` individually (metadata update, `Attachments`,
+`Annotations`, `Bookmarks`, catalog optional content, the active-content sanitizer).
+This is asking whether a **combined** inspect+strip entry point — or a documented recipe
+composing the pieces with one combined report — is in scope, since folding six
+subsystems into one user-facing "sanitize" action seems like something worth having a
+single supported route for.
+
+Happy to share our current shape (a report with one count per category, and an options
+type with one bool per category) as a concrete reference if useful for scoping.


### PR DESCRIPTION
## Summary

Investigates #115 (should the PDF engine move from iText to OfficeIMO) with **direct
source access** to `EvotecIT/OfficeIMO`. Four passes went into this, and each one changed
the answer — so the ordering matters more than usual.

**Pass 1** read OfficeIMO's docs and the shape of its redaction subsystem (~5,200 lines
across dedicated planner/applier/verification files) and concluded the migration was
"very likely viable."

**Pass 2 read the actual algorithm and reached the opposite conclusion on the core.**
`PdfRedactionApplier.TextScrubbing.cs` unioned every span in a `BT`…`ET` block into a
single bounding box and, on any intersection, excised the **entire text object's byte
range**. This project's `ContentStreamEditor` splits at the **glyph** boundary. Since most
producers emit one text object per line, redacting one word removed the whole line.
Measured against real Word PDFs: 73–145 text objects per stream, largest holding 89–105
characters on a single baseline.

**Pass 3 found that blocker fixed — on unreleased `master`.** New
`PdfContentStreamTextRewriter.cs` (610 lines) preserved unaffected glyphs; real font width
providers replaced the flat half-em estimate; invisible `Tr 3` text became opt-in. Verdict
moved from *"blocked at the core"* to *"blocked pending a release."*

## Pass 4 — it shipped, and the remaining gap is text editing, not redaction

**The release exists.** `OfficeIMO.Pdf` **3.4.0** shipped on NuGet as
`OfficeIMO-v20260906153413`; **3.4.1**, **3.4.2** and **3.4.3** have followed. Verified
against `api.nuget.org`'s flat container index and by mapping each release tag to its
`VersionPrefix`.

**For the record, since the owner asked specifically about `OfficeIMO-v20260902190744`:
that release contains none of it.** It is 3.3.0 at `bd9e881f`, and
`PdfContentStreamTextRewriter.cs` does not exist in that tree — `git cat-file -e` reports
the path *"exists on disk, but not in"* the tag. The glyph commit `6a384161` landed
2026-09-03, one day after. What that release *did* carry is `#2415`, easy local OCR and
searchable-PDF support — separately relevant to #106.

**But re-reading the shipped 3.4.3 narrows the finding rather than clearing it:**

> `PdfContentStreamTextRewriter.TryRemoveIntersectingGlyphs` has **exactly one caller** in
> the entire library — `PdfRedactionApplier.TextScrubbing.cs:302`.

Redaction got the glyph rewriter. **Text editing did not.** `PdfTextEditor` still routes
through `RemoveTextPreservingUnmatchedSpans` → delete-and-re-stamp, and `ResolveStandardFont`
maps every re-stamp onto one of the 14 standard fonts by substring-matching the base font
name. There is no embedded-font stamping path in `PdfStamper`.

That is softened, but not removed. `RemoveTextPreservingUnmatchedSpans` now calls
`RemoveTextInAreas`, which *does* use the rewriter — so untargeted neighbours survive in the
content stream instead of being redrawn, moving substitution from the default path to the
fallback path. Text the editor **writes** (`Text.Replace`/`Add`/`Move`) still substitutes.

| Surface | Shipped state at 3.4.3 | Migratable? |
|---|---|---|
| Redaction content removal | Glyph-granular, width-compensated `TJ`, original encoding and font resources retained | **Yes** |
| Redaction evidence | `ApplyWithEvidence` → source/output SHA-256, three-state per-item outcome | **Yes** — an upgrade |
| Everything else (merge, pages, forms, encryption, signing, JS, Bates, watermark, Word import) | Mapped 🟢 in the doc | **Yes** |
| **Text editing fidelity** | Standard-font substitution on every stamp | **No** — regresses #29 |

**One feature now stands between this project and dropping iText**, where before it was the
redaction core. Licensing remains verified clean: `OfficeIMO.Pdf` → `OfficeIMO.Core` →
nothing, MIT throughout, read from the published `.nuspec` files.

**Net recommendation:** pin **3.4.3** and run the spike #115 always asked for — it is no
longer hypothetical. Add one case the doc did not previously call for: **edit** a word set
in an embedded font and measure what comes back. That is the case expected to fail, and its
size is now the deciding number. Do #116 regardless; it holds either way.

## Changed files

- **`docs/backend-portability.md`** — capability mapping by #116 seam, the granularity
  analysis with measurements, verified dependency graph, and a new leading "Update 2"
  recording the shipped releases and the redaction/editing split. Pass 3's section is
  retained and marked superseded on the release-status question only — its code-reading is
  still accurate.
- **`docs/officeimo-issues-to-file.md`** — status table plus the **two** drafts still worth
  submitting: per-field JavaScript activation on non-button AcroForm fields, and new
  **Issue 8** — route `PdfTextEditor` through the existing rewriter and support stamping in
  an already-embedded font. The old ask to make `PdfContentStreamInterpreter` /
  `TextContentParser` public is moot for redaction (reachable via the public `Apply` facade
  despite both remaining `internal`) but not for editing. Nothing has been filed upstream;
  the other drafts are preserved in this branch's git history.

## Test plan

Documentation-only change — no code, no build/test impact.

- [x] `docs/backend-portability.md` fills the path already referenced by
      `.github/ISSUE_TEMPLATE/backend_capability_gap.yml`, so that template's link resolves.
- [x] Granularity claim verified against three real PDFs rather than inferred from docs.
- [x] Licensing verified from downloaded `.nuspec` files rather than the README.
- [x] Release/`master` divergence verified by ancestry and by reading the flagged code at
      each revision, not from release notes.
- [x] Published-version claims verified against `api.nuget.org`, and each release tag
      mapped to its `VersionPrefix`.
- [x] The one-caller finding verified by `git grep` over the library at the 3.4.3 tag.
- [ ] Owner review of the revised recommendation before the two upstream issues are filed.
- [ ] The compiled spike #115 asks for is still outstanding, and is now the main open item.
      Needs a real .NET SDK; this session has no `dotnet` and the egress proxy blocks the
      SDK installer domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFVehqX6Yi5e5zR792dHML