### PR TITLE
Verify the committed manifest version at release time instead of syncing it

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -34,6 +34,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      # A final release ships whatever extension/manifest.json says at the tagged commit. The
+      # packaging job stamps the tag's version into the runner's copy, but the committed file is
+      # what everything else reads: a source build, an unpacked load from the repo, and
+      # Directory.Build.props, which derives the assembly version the host reports over `ping`.
+      # If the two disagree, the repository claims a version it never shipped.
+      #
+      # CI cannot fix that for you. The default branch's ruleset requires changes to go through a
+      # pull request, so a GITHUB_TOKEN push to it is rejected outright (GH013) -- an earlier job
+      # here tried exactly that, swallowed the rejection into a warning, and left v2.0.4 shipping
+      # from a manifest that still said 2.0.2, with a green run to show for it. So the bump is a
+      # human step: change extension/manifest.json in the same pull request as the release notes,
+      # before tagging, and this fails the release loudly when that was missed.
+      #
+      # Final releases only. A prerelease tag "vX.Y.Z-<build>" packages as the four-part version
+      # "X.Y.Z.<build>", which can never equal the three-part number a manifest carries, and a
+      # workflow_dispatch run has no tag to compare against.
+      - name: The committed manifest version must match the release tag
+        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          expected="${TAG_NAME#v}"
+          committed=$(python3 -c 'import json; print(json.load(open("extension/manifest.json"))["version"])')
+          if [[ "$committed" != "$expected" ]]; then
+            echo "::error file=extension/manifest.json::extension/manifest.json is at $committed but this release is tagged $TAG_NAME (expected $expected). Bump the manifest on the default branch, then re-tag this release at that commit -- nothing in CI writes it for you."
+            exit 1
+          fi
+          echo "extension/manifest.json is at $committed, matching $TAG_NAME."
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: "8.0.x"
@@ -170,83 +200,6 @@ jobs:
           files: |
             dist/pdf-editor-extension-*.zip
             dist/pdf-editor-bundle-*.zip
