### PR TITLE
Skip file:// navigation into the viewer without file access

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,16 +504,15 @@ a missing runtime library is reported at install time rather than discovered in 
   replacement uses the closest standard font).
 - **Sign then don't rewrite**: a digital signature is invalidated by any subsequent
   full rewrite — encrypt **before** signing (the UI warns about this ordering).
-- Files opened from `file://` URLs need *Allow access to file URLs* enabled for the
-  extension, or just use the 📂 Open button.
-- **Private/Incognito windows**: like any extension, reDACT is disabled in private
-  windows until you turn it on. Chrome and Brave block the extension's own pages
-  there by default, so opening it shows a browser error page (Brave: "This page has
-  been blocked by Brave", `ERR_BLOCKED_BY_CLIENT`) instead of anything reDACT
-  controls. Enable it from the browser's extension settings — `chrome://extensions`
-  (or `brave://extensions`) → reDACT PDF Editor → *Details* → toggle *Allow in
-  Incognito* (Chrome) or *Allow in private windows* (Brave) — then reopen the
-  private window.
+- Files opened from `file://` URLs (navigating straight to a local PDF, rather than
+  the 📂 Open button or dragging the file in) need *Allow access to file URLs*
+  enabled for the extension — `chrome://extensions` (or `brave://extensions`) →
+  reDACT PDF Editor → *Details*. This is separate from *Allow in Incognito*, which
+  private windows also need if you want reDACT there at all. Without file access,
+  reDACT now leaves the browser's own PDF view alone rather than opening a page that
+  can't read the file; on some Brave versions, before this was fixed, it could
+  instead show Brave's own "This page has been blocked by Brave" /
+  `ERR_BLOCKED_BY_CLIENT` error.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,14 @@ a missing runtime library is reported at install time rather than discovered in 
   full rewrite — encrypt **before** signing (the UI warns about this ordering).
 - Files opened from `file://` URLs need *Allow access to file URLs* enabled for the
   extension, or just use the 📂 Open button.
+- **Private/Incognito windows**: like any extension, reDACT is disabled in private
+  windows until you turn it on. Chrome and Brave block the extension's own pages
+  there by default, so opening it shows a browser error page (Brave: "This page has
+  been blocked by Brave", `ERR_BLOCKED_BY_CLIENT`) instead of anything reDACT
+  controls. Enable it from the browser's extension settings — `chrome://extensions`
+  (or `brave://extensions`) → reDACT PDF Editor → *Details* → toggle *Allow in
+  Incognito* (Chrome) or *Allow in private windows* (Brave) — then reopen the
+  private window.
 
 ## Repository layout
 

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -8,7 +8,20 @@ import { checkHostVersion, versionStateSummary } from './host-version.js';
 
 const VIEWER = chrome.runtime.getURL('src/viewer.html');
 
-function viewerUrlFor(pdfUrl) {
+// The viewer loads its `?src=` URL with `fetch()` (viewer.js), which for a file:// URL needs the
+// separate "Allow access to file URLs" grant — a different toggle than "Allow in Incognito", and
+// one this extension never asks for on its own. Without it the fetch always fails; sending the
+// tab there anyway doesn't even fail gracefully everywhere — Brave has been seen blocking the
+// whole navigation outright ("ERR_BLOCKED_BY_CLIENT") rather than letting the page load and the
+// fetch report the real error. So check first, and never build a src the viewer can't read.
+let fileAccessPromise;
+function hasFileAccess() {
+  fileAccessPromise ??= new Promise((resolve) => chrome.extension.isAllowedFileSchemeAccess(resolve));
+  return fileAccessPromise;
+}
+
+async function viewerUrlFor(pdfUrl) {
+  if (pdfUrl?.startsWith('file:') && !(await hasFileAccess())) pdfUrl = null;
   return pdfUrl ? `${VIEWER}?src=${encodeURIComponent(pdfUrl)}` : VIEWER;
 }
 
@@ -40,14 +53,18 @@ chrome.webNavigation.onBeforeNavigate.addListener(async (details) => {
   if (!looksLikePdfUrl(details.url) || isAdobeContext(details.url)) return;
   const { autoOpen } = await chrome.storage.sync.get({ autoOpen: true });
   if (!autoOpen) return;
-  chrome.tabs.update(details.tabId, { url: viewerUrlFor(details.url) });
+  // Without file access a file:// tab can't be redirected into a working editor (see
+  // viewerUrlFor above) — leave the browser's own PDF view in place rather than swap it for
+  // one that's certain to fail or, in Brave, simply won't load at all.
+  if (details.url.startsWith('file:') && !(await hasFileAccess())) return;
+  chrome.tabs.update(details.tabId, { url: await viewerUrlFor(details.url) });
 });
 
 // --- Toolbar button. ---------------------------------------------------------
 
-chrome.action.onClicked.addListener((tab) => {
+chrome.action.onClicked.addListener(async (tab) => {
   const src = tab?.url && looksLikePdfUrl(tab.url) && !isAdobeContext(tab.url) ? tab.url : null;
-  chrome.tabs.create({ url: viewerUrlFor(src) });
+  chrome.tabs.create({ url: await viewerUrlFor(src) });
 });
 
 // --- Context menus. -----------------------------------------------------------
@@ -123,12 +140,12 @@ async function checkHost({ openOptionsIfMissing = false } = {}) {
 // and this is what clears the badge afterwards without the user having to hunt for a re-test.
 chrome.runtime.onStartup.addListener(() => { checkHost(); });
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (info.menuItemId === 'open-link-in-editor' && info.linkUrl) {
-    chrome.tabs.create({ url: viewerUrlFor(info.linkUrl) });
+    chrome.tabs.create({ url: await viewerUrlFor(info.linkUrl) });
   } else if (info.menuItemId === 'open-page-in-editor') {
     const src = tab?.url && looksLikePdfUrl(tab.url) ? tab.url : null;
-    chrome.tabs.create({ url: viewerUrlFor(src) });
+    chrome.tabs.create({ url: await viewerUrlFor(src) });
   }
 });
 
@@ -136,9 +153,11 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message?.type === 'open-in-editor') {
-    chrome.tabs.create({ url: viewerUrlFor(message.url) });
-    sendResponse({ ok: true });
-    return false;
+    viewerUrlFor(message.url).then((url) => {
+      chrome.tabs.create({ url });
+      sendResponse({ ok: true });
+    });
+    return true; // the response is async, so keep the channel open
   }
   // The options page re-tests on demand; let its result clear or restore the badge too.
   if (message?.type === 'recheck-host') {


### PR DESCRIPTION
## Summary

A user reported that opening a local PDF in a Brave private window fails with:

```
cbmfodojjlfppljbdebmpbcppngkkibi is blocked
This page has been blocked by Brave
ERR_BLOCKED_BY_CLIENT
```

(`cbmfodojjlfppljbdebmpbcppngkkibi` is reDACT's real, pinned Chrome Web Store extension ID.) The address bar showed the actual failing navigation: `chrome-extension://…/src/viewer.html?src=file%3A%2F%2F%2Fhome%2Fmichael%2FDownloads%2F….pdf`.

My first guess — that "Allow in Incognito" wasn't enabled — was wrong; the user confirmed it was already on. Tracing the actual flow found the real cause:

- `viewer.html?src=<url>` is loaded by `viewer.js`'s `openFromUrl()`, which does `fetch(url, { credentials: 'include' })` to read the PDF bytes.
- For a `file://` URL, that `fetch()` needs the extension's **separate** "Allow access to file URLs" permission — a different toggle from "Allow in Incognito", which this extension has never asked users to enable for this auto-open path.
- Without it, the fetch always fails. In a normal window that fails gracefully (caught, logged as "Failed to fetch" in the activity console — reproduced by the same user, confirming the mechanism). In Brave's private windows specifically, Brave has been seen blocking the whole navigation to `viewer.html?src=file://…` outright before the page even loads, which is the "blocked by Brave" screen.
- `background.js` had **four** places that built such a URL and sent a tab there — the auto-navigate `webNavigation` listener, the toolbar button, both context-menu items, and the content-script "Edit in reDACT" overlay message — none of which checked file access first.

## Fix

- `viewerUrlFor()` now checks `chrome.extension.isAllowedFileSchemeAccess()` and drops a `file://` `src` it won't be able to read, falling back to the plain (empty) viewer instead of a URL that's certain to fail.
- The auto-navigate listener additionally bails out early in that case, so a `file://` PDF tab without file access keeps the browser's own native PDF view instead of being hijacked into a page that can't load it.
- All four call sites (`viewerUrlFor` is now async) were updated to await it, including making the `open-in-editor` runtime message handler keep its response channel open.
- Corrected the README note this report originally produced, which pointed at the wrong toggle ("Allow in Incognito"); it now correctly points at "Allow access to file URLs" and documents the new graceful-fallback behavior.

## Test plan

- [x] `node --test "extension/test/**/*.test.mjs"` — 116 pass, 0 fail
- [x] `node scripts/check-innerhtml.mjs` — clean
- [x] `node --check extension/src/background.js` — clean
- [x] Maintainer: confirm the private-window case now falls through to the browser's native PDF view instead of the blocked-page screen (I don't have a Brave instance to reproduce the exact private-window block in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHQnn9v3uzCgW5ppxLhnBu