-
-  # Write the released version back to extension/manifest.json on the default branch.
-  #
-  # The stamp above lives only in the runner's checkout, so before this job the committed manifest
-  # never moved: it still said 2.0.0 while v2.0.2 was the shipped release. Everything derived from
-  # it inherited that — a host built from a clean checkout reported 2.0.0, and an unpacked
-  # extension loaded from the repo showed 2.0.0 in chrome://extensions no matter how many releases
-  # had gone out. Syncing it here keeps the repository's own number equal to the last thing
-  # actually shipped.
-  #
-  # A separate job, deliberately: it must not sit between `package` and the Chrome Web Store
-  # deploy, and a push that loses a race is not a reason to fail a release that already shipped.
-  # Pushing with GITHUB_TOKEN does not fire another workflow (GitHub's anti-recursion rule), so
-  # this commit does not cut a release candidate of its own.
-  sync-manifest-version:
-    needs: package
-    # Final releases only. A prerelease (every RC) is not what the repository should claim to be.
-    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false && needs.package.outputs.version != '' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
-        with:
-          python-version: "3.x"
-
-      - name: Sync extension/manifest.json to the released version
-        env:
-          RELEASE_VERSION: ${{ needs.package.outputs.version }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          python3 - "$RELEASE_VERSION" <<'EOF'
-          import json
-          import sys
-
-          path = "extension/manifest.json"
-          with open(path) as f:
-              manifest = json.load(f)
-          released = tuple(int(p) for p in sys.argv[1].split("."))
-          committed = tuple(int(p) for p in manifest["version"].split("."))
-          # Never walk the number backwards: the default branch may already carry a later version
-          # than the release being published (a hotfix promoted out of order, or a manual bump).
-          if committed >= released:
-              print(f"manifest.json is already at {manifest['version']}; leaving it alone.")
-              sys.exit(0)
-          manifest["version"] = sys.argv[1]
-          with open(path, "w") as f:
-              json.dump(manifest, f, indent=2)
-              f.write("\n")
-          print(f"manifest.json: {'.'.join(map(str, committed))} -> {sys.argv[1]}")
-          EOF
-
-          if git diff --quiet -- extension/manifest.json; then
-            echo "Nothing to sync."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add extension/manifest.json
-          git commit -m "Sync extension/manifest.json to released v$RELEASE_VERSION"
-
-          # Someone may have pushed while the release was building; rebase and retry rather than
-          # failing a release whose artifacts are already out.
-          for attempt in 1 2 3; do
-            if git push origin "HEAD:$DEFAULT_BRANCH"; then
-              exit 0
-            fi
-            echo "Push rejected (attempt $attempt); rebasing onto $DEFAULT_BRANCH."
-            git fetch origin "$DEFAULT_BRANCH"
-            git rebase "origin/$DEFAULT_BRANCH" || { git rebase --abort; break; }
-          done
-          echo "::warning::Could not sync extension/manifest.json to v$RELEASE_VERSION on $DEFAULT_BRANCH; bump it by hand."
 
   publish-to-chrome-web-store:
     needs: package

--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ empty **prerelease** for it. Creating that prerelease triggers stage 2.
 auto-created RC prereleases and manually-promoted final releases — and does the actual
 build/test/package/publish work:
 
-1. **`verify`** — builds and runs the full .NET test suite. Nothing downstream runs if
-   this fails.
+1. **`verify`** — on a final release, first checks that the committed
+   `extension/manifest.json` version equals the tag being released; then builds and runs
+   the full .NET test suite. Nothing downstream runs if this fails.
 2. **`package`** — stamps `extension/manifest.json`'s version from the release's tag
    (an RC tag `v1.0.1-57` becomes manifest version `1.0.1.57` — Chrome allows up to four
    dot-separated parts — a final tag `v1.0.1` stays `1.0.1`), packages via
@@ -263,6 +264,15 @@ with a clean tag — `v1.0.1`, no `-<build>` suffix — and leave "Set as a pre-
 unchecked. `release-extension.yml` refuses to deploy an RC-style tag if it isn't marked
 as a prerelease, so a mistagged promotion fails loudly instead of shipping the wrong
 version.
+
+**Bump `extension/manifest.json` before you promote.** The `package` job's stamp lives only
+in the runner's checkout, and nothing in CI writes the number back — the branch ruleset
+requires a pull request, so a workflow cannot push to `main` at all. The committed manifest
+is what a source build, an unpacked load from `extension/`, and `Directory.Build.props` (and
+so the version the host reports over `ping`) all read, so leaving it behind means the
+repository claims a version it never shipped. Set it to the version you are about to tag in
+the same pull request as the release notes; `verify` compares the two on every final release
+and fails the run when they disagree.
 
 `scripts/package-extension.sh` (used by both workflows, and manually if you want) builds
 a Chrome Web Store-ready zip: it (re)generates the icons, validates

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "reDACT PDF Editor",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnCJtKqFQacaY0uHvI7We7kYlDq+uL4gX3nRSnSKAOKlOO5tyOzvSc4D5mCMb6qIDBBOzwiOZR2MBizmMTY/cqRf/1wZALr0g4+ZqNFiUpZYXDlLeiuR8KgjTU+25qYPFJQuuGlhnUGu4P43lYl6YRDOb+kUFjRyKRcZ4emCu93VLm3/hS1DfWjz65HT0kp8sGfwGBnTnLhJqGiHzavQmTFFvXp4c3Zu/ndx4XRlyp9f3dY3w0F3f5IQCLhsRLwt1zOpWcrYYij9heqsfZk6Pom8D+FEDCoIfjmat75Xn6gP5CDx6WItsrmi2xZOifMibCxzcDoc/IoIRHCczFZ154QIDAQAB",
   "description": "Edit text, truly redact, merge, OCR, sign and encrypt PDFs in your browser. Processed locally \u2014 files never leave your PC.",
   "minimum_chrome_version": "116",

--- a/extension/test/version-sync.test.mjs
+++ b/extension/test/version-sync.test.mjs
@@ -15,11 +15,12 @@
 // whatever was last committed. Nothing fails either way; the number is just wrong everywhere it
 // is shown, and host-version.js compares only major.minor, so the drift raises no banner.
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+const repoDir = (rel) => readdirSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)));
 
 const manifestVersion = JSON.parse(repoFile('extension/manifest.json')).version;
 const props = repoFile('Directory.Build.props');
@@ -70,6 +71,40 @@ test('no workflow stamps a version into Directory.Build.props', () => {
       `${wf} stamps Directory.Build.props; it derives its version from the manifest instead, and `
       + 'a substitution step there fails the release when it finds no literal to replace');
   }
+});
+
+test('no workflow pushes to the default branch', () => {
+  // The bump has to be a human step, and this is why. A GITHUB_TOKEN push to the default branch
+  // is rejected by the branch ruleset ("Changes must be made through a pull request", GH013), so
+  // a job that syncs the manifest there cannot work no matter how it retries. One did: it ran on
+  // the v2.0.4 release, hit GH013 three times, downgraded the failure to a ::warning so it would
+  // not fail a release whose artifacts were already out, and reported success — leaving 2.0.4
+  // shipped from a manifest that still said 2.0.2, with nothing red to notice. Writing to the
+  // default branch from CI is the shape of that bug; pushing a branch and opening a pull request
+  // (generate-screenshots.yml) is the shape that works.
+  const pushesToDefault = /git push[^\n]*(\$\{?DEFAULT_BRANCH|default_branch|HEAD:main\b|origin\s+main\b)/;
+  for (const wf of repoDir('.github/workflows').filter((f) => /\.ya?ml$/.test(f))) {
+    const match = pushesToDefault.exec(repoFile(`.github/workflows/${wf}`));
+    assert.equal(
+      match, null,
+      `.github/workflows/${wf} pushes to the default branch (${match?.[0]}); the ruleset rejects `
+      + 'that, so it can only ever fail or silently no-op — push a branch and open a pull request');
+  }
+});
+
+test('a final release verifies the committed manifest against its tag', () => {
+  // With nothing writing the manifest back, the only thing keeping the repository's version equal
+  // to the last thing shipped is that a mismatch fails the release. Deleting this check would
+  // restore the silent drift the sync job left behind, just without the warning.
+  const wf = repoFile('.github/workflows/release-extension.yml');
+  assert.match(
+    wf, /committed manifest version must match the release tag/i,
+    'release-extension.yml no longer checks extension/manifest.json against the release tag, so a '
+    + 'release cut without bumping it would ship a version the repository never claims');
+  assert.match(
+    wf, /prerelease == false/,
+    'the manifest/tag check must be scoped to final releases: a "vX.Y.Z-<build>" prerelease '
+    + 'packages as the four-part "X.Y.Z.<build>", which never equals a committed three-part version');
 });
 
 test('the packagers all read the version from the manifest, not a copy of their own', () => {


### PR DESCRIPTION
## The problem

The `sync-manifest-version` job added in #156 could never have worked, and I should have caught that before shipping it.

It pushed the released version back to `extension/manifest.json` on `main` using `GITHUB_TOKEN`. But `main`'s ruleset requires changes to go through a pull request, so every push is rejected outright:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Code scanning is waiting for results from CodeQL for the commit 8a3c26f.
 ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
Push rejected (attempt 1); rebasing onto main.   [x3]
##[warning]Could not sync extension/manifest.json to v2.0.4 on main; bump it by hand.
```

The retry loop rebased and retried three times, then downgraded the failure to a `::warning` so it would not fail a release whose artifacts were already out. That fallback worked exactly as designed — and that is the bug. On the v2.0.4 release the job ran, reported **success**, and wrote nothing. The committed manifest stayed at `2.0.2` while `v2.0.4` shipped, with a green run to show for it.

## The fix

Delete the job. Check the invariant instead.

- **`verify` now compares the committed manifest version against the release tag** before it builds anything, and fails the release when they disagree, with an `::error` annotation pointing at `extension/manifest.json`.
- **Final releases only.** An RC tag `vX.Y.Z-BUILD` packages as the four-part `X.Y.Z.BUILD`, which can never equal a three-part committed version, and a `workflow_dispatch` run has no tag to compare against.
- **The bump becomes a human step**, in the same pull request as the release notes, before tagging. Nothing in CI writes to `main`.

Drift is now a loud failure rather than a silent one, and the failure happens *before* anything is packaged or deployed to a store rather than after.

## Also in this PR

- **`extension/manifest.json` → `2.0.4`**, the version actually shipped. This is what a source build, an unpacked load from `extension/`, and `Directory.Build.props` (and so the version the host reports over `ping`) all read. Confirmed the derivation follows: `dotnet msbuild -getProperty:Version` now returns `2.0.4`.
- **README**: documents the bump as an explicit step in "To promote a release candidate", and notes what `verify` checks.

## Tests

Two new cases in `extension/test/version-sync.test.mjs`:

- **`no workflow pushes to the default branch`** — scans every workflow for a `git push` targeting the default branch. Pushing a branch and opening a pull request (`generate-screenshots.yml`) still passes; pushing a tag (`release-candidate.yml`) still passes.
- **`a final release verifies the committed manifest against its tag`** — the check itself can't be quietly deleted, and must stay scoped to final releases.

Verified locally:

- `node --test "extension/test/**/*.test.mjs"` — 118/118 pass.
- The new guard's regex was checked against the three bad shapes (`HEAD:$DEFAULT_BRANCH`, `origin HEAD:main`, `origin main`) and the two legitimate ones.
- The check's shell logic was run against `v2.0.4` (passes), `v2.0.5` (fails), `v2.0.4-55` (fails).
- The workflow parses as YAML and the remaining jobs are `verify`, `package`, `publish-to-chrome-web-store`, `publish-to-edge-add-ons-store`.

No C# changed, so the .NET suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV5c2TRxLJZ3E6gNXenvBB